### PR TITLE
Update installation step for Ubuntu

### DIFF
--- a/doc/02-Installation.md
+++ b/doc/02-Installation.md
@@ -130,7 +130,7 @@ Below is a list with examples for various distributions. The additional package 
 
 **Debian and Ubuntu**:
 ```
-apt-get install icingaweb2
+apt-get install icingaweb2 icingacli
 ```
 
 **RHEL, CentOS and Fedora**:


### PR DESCRIPTION
Install `icingacli` (as for other distros) to avoid `The program 'icingacli' is currently not installed. You can install...`