### PR TITLE
Changing password fields in backend to hide passwords when typing

### DIFF
--- a/application/forms/Config/User/UserForm.php
+++ b/application/forms/Config/User/UserForm.php
@@ -34,7 +34,7 @@ class UserForm extends RepositoryForm
             )
         );
         $this->addElement(
-            'text',
+            'password',
             'password',
             array(
                 'required'  => true,
@@ -56,7 +56,7 @@ class UserForm extends RepositoryForm
         $this->createInsertElements($formData);
 
         $this->addElement(
-            'text',
+            'password',
             'password',
             array(
                 'label' => $this->translate('Password')


### PR DESCRIPTION
When adding and editing users, the password displays as it is typed. It probably makes sense to use a password field for that so that other people watching dont see the typed password on the screen. 