### PR TITLE
hostgroups url filter also for services

### DIFF
--- a/modules/monitoring/application/views/scripts/list/hostgroups.phtml
+++ b/modules/monitoring/application/views/scripts/list/hostgroups.phtml
@@ -148,6 +148,7 @@ if (! $this->compact): ?>
                 $stateBadges = new StateBadges();
                 $stateBadges
                     ->setUrl('monitoring/list/services')
+                    ->setBaseFilter($this->filterEditor->getFilter())
                     ->add(
                         StateBadges::STATE_OK,
                         $hostGroup->services_ok,


### PR DESCRIPTION
use the url filter also for services.
The filter is already used for hosts, but not for services