### PR TITLE
Update icingacli script to be portable

### DIFF
--- a/bin/icingacli
+++ b/bin/icingacli
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 /* Icinga Web 2 | (c) 2013-2015 Icinga Development Team | GPLv2+ */
 


### PR DESCRIPTION
Current shebang `#!/usr/bin/php` is not correct for example on FreeBSD.