### PR TITLE
Let redirectHttp use HTTP for redirection

### DIFF
--- a/library/Icinga/Web/Controller/ActionController.php
+++ b/library/Icinga/Web/Controller/ActionController.php
@@ -424,6 +424,10 @@ class ActionController extends Zend_Controller_Action
 
     protected function redirectHttp($url)
     {
+        if ($this->isXhr()) {
+            $this->getResponse()->setHeader('X-Icinga-Redirect-Http', 'yes');
+        }
+
         $this->getResponse()->redirectAndExit($url);
     }
 

--- a/public/js/icinga/loader.js
+++ b/public/js/icinga/loader.js
@@ -343,6 +343,12 @@
                 }
             }
 
+            var useHttp = req.getResponseHeader('X-Icinga-Redirect-Http');
+            if (useHttp === 'yes') {
+                window.location.replace(redirect);
+                return true;
+            }
+
             this.redirectToUrl(
                 redirect, req.$target, req.url, req.getResponseHeader('X-Icinga-Rerender-Layout'), req.forceFocus,
                 req.getResponseHeader('X-Icinga-Refresh')


### PR DESCRIPTION
We've got three methods for redirection in our ActionController:

* `redirectNow`
* `redirectHttp`
* `redirectXhr`

Though, they behave in no way differently in which method to use for the actual redirection.

That's why I'm proposing to introduce a new header and transmitting it by default when using `redirectHttp`.

This way, utilizing this method actually causes our JS to issue a true HTTP redirect.

@lippserd Would be cool if we'd get this into 2.6, if it's reasonable to implement it this way.