### PR TITLE
POC: external attribute based authorization

### DIFF
--- a/library/Icinga/Authentication/User/ExternalBackend.php
+++ b/library/Icinga/Authentication/User/ExternalBackend.php
@@ -116,6 +116,9 @@ class ExternalBackend implements UserBackendInterface
             }
 
             $user->setUsername($username);
+            if (array_key_exists('entitlement', $_SERVER)) {
+                $user->setGroups(explode(';', $_SERVER['entitlement']));
+            }
             return true;
         }
 


### PR DESCRIPTION
Hi,

This is a proof-of-concept patchlet I'm currently experimenting with in the hope of "fixing" #1594.
I don't know the internals of IcingaWeb2, so I've got no idea if this approach is sound, but it makes external entitlements available in `roles.ini` as group names, which is pretty much adequate for our purposes. Do IcingaWeb sessions expire eventually? That would be required for (delayed) revocation of group memberships in this simplistic approach. Comments welcome!

Thanks,
Feri.