### PR TITLE
Hook.php: Problem with module permissions

### DIFF
--- a/library/Icinga/Application/Hook.php
+++ b/library/Icinga/Application/Hook.php
@@ -165,12 +165,12 @@ class Hook
         return lcfirst(
             substr(
                 $class,
-                ClassLoader::MODULE_PREFIX_LENGTH,
+                ClassLoader::MODULE_PREFIX_LENGTH + 1,
                 strpos(
                     $class,
                     ClassLoader::NAMESPACE_SEPARATOR,
                     ClassLoader::MODULE_PREFIX_LENGTH + 1
-                ) - ClassLoader::MODULE_PREFIX_LENGTH
+                ) - ClassLoader::MODULE_PREFIX_LENGTH - 1
             )
         );
     }


### PR DESCRIPTION
Noticed while using the graphite module. User had permissions 'module/graphite' but couldnt see graphs, only users with permission '*' could see graphs.
This function returns the module name as '\Graphite' but it should return 'graphite'. This is not a beautiful fix but works for me.
Maybe instead if this consider setting MODULE_PREFIX_LENGTH to 15 instead of 14? Then it would include the leading "\\". Dont know if this would break something else though.