### PR TITLE
Check LDAP username in case insensitive way

### DIFF
--- a/library/Icinga/Authentication/Backend/LdapUserBackend.php
+++ b/library/Icinga/Authentication/Backend/LdapUserBackend.php
@@ -150,7 +150,7 @@ class LdapUserBackend extends UserBackend
     public function hasUser(User $user)
     {
         $username = $user->getUsername();
-        return $this->conn->fetchOne($this->selectUser($username)) === $username;
+        return strtolower($this->conn->fetchOne($this->selectUser($username))) === strtolower($username);
     }
 
     /**


### PR DESCRIPTION
I spent over an hour trying to work out why I couldn't authenticate using my LDAP account (Microsoft Active Directory server) until I realised that I was using `tom` as my username but the LDAP server was returning `Tom`!
