### PR TITLE
Allow pdo_ibm for database resources

### DIFF
--- a/application/forms/Config/Resource/DbResourceForm.php
+++ b/application/forms/Config/Resource/DbResourceForm.php
@@ -36,6 +36,9 @@ class DbResourceForm extends Form
         if (Platform::hasMssqlSupport()) {
             $dbChoices['mssql'] = 'MSSQL';
         }
+        if (Platform::hasIbmSupport()) {
+            $dbChoices['ibm'] = 'IBM (DB2)';
+        }
         if (Platform::hasOracleSupport()) {
             $dbChoices['oracle'] = 'Oracle';
         }
@@ -45,6 +48,7 @@ class DbResourceForm extends Form
 
         $offerSsl = false;
         $offerPostgres = false;
+        $offerIbm = false;
         $offerMysql = false;
         $dbChoice = isset($formData['db']) ? $formData['db'] : key($dbChoices);
         if ($dbChoice === 'pgsql') {
@@ -54,6 +58,8 @@ class DbResourceForm extends Form
             if (version_compare(Platform::getPhpVersion(), '5.4.0', '>=')) {
                 $offerSsl = true;
             }
+        } elseif ($dbChoice === 'ibm') {
+            $offerIbm = true;
         }
 
         $socketInfo = '';

--- a/library/Icinga/Application/Platform.php
+++ b/library/Icinga/Application/Platform.php
@@ -367,6 +367,18 @@ class Platform
     }
 
     /**
+     * Return whether it's possible to connect to a IBM DB2 database
+     *
+     * Checks whether the ibm pdo extension has been loaded and the Zend framework adapter for IBM is available
+     *
+     * @return  bool
+     */
+    public static function hasIbmSupport()
+    {
+        return static::extensionLoaded('pdo_ibm') && static::classExists('Zend_Db_Adapter_Pdo_Ibm');
+    }
+
+    /**
      * Return whether it's possible to connect to a Oracle database using OCI8
      *
      * Checks whether the OCI8 extension has been loaded and the Zend framework adapter for Oracle is available

--- a/library/Icinga/Data/Db/DbConnection.php
+++ b/library/Icinga/Data/Db/DbConnection.php
@@ -203,6 +203,10 @@ class DbConnection implements Selectable, Extensible, Updatable, Reducible, Insp
                 $adapter = 'Pdo_Pgsql';
                 $defaultPort = 5432;
                 break;
+            case 'ibm':
+                $adapter = 'Pdo_Ibm';
+                $defaultPort = 50000;
+                break;
             default:
                 throw new ConfigurationError(
                     'Backend "%s" is not supported',


### PR DESCRIPTION
This enables the access to an IBM DB2 database with the driver pdo_ibm.
