### PR TITLE
FilterEditor: Add a hidden submit button to the start of the form's m…

### DIFF
--- a/library/Icinga/Web/Widget/FilterEditor.php
+++ b/library/Icinga/Web/Widget/FilterEditor.php
@@ -778,6 +778,7 @@ class FilterEditor extends AbstractWidget
             . '<form action="'
             . Url::fromRequest()
             . '" class="editor" method="POST">'
+            . '<input type="submit" name="submit" value="Apply" style="display:none;"/>'
             . '<ul class="tree"><li>'
             . $this->renderFilter($this->filter)
             . '</li></ul>'


### PR DESCRIPTION
…arkup

When pushing enter our JS mimics what a browser would do. And that is
pushing the first submit button found in the form. Without this, that's
a delete button of the first logical junction. (the root condition)

fixes #3454