### PR TITLE
Bugfix/cant create resources and command transports 2998

### DIFF
--- a/library/Icinga/Web/Form.php
+++ b/library/Icinga/Web/Form.php
@@ -19,18 +19,6 @@ use Icinga\Web\Form\Element\CsrfCounterMeasure;
 /**
  * Base class for forms providing CSRF protection, confirmation logic and auto submission
  *
- * @method $this setDefaults(array $defaults) {
- *     Use `Form::populate()' for setting default values for elements instead because `Form::setDefaults()' does not
- *     create the form via `Form::create()'.
- *
- *     Due to a BC introduced with https://github.com/mhujer/zf1/commit/244e3d3f88a363ee0ca49cf63eee31f925f515cd
- *     we cannot override this function without running into a strict standards violation on Zend version 1.12.7.
- *
- *     @param   array $defaults
- *
- *     @return  $this
- * }
- *
  * @method \Zend_Form_Element[] getElements() {
  *     {@inheritdoc}
  *     @return \Zend_Form_Element[]
@@ -1081,6 +1069,21 @@ class Form extends Zend_Form
             }
         }
         return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Creates the form if not created yet.
+     *
+     * @param   array   $values
+     *
+     * @return  $this
+     */
+    public function setDefaults(array $values)
+    {
+        $this->create($values);
+        return parent::setDefaults($values);
     }
 
     /**

--- a/library/Icinga/Web/Form.php
+++ b/library/Icinga/Web/Form.php
@@ -1102,22 +1102,21 @@ class Form extends Zend_Form
      *
      * @param   Zend_Form   $form
      * @param   array       $defaults
-     * @param   bool        $ignoreDisabled
      */
-    protected function preserveDefaults(Zend_Form $form, array & $defaults, $ignoreDisabled = true)
+    protected function preserveDefaults(Zend_Form $form, array & $defaults)
     {
         foreach ($form->getElements() as $name => $element) {
             if ((array_key_exists($name, $defaults)
                     && array_key_exists($name . static::DEFAULT_SUFFIX, $defaults)
                     && $defaults[$name] === $defaults[$name . static::DEFAULT_SUFFIX])
-                || (! $ignoreDisabled && $element->getAttrib('disabled'))
+                || $element->getAttrib('disabled')
             ) {
                 unset($defaults[$name]);
             }
         }
 
         foreach ($form->getSubForms() as $_ => $subForm) {
-            $this->preserveDefaults($subForm, $defaults, $ignoreDisabled);
+            $this->preserveDefaults($subForm, $defaults);
         }
     }
 
@@ -1144,11 +1143,6 @@ class Form extends Zend_Form
             if (($frameUpload = (bool) $request->getUrl()->shift('_frameUpload', false))) {
                 $this->getView()->layout()->setLayout('wrapped');
             }
-
-            // To prevent a BC, this is here. The proper fix is to extend populate()
-            // and pass $ignoreDisabled through to preserveDefaults()
-            $this->create($formData)->preserveDefaults($this, $formData, false);
-
             $this->populate($formData); // Necessary to get isSubmitted() to work
             if (! $this->getSubmitLabel() || $this->isSubmitted()) {
                 if ($this->isValid($formData)


### PR DESCRIPTION
Note that this change heavily relies on the assumption that populate() was necessary to get isSubmitted() to work. In case the call to Form::populate() is required due to additional reasons this change will most likely break them. However, I couldn't find any other reason and tests (not exhaustive <- only Web 2 and core modules) showed no errors.

The most important change is that at the time isSubmitted() is called the form may not be already created anymore. Any form relying on this case (as shown in d118b5c) may not work properly anymore. This is due to an already wrong implementation, though.

fixes #2998
refs #2509 