### PR TITLE
Allow users to be held in a separate Base DN to Groups

### DIFF
--- a/library/Icinga/Authentication/UserGroup/LdapUserGroupBackend.php
+++ b/library/Icinga/Authentication/UserGroup/LdapUserGroupBackend.php
@@ -392,7 +392,7 @@ class LdapUserGroupBackend extends LdapRepository implements UserGroupBackendInt
                 ->setUnfoldAttribute($this->groupMemberAttribute)
                 ->setBase($this->groupBaseDn)
                 ->fetchOne();
-            $this->ambiguousMemberAttribute = !$this->isRelatedDn($sampleValue);
+            $this->ambiguousMemberAttribute = !$this->isRelatedDn($sampleValue, $this->getUserBaseDn());
         }
 
         return $this->ambiguousMemberAttribute;


### PR DESCRIPTION
When users are in a different BaseDN to the groups, this causes no groups to be loaded out of Ldap. The following error is given:
```
2015-11-30T08:29:51+00:00 - ERROR - Stacktrace: #0 [internal function]: Icinga\Application\ApplicationBootstrap->Icinga\Application\{closure}(2, 'strpos(): Empty...', '/icingaweb2/lib...', 88, Array)
#1 /icingaweb2/library/Icinga/Repository/LdapRepository.php(88): strpos('<USER DN>', '')
#2 /icingaweb2/library/Icinga/Authentication/UserGroup/LdapUserGroupBackend.php(394): Icinga\Repository\LdapRepository->isRelatedDn('<USER DN>')
#3 /icingaweb2/library/Icinga/Authentication/UserGroup/LdapUserGroupBackend.php(487): Icinga\Authentication\UserGroup\LdapUserGroupBackend->isMemberAttributeAmbiguous()
#4 /icingaweb2/library/Icinga/Repository/Repository.php(436): Icinga\Authentication\UserGroup\LdapUserGroupBackend->initializeConversionRules()
#5 /icingaweb2/library/Icinga/Repository/Repository.php(590): Icinga\Repository\Repository->getConversionRules()
#6 /icingaweb2/library/Icinga/Repository/RepositoryQuery.php(329): Icinga\Repository\Repository->providesValueConversion('group', 'group_name')
#7 /icingaweb2/library/Icinga/Web/Widget/SortBox.php(126): Icinga\Repository\RepositoryQuery->order('group_name', 'asc')
#8 /icingaweb2/library/Icinga/Web/Controller.php(117): Icinga\Web\Widget\SortBox->handleRequest(Object(Icinga\Web\Request))
#9 /icingaweb2/application/controllers/GroupController.php(74): Icinga\Web\Controller->setupSortControl(Array, Object(Icinga\Repository\RepositoryQuery))
#10 /icingaweb2/library/vendor/Zend/Controller/Action.php(507): Icinga\Controllers\GroupController->listAction()
#11 /icingaweb2/library/Icinga/Web/Controller/Dispatcher.php(76): Zend_Controller_Action->dispatch('listAction')
#12 /icingaweb2/library/vendor/Zend/Controller/Front.php(937): Icinga\Web\Controller\Dispatcher->dispatch(Object(Icinga\Web\Request), Object(Icinga\Web\Response))
#13 /icingaweb2/library/Icinga/Application/Web.php(361): Zend_Controller_Front->dispatch(Object(Icinga\Web\Request), Object(Icinga\Web\Response))
#14 /icingaweb2/library/Icinga/Application/webrouter.php(109): Icinga\Application\Web->dispatch()
#15 /icingaweb2/public/index.php(4): require_once('/icingaweb2/lib...')
#16 {main}
```
