### PR TITLE
actiontable.js: Use `event.currentTarget` instead of the closest tr

### DIFF
--- a/public/js/icinga/behavior/actiontable.js
+++ b/public/js/icinga/behavior/actiontable.js
@@ -375,7 +375,7 @@
     ActionTable.prototype.onRowClicked = function (event) {
         var _this = event.data.self;
         var $target = $(event.target);
-        var $tr = $target.closest('tr');
+        var $tr = $(event.currentTarget);
         var table = new Selection($tr.closest('table.action, table.table-row-selectable')[0], _this.icinga);
 
         // some rows may contain form actions that trigger a different action, pass those through


### PR DESCRIPTION
This event is triggered due to delegation. If any onclick event is able to bubble up this far that it gets triggered we can safely use whatever it has been triggered for. (i.e. it can only be a tr[href])

fixes #3298 