### PR TITLE
IcingaException::getConfidentialTraceAsString(): don't fail on internal functions

### DIFF
--- a/library/Icinga/Exception/IcingaException.php
+++ b/library/Icinga/Exception/IcingaException.php
@@ -74,7 +74,9 @@ class IcingaException extends Exception
         $trace = array();
 
         foreach ($exception->getTrace() as $index => $frame) {
-            $trace[] = "#{$index} {$frame['file']}({$frame['line']}): ";
+            $trace[] = isset($frame['file'])
+                ? "#{$index} {$frame['file']}({$frame['line']}): "
+                : "#{$index} [internal function]: ";
 
             if (isset($frame['class'])) {
                 $trace[] = $frame['class'];


### PR DESCRIPTION
fixes #3318