### PR TITLE
Use yellow for warning logs in ANSI CLI

### DIFF
--- a/library/Icinga/Application/Logger/Writer/StdoutWriter.php
+++ b/library/Icinga/Application/Logger/Writer/StdoutWriter.php
@@ -36,7 +36,7 @@ class StdoutWriter extends LogWriter
                 $color = 'red';
                 break;
             case Logger::WARNING:
-                $color = 'orange';
+                $color = 'yellow';
                 break;
             case Logger::INFO:
                 $color = 'green';


### PR DESCRIPTION
Orange does not exist as an ANSI color. See https://github.com/Icinga/icingaweb2/blob/aecfb2eb97d94aa848b39ab0e885c4f31ee71218/library/Icinga/Cli/AnsiScreen.php

This solves a problem where I got the following stack trace from icingacli:

```
PHP Fatal error:  Uncaught exception 'Icinga\Exception\IcingaException' with message 'There is no such foreground color: orange' in /usr/share/php/Icinga/Cli/AnsiScreen.php:77
Stack trace:
#0 /usr/share/php/Icinga/Cli/AnsiScreen.php(111): Icinga\Cli\AnsiScreen->fgColor('orange')
#1 /usr/share/php/Icinga/Cli/AnsiScreen.php(69): Icinga\Cli\AnsiScreen->startColor('orange', NULL)
#2 /usr/share/php/Icinga/Application/Logger/Writer/StdoutWriter.php(48): Icinga\Cli\AnsiScreen->colorize('Module path "/u...', 'orange')
#3 /usr/share/php/Icinga/Application/Logger.php(202): Icinga\Application\Logger\Writer\StdoutWriter->log(4, 'Module path "/u...')
#4 /usr/share/php/Icinga/Application/Logger.php(274): Icinga\Application\Logger->log(4, 'Module path "/u...')
#5 /usr/share/php/Icinga/Application/Modules/Manager.php(518): Icinga\Application\Logger::warning('Module path "%s...', '/usr/share/icin...')
#6 /usr/share/php/Icinga/Application/Modules/Manager.php(364): Icinga\Application\Modules\Manager->detectInstalledModules()
#7 /usr/share/php/Ic in /usr/share/php/Icinga/Cli/AnsiScreen.php on line 77
```

(Also mentioned by another user [on the forums](http://www.monitoring-portal.org/wbb/index.php?page=Thread&threadID=33314)).