### PR TITLE
Modify authentication function to support alternative algorithms

### DIFF
--- a/library/Icinga/Authentication/User/DbUserBackend.php
+++ b/library/Icinga/Authentication/User/DbUserBackend.php
@@ -225,9 +225,7 @@ class DbUserBackend extends DbRepository implements UserBackendInterface, Inspec
     {
         try {
             $passwordHash = $this->getPasswordHash($user->getUsername());
-            $passwordSalt = $this->getSalt($passwordHash);
-            $hashToCompare = $this->hashPassword($password, $passwordSalt);
-            return $hashToCompare === $passwordHash;
+            return crypt($password, $passwordHash) === $passwordHash;
         } catch (Exception $e) {
             throw new AuthenticationException(
                 'Failed to authenticate user "%s" against backend "%s". An exception was thrown:',
@@ -236,18 +234,6 @@ class DbUserBackend extends DbRepository implements UserBackendInterface, Inspec
                 $e
             );
         }
-    }
-
-    /**
-     * Extract salt from the given password hash
-     *
-     * @param   string  $hash   The hashed password
-     *
-     * @return  string
-     */
-    protected function getSalt($hash)
-    {
-        return substr($hash, strlen(self::HASH_ALGORITHM), self::SALT_LENGTH);
     }
 
     /**


### PR DESCRIPTION
The existing usage of crypt() was borderline incorrect. This simplified function will allow hashes of other types (e.g. bcrypt) and thus mitigate #2954 (use password_hash) until this can be implemented.

The getSalt protected method was also removed as this is no longer required, though this can be added again in future.

I will make an additional pull request to migrate to bcrypt with crypt.