### PR TITLE
Documentation for the webserver installation on Debian

### DIFF
--- a/doc/02-Installation.md
+++ b/doc/02-Installation.md
@@ -230,7 +230,7 @@ systemctl enable apache2.service
     
 **Debian / Ubuntu**
 
-Your web server should be up and running after the installation.
+Your web server should be up and running after the installation of Icinga Web 2.
 
 ### Setting up FPM <a id="setting-up-fpm"></a>
 


### PR DESCRIPTION
The documentation was missing and it just said: 
> Debian / Ubuntu
> Your web server should be up and running after the installation.

Fixed this and added a short how-to test it. 