### PR TITLE
Support array syntax in the filter editor

### DIFF
--- a/modules/monitoring/application/controllers/CommentController.php
+++ b/modules/monitoring/application/controllers/CommentController.php
@@ -68,8 +68,7 @@ class CommentController extends Controller
         $this->view->comment = $this->comment;
 
         if ($this->hasPermission('monitoring/command/comment/delete')) {
-            $listUrl = Url::fromPath('monitoring/list/comments')
-                ->setQueryString('comment_type=comment|comment_type=ack');
+            $listUrl = Url::fromPath('monitoring/list/comments')->setQueryString('comment_type=(comment|ack)');
             $form = new DeleteCommentCommandForm();
             $form
                 ->populate(array(

--- a/modules/monitoring/configuration.php
+++ b/modules/monitoring/configuration.php
@@ -222,7 +222,7 @@ $section->add(N_('Contactgroups'), array(
 $section->add(N_('Comments'), array(
     'icon'        => 'chat-empty',
     'description' => $this->translate('List comments'),
-    'url'         => 'monitoring/list/comments?comment_type=comment|comment_type=ack',
+    'url'      => 'monitoring/list/comments?comment_type=(comment|ack)',
     'priority'    => 80
 ));
 $section->add(N_('Downtimes'), array(


### PR DESCRIPTION
This changes the filter editor in the following ways:
* Parentheses are not rendered anymore for sequences of expressions in the editor's input
* Two new (FilterEditor specific) filter signs are introduced: IN and NOT IN
* Sequences of expressions may also defined with commas (for the user's convenience only, they will be transformed to pipes when applied)
* The change introduced with #2925 is reverted

The latter two changes may be dropped without interfering with this solution.

The rationale for the others is to avoid encoding issues. The parentheses are not required in the editor, so we can safely encode any parentheses put in by the user. Introducing specific filter signs allows the editor to split by `|` or `,` while the user is able to recognize that there is the possibility to input sequences of expressions *and* to input literal pipes or commas by choosing the standard filter signs.

fixes #3040