### PR TITLE
DbUserBackend - inspect reports 0 users when one does exist

### DIFF
--- a/library/Icinga/Authentication/User/DbUserBackend.php
+++ b/library/Icinga/Authentication/User/DbUserBackend.php
@@ -260,7 +260,7 @@ class DbUserBackend extends DbRepository implements UserBackendInterface, Inspec
         $insp->write($this->ds->inspect());
         try {
             $users = $this->select()->where('is_active', true)->count();
-            if ($users > 1) {
+            if ($users > 0) {
                 $insp->write(sprintf('%s active users', $users));
             } else {
                 return $insp->error('0 active users', $users);


### PR DESCRIPTION
I notice that when I have a single user, ie. an administrator, I cannot create a Configuration/Authentication User Backend because the form "Edit User Backend" fails with error message: "Cannot... 0 active users". Looking in the file "DbUserBackend.php", the comparision below seems odd to me:
    
    $users = $this->select()->where('is_active', true)->count();
    if ($users > 1) {
        $insp->write(sprintf('%s active users', $users));
    } else {
        return $insp->error('0 active users', $users);
    }

If I have 2+ users, report "2 active users", otherwise I have "0 active users". Should that be:

    if ($users > 0) {