### PR TITLE
Update 02-Installation.md

### DIFF
--- a/doc/02-Installation.md
+++ b/doc/02-Installation.md
@@ -139,7 +139,7 @@ apt-get install icingaweb2
 ```
 yum install icingaweb2 icingacli
 ```
-If you have [SELinux](90-SELinux.md) enabled, the package `icingaweb2-selinux` is also required.
+If you have [SELinux](90-SELinux.md) enabled, the package `icingaweb2-selinux` and `icinga2-selinux` is also required.
 For RHEL/CentOS please read the [package repositories notes](02-Installation.md#package-repositories-rhel-notes).
 
 **SLES and openSUSE**:


### PR DESCRIPTION
The getting started docs on the main website https://www.icinga.com/docs/icinga2/latest/doc/02-getting-started/ and here https://github.com/Icinga/icingaweb2/blob/master/doc/02-Installation.md do not include the mention of `icinga2-selinux` except outside of the quick setup scope in the section titled selinux(mentions just 1 of the 2 packages) which is required otherwise problems like this https://github.com/Icinga/icinga2/issues/5096 will develop; an example of trying to run "Check now" on a service via the web interface:
```
sudo grep icinga /var/log/audit/audit.log | audit2allow


#============= httpd_t ==============
allow httpd_t var_run_t:fifo_file { getattr open };
```