### PR TITLE
Improve Event Grid performance

### DIFF
--- a/modules/monitoring/application/controllers/ListController.php
+++ b/modules/monitoring/application/controllers/ListController.php
@@ -361,13 +361,16 @@ class ListController extends Controller
         );
         $orientationBox->applyRequest($this->getRequest());
 */
+        $objectType = $this->getParam('objecttype', 'services');
+        $from = date('c', $this->getParam('from', strtotime('midnight 3 months ago')));
         $query = $this->backend->select()->from(
-            'eventgrid',
+            'eventgrid' . $objectType,
             array('day', $form->getValue('state'))
         );
         $this->params->remove(array('objecttype', 'from', 'to', 'state', 'btn_submit'));
         $this->view->filter = Filter::fromQuerystring((string) $this->params);
         $query->applyFilter($this->view->filter);
+        $query->applyFilter(Filter::fromQuerystring('timestamp >= ' . $from));
         $this->applyRestriction('monitoring/filter/objects', $query);
         $this->view->summary = $query;
         $this->view->column = $form->getValue('state');

--- a/modules/monitoring/application/controllers/ListController.php
+++ b/modules/monitoring/application/controllers/ListController.php
@@ -361,7 +361,7 @@ class ListController extends Controller
         );
         $orientationBox->applyRequest($this->getRequest());
 */
-        $objectType = $this->getParam('objecttype', 'services');
+        $objectType = $form->getValue('objecttype');
         $from = $form->getValue('from');
         $query = $this->backend->select()->from(
             'eventgrid' . $objectType,

--- a/modules/monitoring/application/controllers/ListController.php
+++ b/modules/monitoring/application/controllers/ListController.php
@@ -362,7 +362,7 @@ class ListController extends Controller
         $orientationBox->applyRequest($this->getRequest());
 */
         $objectType = $this->getParam('objecttype', 'services');
-        $from = date('c', $this->getParam('from', strtotime('midnight 3 months ago')));
+        $from = $form->getValue('from');
         $query = $this->backend->select()->from(
             'eventgrid' . $objectType,
             array('day', $form->getValue('state'))

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/EventgridhostsQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/EventgridhostsQuery.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Icinga\Module\Monitoring\Backend\Ido\Query;
+
+class EventgridhostsQuery extends EventgridQuery
+{
+
+    /**
+     * Join history related columns and tables, hosts only
+     */
+    protected function joinHistory()
+    {
+        $this->fetchHistoryColumns = true;
+        $this->requireVirtualTable('hosts');
+    }
+}

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/EventgridservicesQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/EventgridservicesQuery.php
@@ -4,7 +4,6 @@ namespace Icinga\Module\Monitoring\Backend\Ido\Query;
 
 class EventgridservicesQuery extends EventgridQuery
 {
-
     /**
      * Join history related columns and tables, services only
      */

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/EventgridservicesQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/EventgridservicesQuery.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Icinga\Module\Monitoring\Backend\Ido\Query;
+
+class EventgridservicesQuery extends EventgridQuery
+{
+
+    /**
+     * Join history related columns and tables, services only
+     */
+    protected function joinHistory()
+    {
+        $this->fetchHistoryColumns = true;
+        $this->requireVirtualTable('services');
+    }
+}

--- a/modules/monitoring/library/Monitoring/DataView/Eventgridhosts.php
+++ b/modules/monitoring/library/Monitoring/DataView/Eventgridhosts.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Icinga\Module\Monitoring\DataView;
+
+class Eventgridhosts extends Eventgrid
+{
+}

--- a/modules/monitoring/library/Monitoring/DataView/Eventgridservices.php
+++ b/modules/monitoring/library/Monitoring/DataView/Eventgridservices.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Icinga\Module\Monitoring\DataView;
+
+class Eventgridservices extends Eventgrid
+{
+}


### PR DESCRIPTION
I would like to submit for consideration this pull request to improve "event grid" performance in the monitoring web 2 module.

This patch partially addresses the issue 12732 - Improve IDO query performance.

The patch works by limiting the backend query for events by date, and also selecting only hosts or services in the main subquery (according to what is requested in the form).

In some rough testing on a large system with many (too many...) events, these changes reduced the initial page load time of the Event Grid from over 5 minutes to under 20 seconds.  
