### PR TITLE
Form/Element/Number: The field should be valid when empty

### DIFF
--- a/library/Icinga/Web/Form/Element/Number.php
+++ b/library/Icinga/Web/Form/Element/Number.php
@@ -134,7 +134,7 @@ class Number extends FormElement
     {
         $this->setValue($value);
         $value = $this->getValue();
-        if ($value !== '' && ! is_numeric($value)) {
+        if ($value !== null && $value !== '' && ! is_numeric($value)) {
             $this->addError(sprintf(t('\'%s\' is not a valid number'), $value));
             return false;
         }


### PR DESCRIPTION
This failed me when trying to save the ResourceForm without having set a port number.

    is not a valid number

I guess because `$value !== ''` we should also test for null...