### PR TITLE
Unescape filter queries before parsing

### DIFF
--- a/library/Icinga/Data/Filter/FilterQueryString.php
+++ b/library/Icinga/Data/Filter/FilterQueryString.php
@@ -248,11 +248,10 @@ class FilterQueryString
 
     protected function parseQueryString($string)
     {
+        $filter = urldecode($string);
         $this->pos = 0;
-
-        $this->string = $string;
-
-        $this->length = strlen($string);
+        $this->string = $filter;
+        $this->length = strlen($filter);
 
         if ($this->length === 0) {
             return Filter::matchAll();

--- a/test/php/regression/Bug3239Test.php
+++ b/test/php/regression/Bug3239Test.php
@@ -1,0 +1,23 @@
+<?php
+/* Icinga Web 2 | (c) 2018 Icinga Development Team | GPLv2+ */
+
+namespace Tests\Icinga\Regression;
+
+use Icinga\Test\BaseTestCase;
+use Icinga\Data\Filter\FilterQueryString;
+
+/**
+ * Icingaweb2 can't handle properly escaped URIs
+ *
+ * @see https://github.com/Icinga/icingaweb2/issues/3239
+ */
+class Bug3239Test extends BaseTestCase
+{
+    /**
+     * Ensure an encoded filter does not throw any exceptions
+     */
+    public function testParseFilter()
+    {
+        FilterQueryString::parse('((service=a)%7C(service=b))');
+    }
+}


### PR DESCRIPTION
This is required to convert escapet special characters (e.g. `|` getting
replaced by `%7C`) back to their unescaped form.

Fixes #3239