### PR TITLE
Set url as external if it starts with "/"

### DIFF
--- a/library/Icinga/Web/Url.php
+++ b/library/Icinga/Web/Url.php
@@ -197,6 +197,10 @@ class Url
                     if ($requestBaseUrl && $requestBaseUrl !== '/' && strpos($urlPath, $requestBaseUrl) === 0) {
                         $urlPath = substr($urlPath, strlen($requestBaseUrl) + 1);
                         $urlObject->setBasePath($requestBaseUrl);
+                    } else {
+                        // If the url start with "/" and does not start with the baseurl
+                        // it is an external url
+                        $urlObject->setIsExternal();
                     }
                 }
             } elseif (! $urlObject->isExternal()) {


### PR DESCRIPTION
When adding a new dashlet in dashboard, an exception is thrown if an url starting with "/" is inserted. This Exception does not allow you to see/use/change the dashboard anymore.
```
Cannot create dashboard dashlet "mon" without valid URL

#0 /usr/share/icingaweb2/library/Icinga/Web/Widget/Dashboard.php(178): Icinga\Web\Widget\Dashboard\Dashlet->__construct('mon', '', Object(Icinga\Web\Widget\Dashboard\Pane))
#1 /usr/share/icingaweb2/library/Icinga/Web/Widget/Dashboard.php(120): Icinga\Web\Widget\Dashboard->loadUserDashboardsFromFile('/neteye/shared/...')
#2 /usr/share/icingaweb2/library/Icinga/Web/Widget/Dashboard.php(88): Icinga\Web\Widget\Dashboard->loadUserDashboards()
#3 /usr/share/icingaweb2/application/controllers/DashboardController.php(41): Icinga\Web\Widget\Dashboard->load()
#4 /usr/share/icingaweb2/library/Icinga/Web/Controller/ActionController.php(139): Icinga\Controllers\DashboardController->init()
#5 /usr/share/icingaweb2/library/Icinga/Web/Controller/Dispatcher.php(59): Icinga\Web\Controller\ActionController->__construct(Object(Icinga\Web\Request), Object(Icinga\Web\Response), Array)
#6 /usr/share/icingaweb2/library/vendor/Zend/Controller/Front.php(937): Icinga\Web\Controller\Dispatcher->dispatch(Object(Icinga\Web\Request), Object(Icinga\Web\Response))
#7 /usr/share/icingaweb2/library/Icinga/Application/Web.php(391): Zend_Controller_Front->dispatch(Object(Icinga\Web\Request), Object(Icinga\Web\Response))
#8 /usr/share/icingaweb2/library/Icinga/Application/webrouter.php(109): Icinga\Application\Web->dispatch()
#9 /usr/share/icingaweb2/public/index.php(4): require_once('/usr/share/icin...')
#10 {main}
```
We think that en error message should be given before the "New dashlet" form is submitted.
If the url start with "/" and does not start with the baseUrl it is an external url.