### PR TITLE
Use parse_ini_string() where IniParser::parseIni() is not needed

### DIFF
--- a/library/Icinga/File/Ini/IniParser.php
+++ b/library/Icinga/File/Ini/IniParser.php
@@ -260,6 +260,6 @@ class IniParser
             throw new NotReadableError('Couldn\'t read the file `%s\'', $path);
         }
 
-        return Config::fromArray(self::parseIni($content)->toArray())->setConfigFile($file);
+        return Config::fromArray(parse_ini_string($content, true))->setConfigFile($file);
     }
 }


### PR DESCRIPTION
fixes #2766