### PR TITLE
Vagrant: Install SCL PHP CLI and set PATH

### DIFF
--- a/.puppet/files/etc/profile.d/env.sh
+++ b/.puppet/files/etc/profile.d/env.sh
@@ -1,1 +1,2 @@
+export PATH="/opt/rh/rh-php71/root/bin:$PATH"
 export PATH="$PATH:/usr/local/bin"

--- a/.puppet/profiles/icingaweb2_dev/manifests/init.pp
+++ b/.puppet/profiles/icingaweb2_dev/manifests/init.pp
@@ -22,6 +22,7 @@ class icingaweb2_dev (
 
   # TODO(el): icinga-gui is not a icingaweb2_dev package
   package { [
+    'rh-php71-php-cli',
     'rh-php71-php-gd',
     'rh-php71-php-intl',
     'rh-php71-php-pdo',


### PR DESCRIPTION
This avoids having to set `PATH="/opt/rh/rh-php71/root/bin:$PATH" icingacli`
all the time.