### PR TITLE
SELinux: Add a new plugin context for icingacli

### DIFF
--- a/packages/selinux/icingaweb2.fc
+++ b/packages/selinux/icingaweb2.fc
@@ -5,3 +5,5 @@
 /var/log/icingaweb2(/.*)?         gen_context(system_u:object_r:icingaweb2_rw_content_t,s0)
 /var/cache/icingaweb2(/.*)?         gen_context(system_u:object_r:icingaweb2_rw_content_t,s0)
 /var/lib/icingaweb2(/.*)?         gen_context(system_u:object_r:icingaweb2_rw_content_t,s0)
+
+/usr/bin/icingacli        gen_context(system_u:object_r:nagios_icingacli_plugin_exec_t,s0)

--- a/packages/selinux/icingaweb2.te
+++ b/packages/selinux/icingaweb2.te
@@ -1,4 +1,4 @@
-policy_module(icingaweb2, 0.0.1)
+policy_module(icingaweb2, 0.0.2)
 
 ########################################
 #
@@ -7,6 +7,7 @@ policy_module(icingaweb2, 0.0.1)
 
 require {
 	type httpd_t;
+	type icinga2_t;
 }
 
 ## <desc>
@@ -25,5 +26,18 @@ optional_policy(`
 	tunable_policy(`httpd_can_manage_icingaweb2_config',`
 		icingaweb2_manage_config(httpd_t)
 	')
-')
 
+        nagios_plugin_template(icingacli)
+#        The following interface does not work in an optional_policy block
+#        icinga2_execstrans(nagios_icingacli_plugin_exec_t, nagios_icingacli_plugin_t)
+        domtrans_pattern(icinga2_t, nagios_icingacli_plugin_exec_t, nagios_icingacli_plugin_t)
+        icingaweb2_read_config(nagios_icingacli_plugin_t)
+        list_dirs_pattern(nagios_icingacli_plugin_t, icingaweb2_content_t, icingaweb2_content_t)
+        read_files_pattern(nagios_icingacli_plugin_t, icingaweb2_content_t, icingaweb2_content_t)
+        read_lnk_files_pattern(nagios_icingacli_plugin_t, icingaweb2_content_t, icingaweb2_content_t)
+        corecmd_exec_bin(nagios_icingacli_plugin_t)
+        mysql_stream_connect(nagios_icingacli_plugin_t)
+        mysql_tcp_connect(nagios_icingacli_plugin_t)
+        postgresql_stream_connect(nagios_icingacli_plugin_t)
+        postgresql_tcp_connect(nagios_icingacli_plugin_t)
+')


### PR DESCRIPTION
While this would resolve #3235, it would introduce a new packaging dependency for icingaweb2-selinux requiring icinga2-selinux during build and runtime. I could solve it in other way, but this would introduce the requirement simple from the other side, this way seams more logical for me.

If this gets included, I will create two further pull request. One to add the new plugin context to Icinga 2 docs and one for packaging. 