### PR TITLE
Vagrant: provision even if upgrading Parallels guest tools isn't possible right now

### DIFF
--- a/.puppet/manifests/parallels-upgrade-guest-tools.sh
+++ b/.puppet/manifests/parallels-upgrade-guest-tools.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+# If the installed version is outdated, try to update.
+
+# The updater seems to try to install kernel-devel-$(uname -r) which is not
+# available in case of an outdated kernel version.
+# If the updater fails (for this reason), we try to upgrade the kernel in the
+# hope that the updater will succeed on the next reboot.
+
+ptiagent-cmd --ver || \
+ptiagent-cmd --install || \
+yum update kernel -y

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,8 +28,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     p.name = "Icinga Web 2 Development"
 
-    # Update Parallels Tools automatically
-    p.update_guest_tools = true
+    # Update Parallels Tools automatically ...
+    p.update_guest_tools = false
+    # ... but don't fail completely. (see the shell script)
+    override.vm.provision :shell, :run => "always", :path => ".puppet/manifests/parallels-upgrade-guest-tools.sh"
 
     # Set power consumption mode to "Better Performance"
     p.optimize_power_consumption = false


### PR DESCRIPTION
fixes #2896