### PR TITLE
API Commands: Only send acknowledgement expire time if not null

### DIFF
--- a/modules/monitoring/library/Monitoring/Command/Renderer/IcingaApiCommandRenderer.php
+++ b/modules/monitoring/library/Monitoring/Command/Renderer/IcingaApiCommandRenderer.php
@@ -179,10 +179,12 @@ class IcingaApiCommandRenderer implements IcingaCommandRendererInterface
         $data = array(
             'author'        => $command->getAuthor(),
             'comment'       => $command->getComment(),
-            'expiry'        => $command->getExpireTime(),
             'sticky'        => $command->getSticky(),
             'notify'        => $command->getNotify()
         );
+        if ($command->getExpireTime() !== null) {
+            $data['expiry'] = $command->getExpireTime();
+        }
         $this->applyFilter($data, $command->getObject());
         return IcingaApiCommand::create($endpoint, $data);
     }


### PR DESCRIPTION
Icinga 2 v2.7.0 is more strict with the `expiry` attribute if sent
(cannot be null, or in the past).

While acknowledgments with expire time worked well (and do so with this patch),
the command renderer did not check whether the value is actually not null
before setting it into the data form. The boolean value from the checkbox is
not available in the command renderer unfortunately.

@lippserd: Verified working with and without expire time inside the Vagrant boxes.

fixes #2911