### PR TITLE
Add a isset check to make sure there is no session before creating one

### DIFF
--- a/library/Icinga/Web/Session/PhpSession.php
+++ b/library/Icinga/Web/Session/PhpSession.php
@@ -94,7 +94,9 @@ class PhpSession extends Session
      */
     protected function open()
     {
-        session_name($this->sessionName);
+        if (!isset($_SESSION)) {
+            session_name($this->sessionName);
+        }
 
         if ($this->hasBeenTouched) {
             $cacheLimiter = ini_get('session.cache_limiter');


### PR DESCRIPTION
This fixes an issue in php 7.2 where by it will fail if it trys to create mutiple sessions.

https://stackoverflow.com/questions/47700336/php-7-2-warning-cannot-change-session-name-when-session-is-active

Fixes #3428