### PR TITLE
Add fpm socket commandline switch when generating a webserver's configuration

### DIFF
--- a/modules/setup/application/clicommands/ConfigCommand.php
+++ b/modules/setup/application/clicommands/ConfigCommand.php
@@ -99,6 +99,8 @@ class ConfigCommand extends Command
      *  --root|--document-root=<directory>  The directory from which the webserver will serve files
      *                                      [/path/to/icingaweb2/public]
      *
+     *  --fpm-uri=<uri>                     Address or path where to pass requests to FPM [127.0.0.1:9000]
+     *
      *  --config=<directory>                Path to Icinga Web 2's configuration files [/etc/icingaweb2]
      *
      *  --file=<filename>                   Write configuration to file [stdout]
@@ -115,7 +117,9 @@ class ConfigCommand extends Command
      *  icingacli setup config webserver apache \
      *    --file=/etc/apache2/conf.d/icingaweb2.conf
      *
-     *  icingacli setup config webserver nginx
+     *  icingacli setup config webserver nginx \
+     *    --root=/usr/share/icingaweb2/public \
+     *    --fpm-uri=unix:/var/run/php5-fpm.sock
      */
     public function webserverAction()
     {
@@ -145,10 +149,17 @@ class ConfigCommand extends Command
                 'The argument --config expects a path to Icinga Web 2\'s configuration files'
             ));
         }
+        $fpmUri = trim($this->params->get('fpm-uri', $webserver->getFpmUri()));
+        if (empty($fpmUri)) {
+            $this->fail($this->translate(
+                'The argument --fpm-uri expects an address or path where to pass requests to FPM'
+            ));
+        }
         $webserver
             ->setDocumentRoot($documentRoot)
             ->setConfigDir($configDir)
-            ->setUrlPath($urlPath);
+            ->setUrlPath($urlPath)
+            ->setFpmUri($fpmUri);
         $config = $webserver->generate() . "\n";
         if (($file = $this->params->get('file')) !== null) {
             if (file_exists($file) === true) {

--- a/modules/setup/library/Setup/Webserver.php
+++ b/modules/setup/library/Setup/Webserver.php
@@ -33,6 +33,13 @@ abstract class Webserver
     protected $configDir;
 
     /**
+     * Address or path where to pass requests to FPM
+     *
+     * @var string
+     */
+    protected $fpmUri;
+
+    /**
      * Create instance by type name
      *
      * @param   string $type
@@ -63,11 +70,13 @@ abstract class Webserver
             '{urlPath}',
             '{documentRoot}',
             '{configDir}',
+            '{fpmUri}'
         );
         $replaceTokens = array(
             $this->getUrlPath(),
             $this->getDocumentRoot(),
-            $this->getConfigDir()
+            $this->getConfigDir(),
+            $this->getFpmUri()
         );
         $template = str_replace($searchTokens, $replaceTokens, $template);
         return $template;
@@ -163,5 +172,29 @@ abstract class Webserver
             return Icinga::app()->getConfigDir();
         }
         return $this->configDir;
+    }
+
+    /**
+     * Get the address or path where to pass requests to FPM
+     *
+     * @return  string
+     */
+    public function getFpmUri()
+    {
+        return $this->fpmUri;
+    }
+
+    /**
+     * Set the address or path where to pass requests to FPM
+     *
+     * @param   string  $uri
+     *
+     * @return  $this
+     */
+    public function setFpmUri($uri)
+    {
+        $this->fpmUri = (string) $uri;
+
+        return $this;
     }
 }

--- a/modules/setup/library/Setup/Webserver/Apache.php
+++ b/modules/setup/library/Setup/Webserver/Apache.php
@@ -10,6 +10,8 @@ use Icinga\Module\Setup\Webserver;
  */
 class Apache extends Webserver
 {
+    protected $fpmUri = 'fgci://127.0.0.1:9000';
+
     protected function getTemplate()
     {
             return  <<<'EOD'
@@ -68,7 +70,7 @@ Alias {urlPath} "{documentRoot}"
 #        # Forward PHP requests to FPM
 #        SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
 #        <FilesMatch "\.php$">
-#            SetHandler "proxy:fcgi://127.0.0.1:9000"
+#            SetHandler "proxy:{fpmUri}"
 #            ErrorDocument 503 {urlPath}/error_unavailable.html
 #        </FilesMatch>
 #    </IfVersion>

--- a/modules/setup/library/Setup/Webserver/Nginx.php
+++ b/modules/setup/library/Setup/Webserver/Nginx.php
@@ -10,17 +10,13 @@ use Icinga\Module\Setup\Webserver;
  */
 class Nginx extends Webserver
 {
-    /**
-     * Specific template
-     *
-     * @return array|string
-     */
+    protected $fpmUri = '127.0.0.1:9000';
+
     protected function getTemplate()
     {
         return <<<'EOD'
 location ~ ^{urlPath}/index\.php(.*)$ {
-  # fastcgi_pass 127.0.0.1:9000;
-  fastcgi_pass unix:/var/run/php5-fpm.sock;
+  fastcgi_pass {fpmUri};
   fastcgi_index index.php;
   include fastcgi_params;
   fastcgi_param SCRIPT_FILENAME {documentRoot}/index.php;


### PR DESCRIPTION
Allows to pass a different socket path than the default
when generating a webserver's configuration.

fixes #2862