### PR TITLE
Allow table header in pluginoutput

### DIFF
--- a/application/forms/Config/UserBackend/ExternalBackendForm.php
+++ b/application/forms/Config/UserBackend/ExternalBackendForm.php
@@ -56,6 +56,15 @@ class ExternalBackendForm extends Form
             )
         );
         $this->addElement(
+            'text',
+            'server_variable',
+            array(
+                'label'         => $this->translate('Server Variable'),
+                'description'   => $this->translate(
+                    'Key used to search in the _SERVER variable.')
+            )
+        );
+        $this->addElement(
             'hidden',
             'backend',
             array(

--- a/library/Icinga/Authentication/User/ExternalBackend.php
+++ b/library/Icinga/Authentication/User/ExternalBackend.php
@@ -26,6 +26,14 @@ class ExternalBackend implements UserBackendInterface
     protected $stripUsernameRegexp;
 
     /**
+     * Key used for lookup in _SERVER array
+     * Examples: HTTP_USER, Default: REMOTE_USER
+     *
+     * @var string
+     */
+    protected $serverVariable = 'REMOTE_USER';
+
+    /**
      * Create new authentication backend of type "external"
      *
      * @param ConfigObject $config
@@ -33,6 +41,7 @@ class ExternalBackend implements UserBackendInterface
     public function __construct(ConfigObject $config)
     {
         $this->stripUsernameRegexp = $config->get('strip_username_regexp');
+        $this->serverVariable = $config->get('server_variable', 'REMOTE_USER');
     }
 
     /**
@@ -71,15 +80,14 @@ class ExternalBackend implements UserBackendInterface
         return null;
     }
 
-
     /**
      * {@inheritdoc}
      */
     public function authenticate(User $user, $password = null)
     {
-        $username = static::getRemoteUser();
+        $username = static::getRemoteUser($this->serverVariable);
         if ($username !== null) {
-            $user->setExternalUserInformation($username, 'REMOTE_USER');
+            $user->setExternalUserInformation($username, $this->serverVariable);
 
             if ($this->stripUsernameRegexp) {
                 $stripped = preg_replace($this->stripUsernameRegexp, '', $username);

--- a/modules/monitoring/application/views/helpers/PluginOutput.php
+++ b/modules/monitoring/application/views/helpers/PluginOutput.php
@@ -179,7 +179,7 @@ class Zend_View_Helper_PluginOutput extends Zend_View_Helper_Abstract
 
             $config = HTMLPurifier_Config::createDefault();
             $config->set('Core.EscapeNonASCIICharacters', true);
-            $config->set('HTML.Allowed', 'p,br,b,a[href|target],i,table,tr,td[colspan],div,*[class]');
+            $config->set('HTML.Allowed', 'p,br,b,a[href|target],i,table,tr,th,td[colspan],div,*[class]');
             $config->set('Attr.AllowedFrameTargets', array('_blank'));
             // This avoids permission problems:
             // $config->set('Core.DefinitionCache', null);


### PR DESCRIPTION
Add another html entity which is allowed (`<th>`). This allows us to render tables with a nice looking heading.

Fixes #12125
