### PR TITLE
GetTextTranslationHelper: Make sure we ignore any dotfile or vendor dir

### DIFF
--- a/modules/translation/library/Translation/Util/GettextTranslationHelper.php
+++ b/modules/translation/library/Translation/Util/GettextTranslationHelper.php
@@ -473,7 +473,7 @@ class GettextTranslationHelper
             $filepath = $directory . DIRECTORY_SEPARATOR . $filename;
             if (preg_match('@^[^\.].+\.(' . implode('|', $this->sourceExtensions) . ')$@', $filename)) {
                 $file->fwrite($filepath . PHP_EOL);
-            } elseif (is_dir($filepath)) {
+            } elseif (! is_link($filepath) && is_dir($filepath)) {
                 $subdirs[] = $filepath;
             }
         }

--- a/modules/translation/library/Translation/Util/GettextTranslationHelper.php
+++ b/modules/translation/library/Translation/Util/GettextTranslationHelper.php
@@ -467,10 +467,13 @@ class GettextTranslationHelper
 
         $subdirs = array();
         while (($filename = readdir($directoryHandle)) !== false) {
+            if ($filename[0] === '.' || $filename === 'vendor') {
+                continue;
+            }
             $filepath = $directory . DIRECTORY_SEPARATOR . $filename;
             if (preg_match('@^[^\.].+\.(' . implode('|', $this->sourceExtensions) . ')$@', $filename)) {
                 $file->fwrite($filepath . PHP_EOL);
-            } elseif (is_dir($filepath) && !preg_match('@^(\.|\.\.)$@', $filename)) {
+            } elseif (is_dir($filepath)) {
                 $subdirs[] = $filepath;
             }
         }


### PR DESCRIPTION
Some of our modules ship vendor data, or tend to add scripts adding icingaweb2 and other modules with a vendor/ directory.

This patch avoids the translation tool to scan these directories for translation calls.