### PR TITLE
Authentication Hook

### DIFF
--- a/application/controllers/AuthenticationController.php
+++ b/application/controllers/AuthenticationController.php
@@ -3,6 +3,7 @@
 
 namespace Icinga\Controllers;
 
+use Icinga\Application\Hook\AuthenticationHook;
 use Icinga\Application\Icinga;
 use Icinga\Forms\Authentication\LoginForm;
 use Icinga\Web\Controller;
@@ -35,6 +36,9 @@ class AuthenticationController extends Controller
         }
         $form = new LoginForm();
         if ($this->Auth()->isAuthenticated()) {
+            // Call provided AuthenticationHook(s) when login action is called
+            // but icinga web user is already authenticated
+            AuthenticationHook::triggerLogin($this->Auth()->getUser());
             $this->redirectNow($form->getRedirectUrl());
         }
         if (! $requiresSetup) {
@@ -66,6 +70,8 @@ class AuthenticationController extends Controller
         // Get info whether the user is externally authenticated before removing authorization which destroys the
         // session and the user object
         $isExternalUser = $auth->getUser()->isExternalUser();
+        // Call provided AuthenticationHook(s) when logout action is called
+        AuthenticationHook::triggerLogout($auth->getUser());
         $auth->removeAuthorization();
         if ($isExternalUser) {
             $this->getResponse()->setHttpResponseCode(401);

--- a/application/forms/Authentication/LoginForm.php
+++ b/application/forms/Authentication/LoginForm.php
@@ -4,6 +4,7 @@
 namespace Icinga\Forms\Authentication;
 
 use Icinga\Application\Config;
+use Icinga\Application\Hook\AuthenticationHook;
 use Icinga\Authentication\Auth;
 use Icinga\Authentication\User\ExternalBackend;
 use Icinga\User;
@@ -95,6 +96,8 @@ class LoginForm extends Form
         $authenticated = $authChain->authenticate($user, $password);
         if ($authenticated) {
             $auth->setAuthenticated($user);
+            // Call provided AuthenticationHook(s) after successful login
+            AuthenticationHook::triggerLogin($user);
             $this->getResponse()->setRerenderLayout(true);
             return true;
         }

--- a/library/Icinga/Application/Hook/AuthenticationHook.php
+++ b/library/Icinga/Application/Hook/AuthenticationHook.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Icinga\Application\Hook;
+
+use Icinga\User;
+use Icinga\Web\Hook;
+use Icinga\Application\Logger;
+
+/**
+ * Icinga Web Authentication Hook base class
+ *
+ * This hook can be used to authenticate the user in a third party application.
+ * Extend this class if you want to perform arbitrary actions during the login and logout.
+ */
+abstract class AuthenticationHook
+{
+    /**
+     * Name of the hook
+     */
+    const NAME = 'authentication';
+
+    /**
+     * Triggered after login in Icinga Web and when calling login action even if already authenticated in Icinga Web
+     *
+     * @param User $user
+     */
+    public function onLogin(User $user)
+    {
+    }
+
+    /**
+     * Triggered before logout from Icinga Web
+     *
+     * @param User $user
+     */
+    public function onLogout(User $user)
+    {
+    }
+
+    /**
+     * Call the onLogin() method of all registered AuthHook(s)
+     *
+     * @param User $user
+     */
+    public static function triggerLogin(User $user)
+    {
+        /** @var AuthenticationHook $hook */
+        foreach (Hook::all(self::NAME) as $hook) {
+            try {
+                $hook->onLogin($user);
+            } catch (\Exception $e) {
+                // Avoid error propagation if login failed in third party application
+                Logger::error($e);
+            }
+        }
+    }
+
+    /**
+     * Call the onLogout() method of all registered AuthHook(s)
+     *
+     * @param User $user
+     */
+    public static function triggerLogout(User $user)
+    {
+        /** @var AuthenticationHook $hook */
+        foreach (Hook::all(self::NAME) as $hook) {
+            try {
+                $hook->onLogout($user);
+            } catch (\Exception $e) {
+                // Avoid error propagation if login failed in third party application
+                Logger::error($e);
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
With this patch, we have created a new Hook that allows modules to authenticate the user in third-party applications during login and logout actions.

The implementation of the onLogin and onLogout methods of the hook are not mandatory.

A use case is to authenticate the user in grafana trough the login of icingaweb.
This is an example of how we have implemented the AuthenticationHook for Grafana.
```php
<?php

namespace Icinga\Module\Analytics\ProvidedHook;

use Icinga\Application\Hook\AuthenticationHook;
use Icinga\Application\Logger;
use Icinga\User;

class Authentication extends AuthenticationHook
{
    const GRAFANA_SESS = "grafana_sess";

    public function onLogin(User $user)
    {
        $ch = curl_init();

        curl_setopt($ch, CURLOPT_URL, "http://localhost:3000/login");
        curl_setopt($ch, CURLOPT_HTTPHEADER, array(sprintf("X-WEBAUTH-USER: %s", $user->getUsername())));
        curl_setopt($ch, CURLOPT_HEADER, true);
        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);

        if (!$result = curl_exec($ch)) {
            // don't fail but log the possible errors
            Logger::error(new \Exception(curl_error($ch)));
            return;
        }

        $preg = sprintf('/^\s*Set-Cookie:\s+%s=(.*?);.*$/mi', self::GRAFANA_SESS);
        preg_match($preg, $result, $matches);

        if (count($matches) < 2) {
            Logger::error(new \Exception("Login to grafana did not return any grafana_sess"));
            return;
        }

        $session = $matches[1];

        if (!setcookie(self::GRAFANA_SESS, $session, 0, "/grafana", null, false, true)) {
            Logger::error(new \Exception("Failed to set grafana_sess"));
            return;
        }

        return;
    }

    public function onLogout(User $_)
    {
        // remove the cookie by set it to null
        // this will remove this cookie from all tabs and windows
        // but this will not logout the user from different browsers or devices
        if (!setcookie(self::GRAFANA_SESS, null, 0, "/grafana", null, false, true)) {
            Logger::error(new \Exception("Failed to set grafana_sess"));
            return;
        }

        return;
    }
}
```