### PR TITLE
Config: Fix cached loading of module config

### DIFF
--- a/library/Icinga/Application/Config.php
+++ b/library/Icinga/Application/Config.php
@@ -416,13 +416,12 @@ class Config implements Countable, Iterator, Selectable
             self::$modules[$modulename] = array();
         }
 
-        $moduleConfigs = self::$modules[$modulename];
-        if (! isset($moduleConfigs[$configname]) || $fromDisk) {
-            $moduleConfigs[$configname] = static::fromIni(
+        if (! isset(self::$modules[$modulename][$configname]) || $fromDisk) {
+            self::$modules[$modulename][$configname] = static::fromIni(
                 static::resolvePath('modules/' . $modulename . '/' . $configname . '.ini')
             );
         }
-        return $moduleConfigs[$configname];
+        return self::$modules[$modulename][$configname];
     }
 
     /**


### PR DESCRIPTION
Since the module copied the array to a local variable, the loaded
Config object never got saved to `static::$modules`

I noticed that during Unit testing, I wasn't able to play with module config in memory. Always had to save to disk...