### PR TITLE
Option for default schedule downtime for all services

### DIFF
--- a/modules/monitoring/application/forms/Command/Object/ScheduleHostDowntimeCommandForm.php
+++ b/modules/monitoring/application/forms/Command/Object/ScheduleHostDowntimeCommandForm.php
@@ -4,6 +4,7 @@
 namespace Icinga\Module\Monitoring\Forms\Command\Object;
 
 use DateTime;
+use Icinga\Application\Config;
 use Icinga\Module\Monitoring\Command\Object\PropagateHostDowntimeCommand;
 use Icinga\Module\Monitoring\Command\Object\ScheduleHostDowntimeCommand;
 use Icinga\Module\Monitoring\Command\Object\ScheduleServiceDowntimeCommand;
@@ -22,6 +23,8 @@ class ScheduleHostDowntimeCommandForm extends ScheduleServiceDowntimeCommandForm
     {
         parent::createElements($formData);
 
+        $config = Config::module('monitoring');
+
         $this->addElement(
             'checkbox',
             'all_services',
@@ -29,7 +32,8 @@ class ScheduleHostDowntimeCommandForm extends ScheduleServiceDowntimeCommandForm
                 'description'   => $this->translate(
                     'Schedule downtime for all services on the hosts and the hosts themselves.'
                 ),
-                'label'         => $this->translate('All Services')
+                'label'         => $this->translate('All Services'),
+                'value'         => (bool) $config->get('settings', 'hostdowntime_all_services', false)
             )
         );
 


### PR DESCRIPTION
Adds support for an optional option 'hostdowntime_all_services' in the settings section of the monitoring options. If set to true, this will make the "All Services" checkbox in the schedule host downtime form default to checked.