### PR TITLE
travis: Update build matrix to build with php 5.3 on precise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,18 @@
 language: php
-#dist: trusty
+dist: trusty
 sudo: required
 
 php:
-  - '5.3'
   - '5.4'
   - '5.5'
   - '5.6'
   - '7.0'
   - '7.1'
+
+matrix:
+  include:
+  - php: '5.3'
+    dist: precise
 
 services:
   - mysql


### PR DESCRIPTION
All other builds can happen on trusty.

fixes #2948