### PR TITLE
doc: document 'encryption' directive for LDAP

### DIFF
--- a/doc/04-Resources.md
+++ b/doc/04-Resources.md
@@ -68,6 +68,7 @@ Directive       | Description
 **root_dn**     | Root object of the tree, e.g. "ou=people,dc=icinga,dc=org"
 **bind_dn**     | The user to use when connecting to the server.
 **bind_pw**     | The password to use when connecting to the server.
+**encryption**  | Type of encryption to use: `none` (default), `starttls`, `ldaps`.
 
 **Example:**
 


### PR DESCRIPTION
Documentation for the 'encryption' directive for the LDAP resource type was missing (I had to go digging through the source). This PR adds a single line of documentation describing that directive.