### PR TITLE
Add filter option to LDAP

### DIFF
--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -43,6 +43,7 @@ Directive               | Description
 **resource**            | The name of the LDAP resource defined in [resources.ini](resources.md#resources).
 **user_class**          | LDAP user class.
 **user_name_attribute** | LDAP attribute which contains the username.
+**filter**              | LDAP search filter.
 
 **Example:**
 
@@ -52,6 +53,7 @@ backend             = ldap
 resource            = my_ldap
 user_class          = inetOrgPerson
 user_name_attribute = uid
+filter              = "memberOf=cn=icinga_users,cn=groups,cn=accounts,dc=icinga,dc=org"
 ```
 
 Note that in case the set *user_name_attribute* holds multiple values it is required that all of its


### PR DESCRIPTION
Updated line 46 to include the filter option for LDAP and line 56 to include an example of restricting users by group.