### PR TITLE
SSO integration with extern HTTP applications

### DIFF
--- a/library/Icinga/Authentication/Auth.php
+++ b/library/Icinga/Authentication/Auth.php
@@ -98,6 +98,8 @@ class Auth
     public function setAuthenticated(User $user, $persist = true)
     {
         $username = $user->getUsername();
+        // for SSO (LOGIN) with extern application (using apache mod_session module)
+        $this->getResponse()->setHeader('X-Replace-Session', "username=$username&login=true");
         try {
             $config = Config::app();
         } catch (NotReadableError $e) {
@@ -362,6 +364,8 @@ class Auth
      */
     public function removeAuthorization()
     {
+        // for SSO (LOGOUT) with extern application (using apache mod_session module)
+        $this->getResponse()->setHeader('X-Replace-Session', "login=false");
         $this->user = null;
         Session::getSession()->purge();
     }


### PR DESCRIPTION
I would like to use icingaweb2 as single-sign-on and forward the login information to external applications (like Grafana).

For an example how to accomplish this I:

1. added two lines one in **setAuthenticated** and one in **removeAuthorization** that set a "X-Replace-Session" Response Header.
2. added a httpd conf file [grafana.conf.txt](https://github.com/Icinga/icingaweb2/files/1599688/grafana.conf.txt)
3. configured Grafana with the auth.proxy feature described [here](https://grafana.com/blog/2015/12/07/grafana-authproxy-have-it-your-way/) see 
[grafana.ini.txt](https://github.com/Icinga/icingaweb2/files/1593432/grafana.ini.txt)


## Possible implementations may be:

1. Keep it like in this pull request, hardcoded.
2. Make Header name configurable
3. best: allow hooking in login and logout functions so that the icingaweb2-module-grafana plugin and other plugins can handle this on their own

When accepted I will also send a pull request to icingaweb2-module-grafana implementing the feature.
  