### PR TITLE
Disable auto-refresh when page is not visible

### DIFF
--- a/public/js/icinga/events.js
+++ b/public/js/icinga/events.js
@@ -105,6 +105,8 @@
             // Note: It is important that this is the first handler for this event!
             $(document).on('rendered', { self: this }, this.applyHandlers);
 
+            $(document).on('visibilitychange', { self: this }, this.onVisibilityChange);
+
             $.each(this.icinga.behaviors, function (name, behavior) {
                 behavior.bind($(document));
             });
@@ -170,6 +172,18 @@
             var icinga = event.data.self.icinga;
             icinga.logger.info('Unloading Icinga');
             icinga.destroy();
+        },
+
+        onVisibilityChange: function (event) {
+            var icinga = event.data.self.icinga;
+
+            if (document.visibilityState === undefined || document.visibilityState === 'visible') {
+                icinga.loader.autorefreshSuspended = false;
+                icinga.logger.debug('Page visible, enabling auto-refresh');
+            } else {
+                icinga.loader.autorefreshSuspended = true;
+                icinga.logger.debug('Page invisible, disabling auto-refresh');
+            }
         },
 
         /**
@@ -610,6 +624,7 @@
             $(document).off('change', 'form input.autosubmit', this.submitForm);
             $(document).off('focus', 'form select[data-related-radiobtn]', this.autoCheckRadioButton);
             $(document).off('focus', 'form input[data-related-radiobtn]', this.autoCheckRadioButton);
+            $(document).off('visibilitychange', this.onVisibilityChange);
         },
 
         destroy: function() {

--- a/public/js/icinga/loader.js
+++ b/public/js/icinga/loader.js
@@ -30,7 +30,15 @@
 
         this.iconCache = {};
 
+        /**
+         * Whether auto-refresh is enabled
+         */
         this.autorefreshEnabled = true;
+
+        /**
+         * Whether auto-refresh is suspended due to visibility of page
+         */
+        this.autorefreshSuspended = false;
     };
 
     Icinga.Loader.prototype = {
@@ -209,7 +217,7 @@
 
         autorefresh: function () {
             var _this = this;
-            if (_this.autorefreshEnabled !== true) {
+            if (! _this.autorefreshEnabled || _this.autorefreshSuspended) {
                 return;
             }
 


### PR DESCRIPTION
Icinga offers the user to enable or disable 'auto-refresh' with a
static preference.

But 'auto-refresh' is the default and our users often have dozens of
Icinga tabs open in their browser, which they are not looking at.

The background tabs lead to significant load on the database from
repetitive queries to keep the invisible UI fresh.

This PR adds a visibility listener, which disables auto-refresh when the
page is not visible.

Fixes #2761