### PR TITLE
Only check the session save path is writable if the session handler is '...

### DIFF
--- a/library/Icinga/Web/Session/PhpSession.php
+++ b/library/Icinga/Web/Session/PhpSession.php
@@ -78,8 +78,9 @@ class PhpSession extends Session
             }
         }
 
-        if (!is_writable(session_save_path())) {
-            throw new ConfigurationError('Can\'t save session');
+        $sessionSavePath = session_save_path();
+        if (session_module_name() === 'files' && !is_writable($sessionSavePath)) {
+            throw new ConfigurationError("Can't save session, path '$sessionSavePath' is not writable.");
         }
 
         if ($this->exists()) {


### PR DESCRIPTION
...files'. Fixes #8053

https://dev.icinga.org/issues/8053
