### PR TITLE
Always show full date + time on history list for notifications

### DIFF
--- a/modules/monitoring/application/views/scripts/list/notifications.phtml
+++ b/modules/monitoring/application/views/scripts/list/notifications.phtml
@@ -35,7 +35,7 @@ if (! $this->compact): ?>
             <td class="state-col state-<?= $stateName ?>">
                 <div class="state-label"><?= $stateLabel ?></div>
                 <div class="state-meta">
-                    <?= $this->timeAgo($notification->notification_timestamp, $this->compact) ?>
+                    <?= $this->formatDateTime($notification->notification_timestamp) ?>
                 </div>
             </td>
             <td>


### PR DESCRIPTION
In history list we need to see always the full date + time when a notification was send and not only "on Mar 9" or similar and have to do mouseover to see the time.

View as it is now:
![image](https://user-images.githubusercontent.com/6574967/37462820-824f841c-2853-11e8-98a6-1666271d43a2.png)

New view:
![image](https://user-images.githubusercontent.com/6574967/37462864-a38a2f56-2853-11e8-821b-fc8d38776be7.png)
