### PR TITLE
Remove array syntax from default comment filter

### DIFF
--- a/modules/monitoring/application/controllers/CommentController.php
+++ b/modules/monitoring/application/controllers/CommentController.php
@@ -68,7 +68,7 @@ class CommentController extends Controller
         $this->view->comment = $this->comment;
 
         if ($this->hasPermission('monitoring/command/comment/delete')) {
-            $listUrl = Url::fromPath('monitoring/list/comments')->setQueryString('comment_type=(comment|ack)');
+            $listUrl = Url::fromPath('monitoring/list/comments')->setQueryString('comment_type=comment|comment_type=ack');
             $form = new DeleteCommentCommandForm();
             $form
                 ->populate(array(

--- a/modules/monitoring/configuration.php
+++ b/modules/monitoring/configuration.php
@@ -198,7 +198,7 @@ $section->add(N_('Contactgroups'), array(
     'priority' => 70
 ));
 $section->add(N_('Comments'), array(
-    'url'      => 'monitoring/list/comments?comment_type=(comment|ack)',
+    'url'      => 'monitoring/list/comments?comment_type=comment|comment_type=ack',
     'priority' => 80
 ));
 $section->add(N_('Downtimes'), array(


### PR DESCRIPTION
Added comment types 'comment' and 'ack' as separate fields and removed
the array syntax due to problems with the filter editor.

fixes #2925