### PR TITLE
Fix tactical overview host problem count color

### DIFF
--- a/public/css/icinga/monitoring-colors.less
+++ b/public/css/icinga/monitoring-colors.less
@@ -445,8 +445,9 @@ div.box.contents.zero {
 
 div.box.contents.zero span {
   font-weight: bold;
+  line-height: 2em;
 
-  color: white;
+  color: #666;
 }
 
 div.box.contents.zero h3 {
@@ -454,7 +455,7 @@ div.box.contents.zero h3 {
   font-size: 12em;
   line-height: 1em;
 
-  color: white;
+  color: #666;
 }
 
 div.box.ok_hosts.state_up {


### PR DESCRIPTION
Text was `#fff` on an `#eee` background for some reason. It was really bugging me so I thought I'd just apply the shade of grey used everywhere else. Also, the text 'Service Problems' no longer overlaps the pseudo horizontal rule.