### PR TITLE
Add support for PostgreSQL Unix sockets

### DIFF
--- a/library/Icinga/Data/Db/DbConnection.php
+++ b/library/Icinga/Data/Db/DbConnection.php
@@ -153,6 +153,9 @@ class DbConnection implements Selectable, Extensible, Updatable, Reducible, Insp
             case 'pgsql':
                 $adapter = 'Pdo_Pgsql';
                 $adapterParamaters['port'] = $this->config->get('port', 5432);
+                if ($adapterParamaters['host'] === '') {
+                  unset($adapterParamaters['host']);
+                }
                 break;
             /*case 'oracle':
                 if ($this->dbtype === 'oracle') {


### PR DESCRIPTION
Right now it's impossible to use Unix socket to connect to PostgreSQL. If you do not specify hostname or specify empty hostname connection fails like that:

    Icinga\Exception\AuthenticationException in
    /usr/share/php/Icinga/Authentication/User/DbUserBackend.php:204
    with message: Failed to authenticate user "admin" against backend "icingaweb2".
    An exception was thrown: <- Zend_Db_Adapter_Exception in
    /usr/share/php/Zend/Db/Adapter/Pdo/Abstract.php:144
    with message: SQLSTATE[08006] [7] could not translate host name "dbname=icingaweb"
    to address: Name or service not known <- PDOException in
    /usr/share/php/Zend/Db/Adapter/Pdo/Abstract.php:129 with message:
    SQLSTATE[08006] [7] could not translate host name "dbname=icingaweb" to address:
    Name or service not known

With this patch applied Unix socket will be used to connect to PostgreSQL if you specify empty hostname.