### PR TITLE
Apply role to all users if the role is defined with users=*

### DIFF
--- a/library/Icinga/Authentication/AdmissionLoader.php
+++ b/library/Icinga/Authentication/AdmissionLoader.php
@@ -28,6 +28,9 @@ class AdmissionLoader
         $username = strtolower($username);
         if (! empty($section->users)) {
             $users = array_map('strtolower', StringHelper::trimSplit($section->users));
+            if (in_array('*', $users)) {
+                return true;
+            }
             if (in_array($username, $users)) {
                 return true;
             }


### PR DESCRIPTION
If the users directive contains at least one single asterisk, the role is applied to all users.
So, this supports roles which define users=username, ..., * and users=*

Fixes #3095