### PR TITLE
Fix php fatal error on monitoring/health/info when asking for json

### DIFF
--- a/modules/monitoring/library/Monitoring/Controller.php
+++ b/modules/monitoring/library/Monitoring/Controller.php
@@ -60,7 +60,7 @@ class Controller extends IcingaWebController
                         'Content-Disposition',
                         'inline; filename=' . $this->getRequest()->getActionName() . '.json'
                     )
-                    ->appendBody(Json::encode($query->getQuery()->fetchAll()))
+                    ->appendBody(Json::encode($query->fetchAll()))
                     ->sendResponse();
                 exit;
             case 'csv':


### PR DESCRIPTION
When calling /icingaweb2/monitoring/health/info?format=json you get a php error because we ask for query on query object.

<b>Fatal error</b>:  Uncaught Error: Call to undefined method Icinga\Module\Monitoring\Backend\Ido\Query\ProgramstatusQuery::getQuery() in /usr/share/icingaweb2/modules/monitoring/library/Monitoring/Controller.php:49

This PR fixes this