### PR TITLE
FPM Config: Support Apache < 2.4

### DIFF
--- a/doc/02-Installation.md
+++ b/doc/02-Installation.md
@@ -282,7 +282,8 @@ updated the config file for icingaweb2 with defaults for FPM.
 Check `/etc/httpd/conf.d/icingaweb2.conf` or `/etc/apache2/conf.d/icingaweb2.conf`.
 And `*.rpm*` `*.dpkg*` files there with updates.
 
-Make sure that the `FilesMatch` part is included for Apache.
+Make sure that the `FilesMatch` part is included for Apache >= 2.4. For Apache < 2.4 you have to include the
+`LocationMatch` block.
 
 Also see the example from icingacli:
 ```

--- a/modules/setup/library/Setup/Webserver/Apache.php
+++ b/modules/setup/library/Setup/Webserver/Apache.php
@@ -10,13 +10,18 @@ use Icinga\Module\Setup\Webserver;
  */
 class Apache extends Webserver
 {
-    /**
-     * @return array
-     */
     protected function getTemplate()
     {
             return  <<<'EOD'
 Alias {urlPath} "{documentRoot}"
+
+# Remove comments if you want to use PHP FPM and your Apache version is older than 2.4
+#<IfVersion < 2.4>
+#    # Forward PHP requests to FPM
+#    <LocationMatch "^{urlPath}/(.*\.php)$">
+#        ProxyPassMatch "fcgi://127.0.0.1:9000/{documentRoot}/$1"
+#    </LocationMatch>
+#</IfVersion>
 
 <Directory "{documentRoot}">
     Options SymLinksIfOwnerMatch
@@ -55,13 +60,15 @@ Alias {urlPath} "{documentRoot}"
         DirectoryIndex error_norewrite.html
         ErrorDocument 404 {urlPath}/error_norewrite.html
     </IfModule>
-    
-    # forwarding PHP requests to FPM
-    # remove comments if you want to use FPM
-    #<FilesMatch "\.php$">
-    #    SetHandler "proxy:fcgi://127.0.0.1:9000"
-    #    ErrorDocument 503 {urlPath}/error_unavailable.html
-    #</FilesMatch>
+
+# Remove comments if you want to use PHP FPM and your Apache version is greater than or equal to 2.4
+#    <IfVersion >= 2.4>
+#        # Forward PHP requests to FPM
+#        <FilesMatch "\.php$">
+#            SetHandler "proxy:fcgi://127.0.0.1:9000"
+#            ErrorDocument 503 {urlPath}/error_unavailable.html
+#        </FilesMatch>
+#    </IfVersion>
 </Directory>
 EOD;
     }

--- a/packages/files/apache/icingaweb2.fpm.conf
+++ b/packages/files/apache/icingaweb2.fpm.conf
@@ -1,5 +1,12 @@
 Alias /icingaweb2 "/usr/share/icingaweb2/public"
 
+<IfVersion < 2.4>
+    # Forward PHP requests to FPM
+    <LocationMatch "^/icingaweb2/(.*\.php)$">
+        ProxyPassMatch "fcgi://127.0.0.1:9000/usr/share/icingaweb2/public/$1"
+    </LocationMatch>
+</IfVersion>
+
 <Directory "/usr/share/icingaweb2/public">
     Options SymLinksIfOwnerMatch
     AllowOverride None
@@ -38,9 +45,11 @@ Alias /icingaweb2 "/usr/share/icingaweb2/public"
         ErrorDocument 404 /icingaweb2/error_norewrite.html
     </IfModule>
 
-    # Forward PHP requests to FPM
-    <FilesMatch "\.php$">
-        SetHandler "proxy:fcgi://127.0.0.1:9000"
-        ErrorDocument 503 /icingaweb2/error_unavailable.html
-    </FilesMatch>
+    <IfVersion >= 2.4>
+        # Forward PHP requests to FPM
+        <FilesMatch "\.php$">
+            SetHandler "proxy:fcgi://127.0.0.1:9000"
+            ErrorDocument 503 /icingaweb2/error_unavailable.html
+        </FilesMatch>
+    </IfVersion>
 </Directory>


### PR DESCRIPTION
Apache < 2.4 does not support `SetHandler` in a `FilesMatch` block. The PR introduces `IfVersion` blocks to support FPM for both Apache >= 2.4 and Apache < 2.4.