### PR TITLE
Vagrant: Introduce base profile and install vim

### DIFF
--- a/.puppet/manifests/site.pp
+++ b/.puppet/manifests/site.pp
@@ -6,6 +6,7 @@ node default {
   class { 'epel':
     stage => repositories,
   }
+  include base
   include icinga2_dev
   include icingaweb2_dev
   include motd

--- a/.puppet/profiles/base/manifests/init.pp
+++ b/.puppet/profiles/base/manifests/init.pp
@@ -1,0 +1,5 @@
+class base {
+  package { [ 'vim-enhanced', 'bash-completion' ]:
+    ensure => latest,
+  }
+}

--- a/.puppet/profiles/base/manifests/init.pp
+++ b/.puppet/profiles/base/manifests/init.pp
@@ -1,5 +1,5 @@
 class base {
-  package { [ 'vim-enhanced', 'bash-completion' ]:
+  package { [ 'vim-enhanced', 'bash-completion', 'htop' ]:
     ensure => latest,
   }
 }


### PR DESCRIPTION
This happened too often with `vim: not found`, so I've patched it.