### PR TITLE
Bootstrap modules at last

### DIFF
--- a/library/Icinga/Application/Web.php
+++ b/library/Icinga/Application/Web.php
@@ -89,9 +89,6 @@ class Web extends EmbeddedWeb
             ->setupNotifications()
             ->setupResponse()
             ->setupZendMvc()
-            ->setupModuleManager()
-            ->loadSetupModuleIfNecessary()
-            ->loadEnabledModules()
             ->setupRoute()
             ->setupPagination()
             ->setupUserBackendFactory()
@@ -99,7 +96,10 @@ class Web extends EmbeddedWeb
             ->setupTimezone()
             ->setupLogger()
             ->setupInternationalization()
-            ->setupFatalErrorHandling();
+            ->setupFatalErrorHandling()
+            ->setupModuleManager()
+            ->loadSetupModuleIfNecessary()
+            ->loadEnabledModules();
     }
 
     /**


### PR DESCRIPTION
We initialize modules before we set up the user backend and other
singletons. But modules may access those in order to check the
permissions of the authenticated user for example. With this fix,
modules are loaded once all other bootstrap tasks have been completed.

fixes #3470