### PR TITLE
Fix search over customvars results in sql error 2508

### DIFF
--- a/library/Icinga/Data/Db/DbConnection.php
+++ b/library/Icinga/Data/Db/DbConnection.php
@@ -99,6 +99,16 @@ class DbConnection implements Selectable, Extensible, Updatable, Reducible, Insp
     }
 
     /**
+     * Get the connection configuration
+     *
+     * @return  ConfigObject
+     */
+    public function getConfig()
+    {
+        return $this->config;
+    }
+
+    /**
      * Getter for database type
      *
      * @return string

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/IdoQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/IdoQuery.php
@@ -106,8 +106,7 @@ abstract class IdoQuery extends DbQuery
      *
      * @var string
      */
-    private $customVarsJoinTemplate =
-        '%1$s = %2$s.object_id AND %2$s.varname = %3$s COLLATE latin1_general_ci';
+    private $customVarsJoinTemplate = '%1$s = %2$s.object_id AND %2$s.varname = %3$s';
 
     /**
      * An array with all 'virtual' tables that are already joined
@@ -701,6 +700,9 @@ abstract class IdoQuery extends DbQuery
             $this->initializeForOracle();
         } elseif ($dbType === 'pgsql') {
             $this->initializeForPostgres();
+        } else {
+            $charset = $this->ds->getConfig()->get('charset') ?: 'latin1';
+            $this->customVarsJoinTemplate .= " COLLATE {$charset}_general_ci";
         }
         $this->joinBaseTables();
         $this->select->columns($this->columns);


### PR DESCRIPTION
Utilizes the `charset` configuration value to dynamically generate a `COLLATE` instruction. Still falls back to `latin1` if not set.

fixes #2508