### PR TITLE
Correct hover text of the status bar

### DIFF
--- a/modules/monitoring/application/views/scripts/list/components/servicesummary.phtml
+++ b/modules/monitoring/application/views/scripts/list/components/servicesummary.phtml
@@ -56,7 +56,7 @@ $stateBadges
         ),
         'List %u handled service that is currently in state CRITICAL',
         'List %u handled services which are currently in state CRITICAL',
-        array($stats->services_critical_unhandled)
+        array($stats->services_critical_handled)
     )
     ->add(
         StateBadges::STATE_UNKNOWN,


### PR DESCRIPTION
Correct the count of handled critical services in the hover text in the
status bar.

fixes #2656