### PR TITLE
Platform: Correct detecting MSSQL Support

### DIFF
--- a/library/Icinga/Application/Platform.php
+++ b/library/Icinga/Application/Platform.php
@@ -351,7 +351,8 @@ class Platform
      */
     public static function hasMssqlSupport()
     {
-        return static::extensionLoaded('mssql') && static::classExists('Zend_Db_Adapter_Pdo_Mssql');
+        return (static::extensionLoaded('mssql') || static::extensionLoaded('pdo_dblib'))
+            && static::classExists('Zend_Db_Adapter_Pdo_Mssql');
     }
 
     /**


### PR DESCRIPTION
PDO Implementation of zf1 builds on module mssql OR pdo_dblib, while dblib is preferred.

Newer implementations would support pdo_sqlsrv, but that is not available with ZF1.