### PR TITLE
WIP: Enable referencing other columns in filters

### DIFF
--- a/library/Icinga/Data/Filter/FilterExpression.php
+++ b/library/Icinga/Data/Filter/FilterExpression.php
@@ -182,7 +182,8 @@ class FilterExpression extends Filter
         }
 
         // referencing another column using php variable notation
-        if (strlen($expression) > 2 && $expression[0] == '$' && $expression[1] == '{' && $expression[strlen($expression) - 1] == '}') {
+        if (strlen($expression) > 2 && $expression[0] == '$' && $expression[1] == '{'
+	    && $expression[strlen($expression) - 1] == '}') {
             $expression = substr($expression, 2, strlen($expression) - 3);
             $expression = $row->$expression;
             return (string) $rowValue === $expression;

--- a/library/Icinga/Data/Filter/FilterExpression.php
+++ b/library/Icinga/Data/Filter/FilterExpression.php
@@ -186,7 +186,6 @@ class FilterExpression extends Filter
            && $expression[strlen($expression) - 1] == '}') {
             $expression = substr($expression, 2, strlen($expression) - 3);
             $expression = $row->$expression;
-            return (string) $rowValue === $expression;
         }
 
         $expression = (string) $expression;

--- a/library/Icinga/Data/Filter/FilterExpression.php
+++ b/library/Icinga/Data/Filter/FilterExpression.php
@@ -182,7 +182,7 @@ class FilterExpression extends Filter
         }
 
         // referencing another column using php variable notation
-        if(strlen($expression) > 2 && $expression[0] == '$' && $expression[1] == '{' && $expression[strlen($expression) - 1] == '}') {
+        if (strlen($expression) > 2 && $expression[0] == '$' && $expression[1] == '{' && $expression[strlen($expression) - 1] == '}') {
             $expression = substr($expression, 2, strlen($expression) - 3);
             $expression = $row->$expression;
             return (string) $rowValue === $expression;

--- a/library/Icinga/Data/Filter/FilterExpression.php
+++ b/library/Icinga/Data/Filter/FilterExpression.php
@@ -181,6 +181,13 @@ class FilterExpression extends Filter
             return in_array($rowValue, $expression);
         }
 
+        // referencing another column using php variable notation
+        if(strlen($expression) > 2 && $expression[0] == '$' && $expression[1] == '{' && $expression[strlen($expression) - 1] == '}') {
+            $expression = substr($expression, 2, strlen($expression) - 3);
+            $expression = $row->$expression;
+            return (string) $rowValue === $expression;
+        }
+
         $expression = (string) $expression;
         if (strpos($expression, '*') === false) {
             if (is_array($rowValue)) {

--- a/library/Icinga/Data/Filter/FilterExpression.php
+++ b/library/Icinga/Data/Filter/FilterExpression.php
@@ -183,7 +183,7 @@ class FilterExpression extends Filter
 
         // referencing another column using php variable notation
         if (strlen($expression) > 2 && $expression[0] == '$' && $expression[1] == '{'
-	    && $expression[strlen($expression) - 1] == '}') {
+           && $expression[strlen($expression) - 1] == '}') {
             $expression = substr($expression, 2, strlen($expression) - 3);
             $expression = $row->$expression;
             return (string) $rowValue === $expression;


### PR DESCRIPTION
When used in icinga-director filter expressions, another column may be referenced using php variable notation. Can be used to dynamically evaluate content when used in sync rules.

Example use in the attached picture.
![example](https://user-images.githubusercontent.com/13869941/39914910-a94a7a92-5506-11e8-8d8d-5c6313ea25b6.png)
 