### PR TITLE
loader.js: Make anchor navigation working again

### DIFF
--- a/public/js/icinga/loader.js
+++ b/public/js/icinga/loader.js
@@ -588,7 +588,7 @@
                 oldNotifications.appendTo($('#notifications'));
             }
             if (url.match(/#/)) {
-                this.icinga.ui.focusElement(url.split(/#/)[1], req.$target);
+                setTimeout(this.icinga.ui.focusElement, 0, url.split(/#/)[1], req.$target);
             }
             if (newBody) {
                 this.icinga.ui.fixDebugVisibility().triggerWindowResize();


### PR DESCRIPTION
Adds another call to the event loop regarding focus/scroll stuff. We have not enough competing calls of this type yet.

Eh, on a more serious note: I can't/won't provide a more sophisticated solution since fixing this properly in this crappy code results only in a headache and wasted time.

fixes #3492 

@lippserd I don't mind if you won't approve this. But please demand a proper fix from yourself or someone else then. (`public/js` -> :fire: )
