### PR TITLE
Fix help for icingacli monitoring list (--unhandled is --problems, etc.)

### DIFF
--- a/modules/monitoring/application/clicommands/ListCommand.php
+++ b/modules/monitoring/application/clicommands/ListCommand.php
@@ -129,17 +129,26 @@ class ListCommand extends Command
      *
      *   --format=<csv|json|<custom>>
      *     Dump columns in the given format. <custom> format allows $column$
-     *     placeholders, e.g. --format='$host$: $service$'
+     *     placeholders, e.g. --format='$host$: $service$'. This requires
+     *     that the columns are specified within the --columns parameter.
      *
      *   --<column>[=filter]
      *     Filter given column by optional filter. Boolean (1/0) columns are
      *     true if no filter value is given.
      *
+     *   --problems
+     *     Only show unhandled problems (HARD state and not acknowledged/in downtime).
+     *
+     *   --columns='<comma separated list of host/service columns>'
+     *     Add a limited set of columns to the output. The following host/service
+     *     attributes can be fetched: state, handled, output, acknowledged, in_downtime, perfdata last_state_change
+     *
      * EXAMPLES
      *
-     *   icingacli monitoring list --unhandled
+     *   icingacli monitoring list --problems
+     *   icingacli monitoring list --problems --service_state_type 0
      *   icingacli monitoring list --host=local* --service=*disk*
-     *   icingacli monitoring list --format='$host$: $service$'
+     *   icingacli monitoring list --columns 'host,service,service_output' --format='$host$: $service$ ($service_output$)'
      */
     public function statusAction()
     {


### PR DESCRIPTION
The help text still showed the wrong paramter, while it was not documented
as possible parameter either. In addition to that #562 unveils that a
custom --format parameter requires selected columns to do so.

This patch adds that into the documentation which is rendered as CLI command
help text then.

refs #562