### PR TITLE
Strip newlines from html plugin output

### DIFF
--- a/modules/monitoring/application/views/helpers/PluginOutput.php
+++ b/modules/monitoring/application/views/helpers/PluginOutput.php
@@ -52,6 +52,30 @@ class Zend_View_Helper_PluginOutput extends Zend_View_Helper_Abstract
     );
 
     /**
+     * Patterns to be replaced in html plugin output
+     *
+     * @var array
+     */
+    protected static $htmlPatterns = array(
+        '~\\\n~',
+        '~\\\t~',
+        '~\\\n\\\n~',
+        '~<table~'
+    );
+
+    /**
+     * Replacements for $htmlPatterns
+     *
+     * @var array
+     */
+    protected static $htmlReplacements = array(
+        "\n",
+        "\t",
+        "\n",
+        '<table style="font-size: 0.75em"'
+    );
+
+    /**
      * Render plugin output
      *
      * @param   string  $output
@@ -68,8 +92,8 @@ class Zend_View_Helper_PluginOutput extends Zend_View_Helper_Abstract
         if (preg_match('~<[^>]*["/\'][^>]*>~', $output)) {
             // HTML
             $output = preg_replace(
-                '~<table~',
-                '<table style="font-size: 0.75em"',
+                self::$htmlPatterns,
+                self::$htmlReplacements,
                 $this->getPurifier()->purify($output)
             );
             $isHtml = true;

--- a/modules/monitoring/application/views/helpers/PluginOutput.php
+++ b/modules/monitoring/application/views/helpers/PluginOutput.php
@@ -191,8 +191,11 @@ class Zend_View_Helper_PluginOutput extends Zend_View_Helper_Abstract
 
             $config = HTMLPurifier_Config::createDefault();
             $config->set('Core.EscapeNonASCIICharacters', true);
-            $config->set('HTML.Allowed', 'p,br,b,a[href|target],i,table,tr,th[colspan],td[colspan],div,*[class]');
             $config->set('Attr.AllowedFrameTargets', array('_blank'));
+            $config->set(
+                'HTML.Allowed',
+                'p,br,b,a[href|target],i,ul,ol,li,table,tr,th[colspan],td[colspan],div,*[class]'
+            );
             // This avoids permission problems:
             // $config->set('Core.DefinitionCache', null);
             $config->set('Cache.DefinitionImpl', null);


### PR DESCRIPTION
Transforms whitespace text representations to their actual character representation for html plugin output.

Also allows `ol`, `ul` and `li` as part of html plugin output.

Fixes #2846