### PR TITLE
Looks like group base DN is erroneously typed in place of user base DN when using LDAP backend

### DIFF
--- a/library/Icinga/Authentication/UserGroup/LdapUserGroupBackend.php
+++ b/library/Icinga/Authentication/UserGroup/LdapUserGroupBackend.php
@@ -607,7 +607,7 @@ class LdapUserGroupBackend extends LdapRepository implements UserGroupBackendInt
 
         return $this
             ->setGroupBaseDn($config->base_dn)
-            ->setUserBaseDn($config->get('user_base_dn', $this->getGroupBaseDn()))
+            ->setUserBaseDn($config->get('user_base_dn', $this->getUserBaseDn()))
             ->setGroupClass($config->get('group_class', $defaults->group_class))
             ->setUserClass($config->get('user_class', $defaults->user_class))
             ->setGroupNameAttribute($config->get('group_name_attribute', $defaults->group_name_attribute))


### PR DESCRIPTION
Hi,

In my installation, I have following configuration:

* in `groups.ini`:

  ```
  [icingaweb2]
  ...
  base_dn = "ou=Accounts_Group,dc=xxx,dc=yyy,dc=com"
  ```
* in `authentication.ini`:

  ```
  [icingaweb2]
  ...
  base_dn = "ou=Accounts_User,dc=xxx,dc=yyy,dc=com"
  ```

With that given, I have never been able to see group membership on a user details page (Configuration -> Authorization -> [search user and click him])

It looks like there is a typo in setting the user base DN. As soon as I applied this fix, I started seeing group membership of a user.

Would appreciate if you guys could land this. It's really annoying to manage access on per-user basis.

Thanks,
Vlad
