### PR TITLE
Fix wrong unhandled services count in host views when restrictions ar…

### DIFF
--- a/modules/monitoring/application/controllers/ListController.php
+++ b/modules/monitoring/application/controllers/ListController.php
@@ -106,7 +106,6 @@ class ListController extends Controller
         $this->applyRestriction('monitoring/filter/objects', $stats);
 
         $summary = $hosts->getQuery()->queryServiceProblemSummary();
-        $this->applyRestriction('monitoring/filter/objects', $summary);
 
         $this->view->hosts = $hosts;
         $this->view->stats = $stats;


### PR DESCRIPTION
…e used

The query for fetching the unhandled services count utilises the hosts query as subquery.
Restrictions are applied to both the hosts query and the query for the unhandled services count.
This leads to wrong results since the restrictions are already in place for the unhandled services count because we're using the hosts query as subquery.

Fixes #2822