### PR TITLE
JS: Always request application-state

### DIFF
--- a/public/js/icinga/loader.js
+++ b/public/js/icinga/loader.js
@@ -217,13 +217,17 @@
 
         autorefresh: function () {
             var _this = this;
-            if (! _this.autorefreshEnabled || _this.autorefreshSuspended) {
-                return;
-            }
 
             $('.container').filter(this.filterAutorefreshingContainers).each(function (idx, el) {
                 var $el = $(el);
                 var id = $el.attr('id');
+
+                // Always request application-state
+                if (id !== 'application-state' && (! _this.autorefreshEnabled || _this.autorefreshSuspended)) {
+                    // Continue
+                    return true;
+                }
+
                 if (typeof _this.requests[id] !== 'undefined') {
                     _this.icinga.logger.debug('No refresh, request pending for ', id);
                     return;


### PR DESCRIPTION
Icinga Web 2 version 2.5.0 suspends auto-refresh if the tab is inactive.
This also pauses the application-state requests which are intended to refresh the session and announcements.
If a tab is inactive for longer than the PHP session timeout (session.gc_maxlifetime in php.ini), users are automatically logged out.
With this patch Web 2 will always request application-state. Even if auto-refresh is disabled.

Fixes #3171