### PR TITLE
Add support for the sqlsrv extension

### DIFF
--- a/library/Icinga/Application/Platform.php
+++ b/library/Icinga/Application/Platform.php
@@ -345,14 +345,20 @@ class Platform
     /**
      * Return whether it's possible to connect to a MSSQL database
      *
-     * Checks whether the mssql pdo extension has been loaded and Zend framework adapter for MSSQL is available
+     * Checks whether the mssql/dblib pdo or sqlsrv extension has
+     * been loaded and Zend framework adapter for MSSQL is available
      *
      * @return  bool
      */
     public static function hasMssqlSupport()
     {
-        return (static::extensionLoaded('mssql') || static::extensionLoaded('pdo_dblib'))
-            && static::classExists('Zend_Db_Adapter_Pdo_Mssql');
+        if ((static::extensionLoaded('mssql') || static::extensionLoaded('pdo_dblib'))
+            && static::classExists('Zend_Db_Adapter_Pdo_Mssql')
+        ) {
+            return true;
+        }
+
+        return static::extensionLoaded('sqlsrv') && static::classExists('Zend_Db_Adapter_Sqlsrv');
     }
 
     /**

--- a/library/Icinga/Data/Db/DbConnection.php
+++ b/library/Icinga/Data/Db/DbConnection.php
@@ -139,14 +139,23 @@ class DbConnection implements Selectable, Extensible, Updatable, Reducible, Insp
         switch ($this->dbType) {
             case 'mssql':
                 $adapter = 'Pdo_Mssql';
-                $pdoType = $this->config->get('pdoType', 'dblib');
+                $pdoType = $this->config->get('pdoType');
+                if (empty($pdoType)) {
+                    if (extension_loaded('sqlsrv')) {
+                        $adapter = 'Sqlsrv';
+                    } else {
+                        $pdoType = 'dblib';
+                    }
+                }
                 if ($pdoType === 'dblib') {
                     // Driver does not support setting attributes
                     unset($adapterParamaters['persistent']);
                     unset($adapterParamaters['options']);
                     unset($adapterParamaters['driver_options']);
                 }
-                $adapterParamaters['pdoType'] = $pdoType;
+                if (! empty($pdoType)) {
+                    $adapterParamaters['pdoType'] = $pdoType;
+                }
                 $defaultPort = 1433;
                 break;
             case 'mysql':


### PR DESCRIPTION
Utilizes the `sqlsrv` extension automatically if it's available and none is explicitly configured.

![sqlsrv-resource](https://user-images.githubusercontent.com/16668527/39192328-3d139eec-47d9-11e8-9a05-018487529c4b.jpg)

fixes #3320 