### PR TITLE
EventHistory: Drop obsolete SUM aggregates

### DIFF
--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/EventhistoryQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/EventhistoryQuery.php
@@ -29,11 +29,6 @@ class EventhistoryQuery extends IdoQuery
     protected $columnMap = array(
         'eventhistory' => array(
             'id'                    => 'eh.id',
-            'cnt_notification'      => "SUM(CASE eh.type WHEN 'notify' THEN 1 ELSE 0 END)",
-            'cnt_hard_state'        => "SUM(CASE eh.type WHEN 'hard_state' THEN 1 ELSE 0 END)",
-            'cnt_soft_state'        => "SUM(CASE eh.type WHEN 'hard_state' THEN 1 ELSE 0 END)",
-            'cnt_downtime_start'    => "SUM(CASE eh.type WHEN 'dt_start' THEN 1 ELSE 0 END)",
-            'cnt_downtime_end'      => "SUM(CASE eh.type WHEN 'dt_end' THEN 1 ELSE 0 END)",
             'host_name'             => 'eh.host_name',
             'service_description'   => 'eh.service_description',
             'object_type'           => 'eh.object_type',

--- a/modules/monitoring/library/Monitoring/DataView/Eventhistory.php
+++ b/modules/monitoring/library/Monitoring/DataView/Eventhistory.php
@@ -13,11 +13,6 @@ class EventHistory extends DataView
         return array(
             'id',
             'instance_name',
-            'cnt_notification',
-            'cnt_hard_state',
-            'cnt_soft_state',
-            'cnt_downtime_start',
-            'cnt_downtime_end',
             'host_name',
             'host_display_name',
             'service_description',


### PR DESCRIPTION
Not used anywhere and not working for a long time already,
at least as filter columns.

If someone wants to see aggregated summaries over different event types there's still the timeline.

fixes #2860