### PR TITLE
remove all COLLATE latin1_general_ci from sql statements

### DIFF
--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/ContactQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/ContactQuery.php
@@ -28,16 +28,16 @@ class ContactQuery extends IdoQuery
      */
     protected $columnMap = array(
         'contactgroups' => array(
-            'contactgroup'          => 'cgo.name1 COLLATE latin1_general_ci',
+            'contactgroup'          => 'cgo.name1 ',
             'contactgroup_name'     => 'cgo.name1',
-            'contactgroup_alias'    => 'cg.alias COLLATE latin1_general_ci'
+            'contactgroup_alias'    => 'cg.alias '
         ),
         'contacts' => array(
             'contact_id'                        => 'c.contact_id',
-            'contact'                           => 'co.name1 COLLATE latin1_general_ci',
+            'contact'                           => 'co.name1 ',
             'contact_name'                      => 'co.name1',
-            'contact_alias'                     => 'c.alias COLLATE latin1_general_ci',
-            'contact_email'                     => 'c.email_address COLLATE latin1_general_ci',
+            'contact_alias'                     => 'c.alias ',
+            'contact_email'                     => 'c.email_address ',
             'contact_pager'                     => 'c.pager_address',
             'contact_object_id'                 => 'c.contact_object_id',
             'contact_has_host_notfications'     => 'c.host_notifications_enabled',
@@ -56,33 +56,33 @@ class ContactQuery extends IdoQuery
             'contact_notify_host_downtime'      => 'c.notify_host_downtime'
         ),
         'hostgroups' => array(
-            'hostgroup'         => 'hgo.name1 COLLATE latin1_general_ci',
-            'hostgroup_alias'   => 'hg.alias COLLATE latin1_general_ci',
+            'hostgroup'         => 'hgo.name1 ',
+            'hostgroup_alias'   => 'hg.alias ',
             'hostgroup_name'    => 'hgo.name1'
         ),
         'hosts' => array(
-            'host'              => 'ho.name1 COLLATE latin1_general_ci',
+            'host'              => 'ho.name1 ',
             'host_name'         => 'ho.name1',
             'host_alias'        => 'h.alias',
-            'host_display_name' => 'h.display_name COLLATE latin1_general_ci'
+            'host_display_name' => 'h.display_name '
         ),
         'instances' => array(
             'instance_name' => 'i.instance_name'
         ),
         'servicegroups' => array(
-            'servicegroup'          => 'sgo.name1 COLLATE latin1_general_ci',
+            'servicegroup'          => 'sgo.name1 ',
             'servicegroup_name'     => 'sgo.name1',
-            'servicegroup_alias'    => 'sg.alias COLLATE latin1_general_ci'
+            'servicegroup_alias'    => 'sg.alias '
         ),
         'services' => array(
-            'service'               => 'so.name2 COLLATE latin1_general_ci',
+            'service'               => 'so.name2 ',
             'service_description'   => 'so.name2',
-            'service_display_name'  => 's.display_name COLLATE latin1_general_ci',
+            'service_display_name'  => 's.display_name ',
             'service_host_name'     => 'so.name1'
         ),
         'timeperiods' => array(
-            'contact_notify_host_timeperiod'    => 'ht.alias COLLATE latin1_general_ci',
-            'contact_notify_service_timeperiod' => 'st.alias COLLATE latin1_general_ci'
+            'contact_notify_host_timeperiod'    => 'ht.alias ',
+            'contact_notify_service_timeperiod' => 'st.alias '
         )
     );
 

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/ContactgroupQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/ContactgroupQuery.php
@@ -28,36 +28,36 @@ class ContactgroupQuery extends IdoQuery
      */
     protected $columnMap = array(
         'contactgroups' => array(
-            'contactgroup'          => 'cgo.name1 COLLATE latin1_general_ci',
+            'contactgroup'          => 'cgo.name1 ',
             'contactgroup_name'     => 'cgo.name1',
-            'contactgroup_alias'    => 'cg.alias COLLATE latin1_general_ci'
+            'contactgroup_alias'    => 'cg.alias '
         ),
         'members' => array(
             'contact_count' => 'SUM(CASE WHEN cgmo.object_id IS NOT NULL THEN 1 ELSE 0 END)'
         ),
         'hostgroups' => array(
-            'hostgroup'         => 'hgo.name1 COLLATE latin1_general_ci',
-            'hostgroup_alias'   => 'hg.alias COLLATE latin1_general_ci',
+            'hostgroup'         => 'hgo.name1 ',
+            'hostgroup_alias'   => 'hg.alias ',
             'hostgroup_name'    => 'hgo.name1'
         ),
         'hosts' => array(
-            'host'              => 'ho.name1 COLLATE latin1_general_ci',
+            'host'              => 'ho.name1 ',
             'host_name'         => 'ho.name1',
             'host_alias'        => 'h.alias',
-            'host_display_name' => 'h.display_name COLLATE latin1_general_ci'
+            'host_display_name' => 'h.display_name '
         ),
         'instances' => array(
             'instance_name' => 'i.instance_name'
         ),
         'servicegroups' => array(
-            'servicegroup'          => 'sgo.name1 COLLATE latin1_general_ci',
+            'servicegroup'          => 'sgo.name1 ',
             'servicegroup_name'     => 'sgo.name1',
-            'servicegroup_alias'    => 'sg.alias COLLATE latin1_general_ci'
+            'servicegroup_alias'    => 'sg.alias '
         ),
         'services' => array(
-            'service'               => 'so.name2 COLLATE latin1_general_ci',
+            'service'               => 'so.name2 ',
             'service_description'   => 'so.name2',
-            'service_display_name'  => 's.display_name COLLATE latin1_general_ci',
+            'service_display_name'  => 's.display_name ',
             'service_host_name'     => 'so.name1'
         )
     );

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/CustomvarQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/CustomvarQuery.php
@@ -17,11 +17,11 @@ class CustomvarQuery extends IdoQuery
             'is_json'  => 'cvs.is_json',
         ),
         'objects' => array(
-            'host'                => 'cvo.name1 COLLATE latin1_general_ci',
+            'host'                => 'cvo.name1 ',
             'host_name'           => 'cvo.name1',
-            'service'             => 'cvo.name2 COLLATE latin1_general_ci',
+            'service'             => 'cvo.name2 ',
             'service_description' => 'cvo.name2',
-            'contact'             => 'cvo.name1 COLLATE latin1_general_ci',
+            'contact'             => 'cvo.name1 ',
             'contact_name'        => 'cvo.name1',
             'object_type'         => "CASE cvo.objecttype_id WHEN 1 THEN 'host' WHEN 2 THEN 'service' WHEN 10 THEN 'contact' ELSE 'invalid' END",
             'object_type_id'      => 'cvo.objecttype_id'

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/GroupsummaryQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/GroupsummaryQuery.php
@@ -15,8 +15,8 @@ class GroupsummaryQuery extends IdoQuery
      */
     protected $columnMap = array(
         'hoststatussummary' => array(
-            'hostgroup'                                     => 'hostgroup COLLATE latin1_general_ci',
-            'hostgroup_alias'                               => 'hostgroup_alias COLLATE latin1_general_ci',
+            'hostgroup'                                     => 'hostgroup ',
+            'hostgroup_alias'                               => 'hostgroup_alias ',
             'hostgroup_name'                                => 'hostgroup_name',
             'hosts_up'                                      => 'SUM(CASE WHEN object_type = \'host\' AND state = 0 THEN 1 ELSE 0 END)',
             'hosts_unreachable'                             => 'SUM(CASE WHEN object_type = \'host\' AND state = 2 THEN 1 ELSE 0 END)',
@@ -36,8 +36,8 @@ class GroupsummaryQuery extends IdoQuery
             'hosts_up_last_state_change'                    => 'MAX(CASE WHEN object_type = \'host\' AND state = 0 THEN state_change ELSE 0 END)'
         ),
         'servicestatussummary' => array(
-            'servicegroup'                                  => 'servicegroup COLLATE latin1_general_ci',
-            'servicegroup_alias'                            => 'servicegroup_alias COLLATE latin1_general_ci',
+            'servicegroup'                                  => 'servicegroup ',
+            'servicegroup_alias'                            => 'servicegroup_alias ',
             'servicegroup_name'                             => 'servicegroup_name',
             'services_critical'                             => 'SUM(CASE WHEN object_type = \'service\' AND state = 2 THEN 1 ELSE 0 END)',
             'services_critical_handled'                     => 'SUM(CASE WHEN object_type = \'service\' AND state = 2 AND acknowledged + in_downtime + host_state > 0 THEN 1 ELSE 0 END)',

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/HostcommentQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/HostcommentQuery.php
@@ -28,7 +28,7 @@ class HostcommentQuery extends IdoQuery
      */
     protected $columnMap = array(
         'comments' => array(
-            'comment_author'        => 'c.author_name COLLATE latin1_general_ci',
+            'comment_author'        => 'c.author_name ',
             'comment_author_name'   => 'c.author_name',
             'comment_data'          => 'c.comment_data',
             'comment_expiration'    => 'CASE c.expires WHEN 1 THEN UNIX_TIMESTAMP(c.expiration_time) ELSE NULL END',
@@ -37,18 +37,18 @@ class HostcommentQuery extends IdoQuery
             'comment_name'          => 'c.name',
             'comment_timestamp'     => 'UNIX_TIMESTAMP(c.comment_time)',
             'comment_type'          => "CASE c.entry_type WHEN 1 THEN 'comment' WHEN 2 THEN 'downtime' WHEN 3 THEN 'flapping' WHEN 4 THEN 'ack' END",
-            'host'                  => 'ho.name1 COLLATE latin1_general_ci',
+            'host'                  => 'ho.name1 ',
             'host_name'             => 'ho.name1',
             'object_type'           => '(\'host\')'
         ),
         'hostgroups' => array(
-            'hostgroup'             => 'hgo.name1 COLLATE latin1_general_ci',
-            'hostgroup_alias'       => 'hg.alias COLLATE latin1_general_ci',
+            'hostgroup'             => 'hgo.name1 ',
+            'hostgroup_alias'       => 'hg.alias ',
             'hostgroup_name'        => 'hgo.name1'
         ),
         'hosts' => array(
             'host_alias'            => 'h.alias',
-            'host_display_name'     => 'h.display_name COLLATE latin1_general_ci'
+            'host_display_name'     => 'h.display_name '
         ),
         'hoststatus' => array(
             'host_state'            => 'CASE WHEN hs.has_been_checked = 0 OR hs.has_been_checked IS NULL THEN 99 ELSE hs.current_state END'
@@ -57,14 +57,14 @@ class HostcommentQuery extends IdoQuery
             'instance_name' => 'i.instance_name'
         ),
         'servicegroups' => array(
-            'servicegroup'          => 'sgo.name1 COLLATE latin1_general_ci',
+            'servicegroup'          => 'sgo.name1 ',
             'servicegroup_name'     => 'sgo.name1',
-            'servicegroup_alias'    => 'sg.alias COLLATE latin1_general_ci'
+            'servicegroup_alias'    => 'sg.alias '
         ),
         'services' => array(
-            'service'               => 'so.name2 COLLATE latin1_general_ci',
+            'service'               => 'so.name2 ',
             'service_description'   => 'so.name2',
-            'service_display_name'  => 's.display_name COLLATE latin1_general_ci',
+            'service_display_name'  => 's.display_name ',
         )
     );
 

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/HostcommenthistoryQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/HostcommenthistoryQuery.php
@@ -28,7 +28,7 @@ class HostcommenthistoryQuery extends IdoQuery
      */
     protected $columnMap = array(
         'commenthistory' => array(
-            'host'          => 'ho.name1 COLLATE latin1_general_ci',
+            'host'          => 'ho.name1 ',
             'host_name'     => 'ho.name1',
             'object_id'     => 'hch.object_id',
             'object_type'   => '(\'host\')',
@@ -38,26 +38,26 @@ class HostcommenthistoryQuery extends IdoQuery
             'type'          => "(CASE hch.entry_type WHEN 1 THEN 'comment' WHEN 2 THEN 'dt_comment' WHEN 3 THEN 'flapping' WHEN 4 THEN 'ack' END)"
         ),
         'hostgroups' => array(
-            'hostgroup'         => 'hgo.name1 COLLATE latin1_general_ci',
-            'hostgroup_alias'   => 'hg.alias COLLATE latin1_general_ci',
+            'hostgroup'         => 'hgo.name1 ',
+            'hostgroup_alias'   => 'hg.alias ',
             'hostgroup_name'    => 'hgo.name1'
         ),
         'hosts' => array(
             'host_alias'        => 'h.alias',
-            'host_display_name' => 'h.display_name COLLATE latin1_general_ci'
+            'host_display_name' => 'h.display_name '
         ),
         'instances' => array(
             'instance_name' => 'i.instance_name'
         ),
         'servicegroups' => array(
-            'servicegroup'          => 'sgo.name1 COLLATE latin1_general_ci',
+            'servicegroup'          => 'sgo.name1 ',
             'servicegroup_name'     => 'sgo.name1',
-            'servicegroup_alias'    => 'sg.alias COLLATE latin1_general_ci'
+            'servicegroup_alias'    => 'sg.alias '
         ),
         'services' => array(
-            'service'               => 'so.name2 COLLATE latin1_general_ci',
+            'service'               => 'so.name2 ',
             'service_description'   => 'so.name2',
-            'service_display_name'  => 's.display_name COLLATE latin1_general_ci',
+            'service_display_name'  => 's.display_name ',
             'service_host_name'     => 'so.name1'
         )
     );

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/HostdowntimeQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/HostdowntimeQuery.php
@@ -28,7 +28,7 @@ class HostdowntimeQuery extends IdoQuery
      */
     protected $columnMap = array(
         'downtimes' => array(
-            'downtime_author'           => 'sd.author_name COLLATE latin1_general_ci',
+            'downtime_author'           => 'sd.author_name ',
             'downtime_author_name'      => 'sd.author_name',
             'downtime_comment'          => 'sd.comment_data',
             'downtime_duration'         => 'sd.duration',
@@ -43,18 +43,18 @@ class HostdowntimeQuery extends IdoQuery
             'downtime_scheduled_start'  => 'UNIX_TIMESTAMP(sd.scheduled_start_time)',
             'downtime_start'            => 'UNIX_TIMESTAMP(CASE WHEN UNIX_TIMESTAMP(sd.trigger_time) > 0 then sd.trigger_time ELSE sd.scheduled_start_time END)',
             'downtime_triggered_by_id'  => 'sd.triggered_by_id',
-            'host'                      => 'ho.name1 COLLATE latin1_general_ci',
+            'host'                      => 'ho.name1 ',
             'host_name'                 => 'ho.name1',
             'object_type'               => '(\'host\')'
         ),
         'hostgroups' => array(
-            'hostgroup'                 => 'hgo.name1 COLLATE latin1_general_ci',
-            'hostgroup_alias'           => 'hg.alias COLLATE latin1_general_ci',
+            'hostgroup'                 => 'hgo.name1 ',
+            'hostgroup_alias'           => 'hg.alias ',
             'hostgroup_name'            => 'hgo.name1'
         ),
         'hosts' => array(
             'host_alias'                => 'h.alias',
-            'host_display_name'         => 'h.display_name COLLATE latin1_general_ci'
+            'host_display_name'         => 'h.display_name '
         ),
         'hoststatus' => array(
             'host_state'                => 'CASE WHEN hs.has_been_checked = 0 OR hs.has_been_checked IS NULL THEN 99 ELSE hs.current_state END'
@@ -63,14 +63,14 @@ class HostdowntimeQuery extends IdoQuery
             'instance_name' => 'i.instance_name'
         ),
         'servicegroups' => array(
-            'servicegroup'              => 'sgo.name1 COLLATE latin1_general_ci',
+            'servicegroup'              => 'sgo.name1 ',
             'servicegroup_name'         => 'sgo.name1',
-            'servicegroup_alias'        => 'sg.alias COLLATE latin1_general_ci'
+            'servicegroup_alias'        => 'sg.alias '
         ),
         'services' => array(
-            'service'                   => 'so.name2 COLLATE latin1_general_ci',
+            'service'                   => 'so.name2 ',
             'service_description'       => 'so.name2',
-            'service_display_name'      => 's.display_name COLLATE latin1_general_ci',
+            'service_display_name'      => 's.display_name ',
         )
     );
 

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/HostdowntimestarthistoryQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/HostdowntimestarthistoryQuery.php
@@ -28,7 +28,7 @@ class HostdowntimestarthistoryQuery extends IdoQuery
      */
     protected $columnMap = array(
         'downtimehistory' => array(
-            'host'          => 'ho.name1 COLLATE latin1_general_ci',
+            'host'          => 'ho.name1 ',
             'host_name'     => 'ho.name1',
             'object_id'     => 'hdh.object_id',
             'object_type'   => '(\'host\')',
@@ -38,26 +38,26 @@ class HostdowntimestarthistoryQuery extends IdoQuery
             'type'          => "('dt_start')"
         ),
         'hostgroups' => array(
-            'hostgroup'         => 'hgo.name1 COLLATE latin1_general_ci',
-            'hostgroup_alias'   => 'hg.alias COLLATE latin1_general_ci',
+            'hostgroup'         => 'hgo.name1 ',
+            'hostgroup_alias'   => 'hg.alias ',
             'hostgroup_name'    => 'hgo.name1'
         ),
         'hosts' => array(
             'host_alias'        => 'h.alias',
-            'host_display_name' => 'h.display_name COLLATE latin1_general_ci'
+            'host_display_name' => 'h.display_name '
         ),
         'instances' => array(
             'instance_name' => 'i.instance_name'
         ),
         'servicegroups' => array(
-            'servicegroup'          => 'sgo.name1 COLLATE latin1_general_ci',
+            'servicegroup'          => 'sgo.name1 ',
             'servicegroup_name'     => 'sgo.name1',
-            'servicegroup_alias'    => 'sg.alias COLLATE latin1_general_ci'
+            'servicegroup_alias'    => 'sg.alias '
         ),
         'services' => array(
-            'service'               => 'so.name2 COLLATE latin1_general_ci',
+            'service'               => 'so.name2 ',
             'service_description'   => 'so.name2',
-            'service_display_name'  => 's.display_name COLLATE latin1_general_ci',
+            'service_display_name'  => 's.display_name ',
             'service_host_name'     => 'so.name1'
         )
     );

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/HostflappingstarthistoryQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/HostflappingstarthistoryQuery.php
@@ -37,23 +37,23 @@ class HostflappingstarthistoryQuery extends IdoQuery
             'type'          => '(\'flapping\')'
         ),
         'hostgroups' => array(
-            'hostgroup_alias'   => 'hg.alias COLLATE latin1_general_ci',
+            'hostgroup_alias'   => 'hg.alias ',
             'hostgroup_name'    => 'hgo.name1'
         ),
         'hosts' => array(
             'host_alias'        => 'h.alias',
-            'host_display_name' => 'h.display_name COLLATE latin1_general_ci'
+            'host_display_name' => 'h.display_name '
         ),
         'instances' => array(
             'instance_name' => 'i.instance_name'
         ),
         'servicegroups' => array(
             'servicegroup_name'     => 'sgo.name1',
-            'servicegroup_alias'    => 'sg.alias COLLATE latin1_general_ci'
+            'servicegroup_alias'    => 'sg.alias '
         ),
         'services' => array(
             'service_description'   => 'so.name2',
-            'service_display_name'  => 's.display_name COLLATE latin1_general_ci',
+            'service_display_name'  => 's.display_name ',
             'service_host_name'     => 'so.name1'
         )
     );

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/HostgroupQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/HostgroupQuery.php
@@ -20,8 +20,8 @@ class HostgroupQuery extends IdoQuery
 
     protected $columnMap = array(
         'hostgroups' => array(
-            'hostgroup'         => 'hgo.name1 COLLATE latin1_general_ci',
-            'hostgroup_alias'   => 'hg.alias COLLATE latin1_general_ci',
+            'hostgroup'         => 'hgo.name1 ',
+            'hostgroup_alias'   => 'hg.alias ',
             'hostgroup_name'    => 'hgo.name1'
         ),
         'hoststatus' => array(

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/HostnotificationQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/HostnotificationQuery.php
@@ -24,7 +24,7 @@ class HostnotificationQuery extends IdoQuery
             'hostgroup_name' => 'hgo.name1'
         ),
         'hosts' => array(
-            'host_display_name' => 'h.display_name COLLATE latin1_general_ci'
+            'host_display_name' => 'h.display_name '
         ),
         'history' => array(
             'output'    => null,
@@ -48,7 +48,7 @@ class HostnotificationQuery extends IdoQuery
         ),
         'services' => array(
             'service_description'   => 'so.name2',
-            'service_display_name'  => 's.display_name COLLATE latin1_general_ci',
+            'service_display_name'  => 's.display_name ',
             'service_host_name'     => 'so.name1'
         )
     );
@@ -74,7 +74,7 @@ class HostnotificationQuery extends IdoQuery
             case 'mysql':
                 $concattedContacts = "GROUP_CONCAT("
                     . "DISTINCT co.name1 ORDER BY co.name1 SEPARATOR ', '"
-                    . ") COLLATE latin1_general_ci";
+                    . ") ";
                 break;
             case 'pgsql':
                 // TODO: Find a way to order the contact alias list:

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/HoststatehistoryQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/HoststatehistoryQuery.php
@@ -38,30 +38,30 @@ class HoststatehistoryQuery extends IdoQuery
      */
     protected $columnMap = array(
         'hostgroups' => array(
-            'hostgroup'         => 'hgo.name1 COLLATE latin1_general_ci',
-            'hostgroup_alias'   => 'hg.alias COLLATE latin1_general_ci',
+            'hostgroup'         => 'hgo.name1 ',
+            'hostgroup_alias'   => 'hg.alias ',
             'hostgroup_name'    => 'hgo.name1'
         ),
         'hosts' => array(
             'host_alias'        => 'h.alias',
-            'host_display_name' => 'h.display_name COLLATE latin1_general_ci'
+            'host_display_name' => 'h.display_name '
         ),
         'instances' => array(
             'instance_name' => 'i.instance_name'
         ),
         'servicegroups' => array(
-            'servicegroup'          => 'sgo.name1 COLLATE latin1_general_ci',
+            'servicegroup'          => 'sgo.name1 ',
             'servicegroup_name'     => 'sgo.name1',
-            'servicegroup_alias'    => 'sg.alias COLLATE latin1_general_ci'
+            'servicegroup_alias'    => 'sg.alias '
         ),
         'services' => array(
-            'service'               => 'so.name2 COLLATE latin1_general_ci',
+            'service'               => 'so.name2 ',
             'service_description'   => 'so.name2',
-            'service_display_name'  => 's.display_name COLLATE latin1_general_ci',
+            'service_display_name'  => 's.display_name ',
             'service_host_name'     => 'so.name1'
         ),
         'statehistory' => array(
-            'host'          => 'ho.name1 COLLATE latin1_general_ci',
+            'host'          => 'ho.name1 ',
             'host_name'     => 'ho.name1',
             'object_id'     => 'hh.object_id',
             'object_type'   => '(\'host\')',

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/HoststatusQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/HoststatusQuery.php
@@ -25,20 +25,20 @@ class HoststatusQuery extends IdoQuery
      */
     protected $columnMap = array(
         'checktimeperiods' => array(
-            'host_check_timeperiod' => 'ctp.alias COLLATE latin1_general_ci'
+            'host_check_timeperiod' => 'ctp.alias '
         ),
         'hostgroups' => array(
-            'hostgroup'         => 'hgo.name1 COLLATE latin1_general_ci',
-            'hostgroup_alias'   => 'hg.alias COLLATE latin1_general_ci',
+            'hostgroup'         => 'hgo.name1 ',
+            'hostgroup_alias'   => 'hg.alias ',
             'hostgroup_name'    => 'hgo.name1'
         ),
         'hosts' => array(
-            'host'                  => 'ho.name1 COLLATE latin1_general_ci',
+            'host'                  => 'ho.name1 ',
             'host_action_url'       => 'h.action_url',
             'host_address'          => 'h.address',
             'host_address6'         => 'h.address6',
             'host_alias'            => 'h.alias',
-            'host_display_name'     => 'h.display_name COLLATE latin1_general_ci',
+            'host_display_name'     => 'h.display_name ',
             'host_icon_image'       => 'h.icon_image',
             'host_icon_image_alt'   => 'h.icon_image_alt',
             'host_ipv4'             => 'INET_ATON(h.address)',
@@ -148,14 +148,14 @@ class HoststatusQuery extends IdoQuery
             'instance_name' => 'i.instance_name'
         ),
         'servicegroups' => array(
-            'servicegroup'          => 'sgo.name1 COLLATE latin1_general_ci',
+            'servicegroup'          => 'sgo.name1 ',
             'servicegroup_name'     => 'sgo.name1',
-            'servicegroup_alias'    => 'sg.alias COLLATE latin1_general_ci'
+            'servicegroup_alias'    => 'sg.alias '
         ),
         'services' => array(
-            'service'                => 'so.name2 COLLATE latin1_general_ci',
+            'service'                => 'so.name2 ',
             'service_description'    => 'so.name2',
-            'service_display_name'   => 's.display_name COLLATE latin1_general_ci',
+            'service_display_name'   => 's.display_name ',
         )
     );
 

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/IdoQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/IdoQuery.php
@@ -107,7 +107,7 @@ abstract class IdoQuery extends DbQuery
      * @var string
      */
     private $customVarsJoinTemplate =
-        '%1$s = %2$s.object_id AND %2$s.varname = %3$s COLLATE latin1_general_ci';
+        '%1$s = %2$s.object_id AND %2$s.varname = %3$s ';
 
     /**
      * An array with all 'virtual' tables that are already joined

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/ServicecommentQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/ServicecommentQuery.php
@@ -28,7 +28,7 @@ class ServicecommentQuery extends IdoQuery
      */
     protected $columnMap = array(
         'comments' => array(
-            'comment_author'        => 'c.author_name COLLATE latin1_general_ci',
+            'comment_author'        => 'c.author_name ',
             'comment_author_name'   => 'c.author_name',
             'comment_data'          => 'c.comment_data',
             'comment_expiration'    => 'CASE c.expires WHEN 1 THEN UNIX_TIMESTAMP(c.expiration_time) ELSE NULL END',
@@ -37,22 +37,22 @@ class ServicecommentQuery extends IdoQuery
             'comment_name'          => 'c.name',
             'comment_timestamp'     => 'UNIX_TIMESTAMP(c.comment_time)',
             'comment_type'          => "CASE c.entry_type WHEN 1 THEN 'comment' WHEN 2 THEN 'downtime' WHEN 3 THEN 'flapping' WHEN 4 THEN 'ack' END",
-            'host'                  => 'so.name1 COLLATE latin1_general_ci',
+            'host'                  => 'so.name1 ',
             'host_name'             => 'so.name1',
             'object_type'           => '(\'service\')',
-            'service'               => 'so.name2 COLLATE latin1_general_ci',
+            'service'               => 'so.name2 ',
             'service_description'   => 'so.name2',
-            'service_host'          => 'so.name1 COLLATE latin1_general_ci',
+            'service_host'          => 'so.name1 ',
             'service_host_name'     => 'so.name1'
         ),
         'hostgroups' => array(
-            'hostgroup'         => 'hgo.name1 COLLATE latin1_general_ci',
-            'hostgroup_alias'   => 'hg.alias COLLATE latin1_general_ci',
+            'hostgroup'         => 'hgo.name1 ',
+            'hostgroup_alias'   => 'hg.alias ',
             'hostgroup_name'    => 'hgo.name1'
         ),
         'hosts' => array(
             'host_alias'            => 'h.alias',
-            'host_display_name'     => 'h.display_name COLLATE latin1_general_ci'
+            'host_display_name'     => 'h.display_name '
         ),
         'instances' => array(
             'instance_name' => 'i.instance_name'
@@ -61,12 +61,12 @@ class ServicecommentQuery extends IdoQuery
             'host_state' => 'CASE WHEN hs.has_been_checked = 0 OR hs.has_been_checked IS NULL THEN 99 ELSE hs.current_state END'
         ),
         'servicegroups' => array(
-            'servicegroup'          => 'sgo.name1 COLLATE latin1_general_ci',
+            'servicegroup'          => 'sgo.name1 ',
             'servicegroup_name'     => 'sgo.name1',
-            'servicegroup_alias'    => 'sg.alias COLLATE latin1_general_ci'
+            'servicegroup_alias'    => 'sg.alias '
         ),
         'services' => array(
-            'service_display_name' => 's.display_name COLLATE latin1_general_ci'
+            'service_display_name' => 's.display_name '
         ),
         'servicestatus' => array(
             'service_state' => 'CASE WHEN ss.has_been_checked = 0 OR ss.has_been_checked IS NULL THEN 99 ELSE ss.current_state END'

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/ServicecommenthistoryQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/ServicecommenthistoryQuery.php
@@ -28,38 +28,38 @@ class ServicecommenthistoryQuery extends IdoQuery
      */
     protected $columnMap = array(
         'commenthistory' => array(
-            'host'                  => 'so.name1 COLLATE latin1_general_ci',
+            'host'                  => 'so.name1 ',
             'host_name'             => 'so.name1',
             'object_id'             => 'sch.object_id',
             'object_type'           => '(\'service\')',
             'output'                => "('[' || sch.author_name || '] ' || sch.comment_data)",
-            'service'               => 'so.name2 COLLATE latin1_general_ci',
+            'service'               => 'so.name2 ',
             'service_description'   => 'so.name2',
-            'service_host'          => 'so.name1 COLLATE latin1_general_ci',
+            'service_host'          => 'so.name1 ',
             'service_host_name'     => 'so.name1',
             'state'                 => '(-1)',
             'timestamp'             => 'UNIX_TIMESTAMP(sch.comment_time)',
             'type'                  => "(CASE sch.entry_type WHEN 1 THEN 'comment' WHEN 2 THEN 'dt_comment' WHEN 3 THEN 'flapping' WHEN 4 THEN 'ack' END)"
         ),
         'hostgroups' => array(
-            'hostgroup'         => 'hgo.name1 COLLATE latin1_general_ci',
-            'hostgroup_alias'   => 'hg.alias COLLATE latin1_general_ci',
+            'hostgroup'         => 'hgo.name1 ',
+            'hostgroup_alias'   => 'hg.alias ',
             'hostgroup_name'    => 'hgo.name1'
         ),
         'hosts' => array(
             'host_alias'        => 'h.alias',
-            'host_display_name' => 'h.display_name COLLATE latin1_general_ci'
+            'host_display_name' => 'h.display_name '
         ),
         'instances' => array(
             'instance_name' => 'i.instance_name'
         ),
         'servicegroups' => array(
-            'servicegroup'          => 'sgo.name1 COLLATE latin1_general_ci',
+            'servicegroup'          => 'sgo.name1 ',
             'servicegroup_name'     => 'sgo.name1',
-            'servicegroup_alias'    => 'sg.alias COLLATE latin1_general_ci'
+            'servicegroup_alias'    => 'sg.alias '
         ),
         'services' => array(
-            'service_display_name'  => 's.display_name COLLATE latin1_general_ci'
+            'service_display_name'  => 's.display_name '
         )
     );
 

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/ServicedowntimeQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/ServicedowntimeQuery.php
@@ -28,7 +28,7 @@ class ServicedowntimeQuery extends IdoQuery
      */
     protected $columnMap = array(
         'downtimes' => array(
-            'downtime_author'           => 'sd.author_name COLLATE latin1_general_ci',
+            'downtime_author'           => 'sd.author_name ',
             'downtime_author_name'      => 'sd.author_name',
             'downtime_comment'          => 'sd.comment_data',
             'downtime_duration'         => 'sd.duration',
@@ -43,22 +43,22 @@ class ServicedowntimeQuery extends IdoQuery
             'downtime_scheduled_start'  => 'UNIX_TIMESTAMP(sd.scheduled_start_time)',
             'downtime_start'            => 'UNIX_TIMESTAMP(CASE WHEN UNIX_TIMESTAMP(sd.trigger_time) > 0 then sd.trigger_time ELSE sd.scheduled_start_time END)',
             'downtime_triggered_by_id'  => 'sd.triggered_by_id',
-            'host'                      => 'so.name1 COLLATE latin1_general_ci',
+            'host'                      => 'so.name1 ',
             'host_name'                 => 'so.name1',
             'object_type'               => '(\'service\')',
-            'service'                   => 'so.name2 COLLATE latin1_general_ci',
+            'service'                   => 'so.name2 ',
             'service_description'       => 'so.name2',
-            'service_host'              => 'so.name1 COLLATE latin1_general_ci',
+            'service_host'              => 'so.name1 ',
             'service_host_name'         => 'so.name1'
         ),
         'hostgroups' => array(
-            'hostgroup'         => 'hgo.name1 COLLATE latin1_general_ci',
-            'hostgroup_alias'   => 'hg.alias COLLATE latin1_general_ci',
+            'hostgroup'         => 'hgo.name1 ',
+            'hostgroup_alias'   => 'hg.alias ',
             'hostgroup_name'    => 'hgo.name1'
         ),
         'hosts' => array(
             'host_alias'            => 'h.alias',
-            'host_display_name'     => 'h.display_name COLLATE latin1_general_ci'
+            'host_display_name'     => 'h.display_name '
         ),
         'hoststatus' => array(
             'host_state' => 'CASE WHEN hs.has_been_checked = 0 OR hs.has_been_checked IS NULL THEN 99 ELSE hs.current_state END'
@@ -67,12 +67,12 @@ class ServicedowntimeQuery extends IdoQuery
             'instance_name' => 'i.instance_name'
         ),
         'servicegroups' => array(
-            'servicegroup'          => 'sgo.name1 COLLATE latin1_general_ci',
+            'servicegroup'          => 'sgo.name1 ',
             'servicegroup_name'     => 'sgo.name1',
-            'servicegroup_alias'    => 'sg.alias COLLATE latin1_general_ci'
+            'servicegroup_alias'    => 'sg.alias '
         ),
         'services' => array(
-            'service_display_name' => 's.display_name COLLATE latin1_general_ci'
+            'service_display_name' => 's.display_name '
         ),
         'servicestatus' => array(
             'service_state' => 'CASE WHEN ss.has_been_checked = 0 OR ss.has_been_checked IS NULL THEN 99 ELSE ss.current_state END'

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/ServicedowntimestarthistoryQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/ServicedowntimestarthistoryQuery.php
@@ -28,38 +28,38 @@ class ServicedowntimestarthistoryQuery extends IdoQuery
      */
     protected $columnMap = array(
         'downtimehistory' => array(
-            'host'                  => 'so.name1 COLLATE latin1_general_ci',
+            'host'                  => 'so.name1 ',
             'host_name'             => 'so.name1',
             'object_id'             => 'sdh.object_id',
             'object_type'           => '(\'service\')',
             'output'                => "('[' || sdh.author_name || '] ' || sdh.comment_data)",
-            'service'               => 'so.name2 COLLATE latin1_general_ci',
+            'service'               => 'so.name2 ',
             'service_description'   => 'so.name2',
-            'service_host'          => 'so.name1 COLLATE latin1_general_ci',
+            'service_host'          => 'so.name1 ',
             'service_host_name'     => 'so.name1',
             'state'                 => '(-1)',
             'timestamp'             => 'UNIX_TIMESTAMP(sdh.actual_start_time)',
             'type'                  => "('dt_start')"
         ),
         'hostgroups' => array(
-            'hostgroup'         => 'hgo.name1 COLLATE latin1_general_ci',
-            'hostgroup_alias'   => 'hg.alias COLLATE latin1_general_ci',
+            'hostgroup'         => 'hgo.name1 ',
+            'hostgroup_alias'   => 'hg.alias ',
             'hostgroup_name'    => 'hgo.name1'
         ),
         'hosts' => array(
             'host_alias'        => 'h.alias',
-            'host_display_name' => 'h.display_name COLLATE latin1_general_ci'
+            'host_display_name' => 'h.display_name '
         ),
         'instances' => array(
             'instance_name' => 'i.instance_name'
         ),
         'servicegroups' => array(
-            'servicegroup'          => 'sgo.name1 COLLATE latin1_general_ci',
+            'servicegroup'          => 'sgo.name1 ',
             'servicegroup_name'     => 'sgo.name1',
-            'servicegroup_alias'    => 'sg.alias COLLATE latin1_general_ci'
+            'servicegroup_alias'    => 'sg.alias '
         ),
         'services' => array(
-            'service_display_name'  => 's.display_name COLLATE latin1_general_ci'
+            'service_display_name'  => 's.display_name '
         )
     );
 

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/ServiceflappingstarthistoryQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/ServiceflappingstarthistoryQuery.php
@@ -39,22 +39,22 @@ class ServiceflappingstarthistoryQuery extends IdoQuery
             'type'                  => "('flapping')"
         ),
         'hostgroups' => array(
-            'hostgroup_alias'   => 'hg.alias COLLATE latin1_general_ci',
+            'hostgroup_alias'   => 'hg.alias ',
             'hostgroup_name'    => 'hgo.name1'
         ),
         'hosts' => array(
             'host_alias'        => 'h.alias',
-            'host_display_name' => 'h.display_name COLLATE latin1_general_ci'
+            'host_display_name' => 'h.display_name '
         ),
         'instances' => array(
             'instance_name' => 'i.instance_name'
         ),
         'servicegroups' => array(
             'servicegroup_name'     => 'sgo.name1',
-            'servicegroup_alias'    => 'sg.alias COLLATE latin1_general_ci'
+            'servicegroup_alias'    => 'sg.alias '
         ),
         'services' => array(
-            'service_display_name'  => 's.display_name COLLATE latin1_general_ci'
+            'service_display_name'  => 's.display_name '
         )
     );
 

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/ServicegroupQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/ServicegroupQuery.php
@@ -26,8 +26,8 @@ class ServicegroupQuery extends IdoQuery
             'service_description'   => 'so.name2'
         ),
         'servicegroups' => array(
-            'servicegroup'          => 'sgo.name1 COLLATE latin1_general_ci',
-            'servicegroup_alias'    => 'sg.alias COLLATE latin1_general_ci',
+            'servicegroup'          => 'sgo.name1 ',
+            'servicegroup_alias'    => 'sg.alias ',
             'servicegroup_name'     => 'sgo.name1'
         ),
         'servicestatus' => array(

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/ServicenotificationQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/ServicenotificationQuery.php
@@ -30,7 +30,7 @@ class ServicenotificationQuery extends IdoQuery
             'hostgroup_name' => 'hgo.name1'
         ),
         'hosts' => array(
-            'host_display_name' => 'h.display_name COLLATE latin1_general_ci'
+            'host_display_name' => 'h.display_name '
         ),
         'instances' => array(
             'instance_name' => 'i.instance_name'
@@ -49,7 +49,7 @@ class ServicenotificationQuery extends IdoQuery
             'servicegroup_name' => 'sgo.name1'
         ),
         'services' => array(
-            'service_display_name'  => 's.display_name COLLATE latin1_general_ci'
+            'service_display_name'  => 's.display_name '
         )
     );
 
@@ -74,7 +74,7 @@ class ServicenotificationQuery extends IdoQuery
             case 'mysql':
                 $concattedContacts = "GROUP_CONCAT("
                     . "DISTINCT co.name1 ORDER BY co.name1 SEPARATOR ', '"
-                    . ") COLLATE latin1_general_ci";
+                    . ") ";
                 break;
             case 'pgsql':
                 // TODO: Find a way to order the contact alias list:

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/ServicestatehistoryQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/ServicestatehistoryQuery.php
@@ -38,34 +38,34 @@ class ServicestatehistoryQuery extends IdoQuery
      */
     protected $columnMap = array(
         'hostgroups' => array(
-            'hostgroup'         => 'hgo.name1 COLLATE latin1_general_ci',
-            'hostgroup_alias'   => 'hg.alias COLLATE latin1_general_ci',
+            'hostgroup'         => 'hgo.name1 ',
+            'hostgroup_alias'   => 'hg.alias ',
             'hostgroup_name'    => 'hgo.name1'
         ),
         'hosts' => array(
             'host_alias'        => 'h.alias',
-            'host_display_name' => 'h.display_name COLLATE latin1_general_ci'
+            'host_display_name' => 'h.display_name '
         ),
         'instances' => array(
             'instance_name' => 'i.instance_name'
         ),
         'servicegroups' => array(
-            'servicegroup'          => 'sgo.name1 COLLATE latin1_general_ci',
+            'servicegroup'          => 'sgo.name1 ',
             'servicegroup_name'     => 'sgo.name1',
-            'servicegroup_alias'    => 'sg.alias COLLATE latin1_general_ci'
+            'servicegroup_alias'    => 'sg.alias '
         ),
         'services' => array(
-            'service_display_name'  => 's.display_name COLLATE latin1_general_ci'
+            'service_display_name'  => 's.display_name '
         ),
         'statehistory' => array(
-            'host'                  => 'so.name1 COLLATE latin1_general_ci',
+            'host'                  => 'so.name1 ',
             'host_name'             => 'so.name1',
             'object_id'             => 'sh.object_id',
             'object_type'           => '(\'service\')',
             'output'                => '(CASE WHEN sh.state_type = 1 THEN sh.output ELSE \'[ \' || sh.current_check_attempt || \'/\' || sh.max_check_attempts || \' ] \' || sh.output END)',
-            'service'               => 'so.name2 COLLATE latin1_general_ci',
+            'service'               => 'so.name2 ',
             'service_description'   => 'so.name2',
-            'service_host'          => 'so.name1 COLLATE latin1_general_ci',
+            'service_host'          => 'so.name1 ',
             'service_host_name'     => 'so.name1',
             'state'                 => 'sh.state',
             'timestamp'             => 'UNIX_TIMESTAMP(sh.state_time)',

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/ServicestatusQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/ServicestatusQuery.php
@@ -28,19 +28,19 @@ class ServicestatusQuery extends IdoQuery
      */
     protected $columnMap = array(
         'checktimeperiods' => array(
-            'service_check_timeperiod' => 'ctp.alias COLLATE latin1_general_ci'
+            'service_check_timeperiod' => 'ctp.alias '
         ),
         'hostgroups' => array(
-            'hostgroup'         => 'hgo.name1 COLLATE latin1_general_ci',
-            'hostgroup_alias'   => 'hg.alias COLLATE latin1_general_ci',
+            'hostgroup'         => 'hgo.name1 ',
+            'hostgroup_alias'   => 'hg.alias ',
             'hostgroup_name'    => 'hgo.name1'
         ),
         'hosts' => array(
             'host_action_url'       => 'h.action_url',
             'host_address'          => 'h.address',
             'host_address6'         => 'h.address6',
-            'host_alias'            => 'h.alias COLLATE latin1_general_ci',
-            'host_display_name'     => 'h.display_name COLLATE latin1_general_ci',
+            'host_alias'            => 'h.alias ',
+            'host_display_name'     => 'h.display_name ',
             'host_icon_image'       => 'h.icon_image',
             'host_icon_image_alt'   => 'h.icon_image_alt',
             'host_ipv4'             => 'INET_ATON(h.address)',
@@ -133,14 +133,14 @@ class ServicestatusQuery extends IdoQuery
             'instance_name' => 'i.instance_name'
         ),
         'services' => array(
-            'host'                      => 'so.name1 COLLATE latin1_general_ci',
+            'host'                      => 'so.name1 ',
             'host_name'                 => 'so.name1',
             'object_type'               => '(\'service\')',
-            'service'                   => 'so.name2 COLLATE latin1_general_ci',
+            'service'                   => 'so.name2 ',
             'service_action_url'        => 's.action_url',
             'service_description'       => 'so.name2',
-            'service_display_name'      => 's.display_name COLLATE latin1_general_ci',
-            'service_host'              => 'so.name1 COLLATE latin1_general_ci',
+            'service_display_name'      => 's.display_name ',
+            'service_host'              => 'so.name1 ',
             'service_host_name'         => 'so.name1',
             'service_icon_image'        => 's.icon_image',
             'service_icon_image_alt'    => 's.icon_image_alt',
@@ -148,9 +148,9 @@ class ServicestatusQuery extends IdoQuery
             'service_notes'             => 's.notes'
         ),
         'servicegroups' => array(
-            'servicegroup'          => 'sgo.name1 COLLATE latin1_general_ci',
+            'servicegroup'          => 'sgo.name1 ',
             'servicegroup_name'     => 'sgo.name1',
-            'servicegroup_alias'    => 'sg.alias COLLATE latin1_general_ci'
+            'servicegroup_alias'    => 'sg.alias '
         ),
         'servicestatus' => array(
             'service_acknowledged'                      => 'ss.problem_has_been_acknowledged',


### PR DESCRIPTION
hard coded COLLATE breaks a pure utf-8 database and makes modules (e.g. graphite) unusable