### PR TITLE
Support basic auth on PHP-FPM

### DIFF
--- a/modules/setup/library/Setup/Webserver/Apache.php
+++ b/modules/setup/library/Setup/Webserver/Apache.php
@@ -18,6 +18,7 @@ Alias {urlPath} "{documentRoot}"
 # Remove comments if you want to use PHP FPM and your Apache version is older than 2.4
 #<IfVersion < 2.4>
 #    # Forward PHP requests to FPM
+#    SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
 #    <LocationMatch "^{urlPath}/(.*\.php)$">
 #        ProxyPassMatch "fcgi://127.0.0.1:9000/{documentRoot}/$1"
 #    </LocationMatch>
@@ -65,6 +66,7 @@ Alias {urlPath} "{documentRoot}"
 # is greater than or equal to 2.4
 #    <IfVersion >= 2.4>
 #        # Forward PHP requests to FPM
+#        SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
 #        <FilesMatch "\.php$">
 #            SetHandler "proxy:fcgi://127.0.0.1:9000"
 #            ErrorDocument 503 {urlPath}/error_unavailable.html

--- a/modules/setup/library/Setup/Webserver/Apache.php
+++ b/modules/setup/library/Setup/Webserver/Apache.php
@@ -61,7 +61,8 @@ Alias {urlPath} "{documentRoot}"
         ErrorDocument 404 {urlPath}/error_norewrite.html
     </IfModule>
 
-# Remove comments if you want to use PHP FPM and your Apache version is greater than or equal to 2.4
+# Remove comments if you want to use PHP FPM and your Apache version
+# is greater than or equal to 2.4
 #    <IfVersion >= 2.4>
 #        # Forward PHP requests to FPM
 #        <FilesMatch "\.php$">

--- a/packages/files/apache/icingaweb2.conf
+++ b/packages/files/apache/icingaweb2.conf
@@ -3,6 +3,7 @@ Alias /icingaweb2 "/usr/share/icingaweb2/public"
 # Remove comments if you want to use PHP FPM and your Apache version is older than 2.4
 #<IfVersion < 2.4>
 #    # Forward PHP requests to FPM
+#    SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
 #    <LocationMatch "^{urlPath}/(.*\.php)$">
 #        ProxyPassMatch "fcgi://127.0.0.1:9000/{documentRoot}/$1"
 #    </LocationMatch>
@@ -50,6 +51,7 @@ Alias /icingaweb2 "/usr/share/icingaweb2/public"
 # is greater than or equal to 2.4
 #    <IfVersion >= 2.4>
 #        # Forward PHP requests to FPM
+#        SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
 #        <FilesMatch "\.php$">
 #            SetHandler "proxy:fcgi://127.0.0.1:9000"
 #            ErrorDocument 503 {urlPath}/error_unavailable.html

--- a/packages/files/apache/icingaweb2.conf
+++ b/packages/files/apache/icingaweb2.conf
@@ -1,5 +1,13 @@
 Alias /icingaweb2 "/usr/share/icingaweb2/public"
 
+# Remove comments if you want to use PHP FPM and your Apache version is older than 2.4
+#<IfVersion < 2.4>
+#    # Forward PHP requests to FPM
+#    <LocationMatch "^{urlPath}/(.*\.php)$">
+#        ProxyPassMatch "fcgi://127.0.0.1:9000/{documentRoot}/$1"
+#    </LocationMatch>
+#</IfVersion>
+
 <Directory "/usr/share/icingaweb2/public">
     Options SymLinksIfOwnerMatch
     AllowOverride None
@@ -38,10 +46,13 @@ Alias /icingaweb2 "/usr/share/icingaweb2/public"
         ErrorDocument 404 /icingaweb2/error_norewrite.html
     </IfModule>
 
-    # forwarding PHP requests to FPM
-    # remove comments if you want to use FPM
-    #<FilesMatch "\.php$">
-    #    SetHandler "proxy:fcgi://127.0.0.1:9000"
-    #    ErrorDocument 503 /icingaweb2/error_unavailable.html
-    #</FilesMatch>
+# Remove comments if you want to use PHP FPM and your Apache version
+# is greater than or equal to 2.4
+#    <IfVersion >= 2.4>
+#        # Forward PHP requests to FPM
+#        <FilesMatch "\.php$">
+#            SetHandler "proxy:fcgi://127.0.0.1:9000"
+#            ErrorDocument 503 {urlPath}/error_unavailable.html
+#        </FilesMatch>
+#    </IfVersion>
 </Directory>

--- a/packages/files/apache/icingaweb2.fpm.conf
+++ b/packages/files/apache/icingaweb2.fpm.conf
@@ -2,6 +2,7 @@ Alias /icingaweb2 "/usr/share/icingaweb2/public"
 
 <IfVersion < 2.4>
     # Forward PHP requests to FPM
+    SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
     <LocationMatch "^/icingaweb2/(.*\.php)$">
         ProxyPassMatch "fcgi://127.0.0.1:9000/usr/share/icingaweb2/public/$1"
     </LocationMatch>
@@ -47,6 +48,7 @@ Alias /icingaweb2 "/usr/share/icingaweb2/public"
 
     <IfVersion >= 2.4>
         # Forward PHP requests to FPM
+        SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
         <FilesMatch "\.php$">
             SetHandler "proxy:fcgi://127.0.0.1:9000"
             ErrorDocument 503 /icingaweb2/error_unavailable.html


### PR DESCRIPTION
For authenticating against the Icinga Web 2 API.

Suggested in https://github.com/Icinga/icinga-packaging/issues/71

FYI @SimonHoenscheid

fixes #3173