### PR TITLE
Return non-zero on display usage

### DIFF
--- a/library/Icinga/Application/Cli.php
+++ b/library/Icinga/Application/Cli.php
@@ -151,7 +151,9 @@ class Cli extends ApplicationBootstrap
         if ($this->showBenchmark) {
             Benchmark::dump();
         }
-        if ($result === FALSE) exit(1);
+        if (false === $result) {
+            exit(1);
+        }
     }
 
     protected function dispatchEndless()

--- a/library/Icinga/Application/Cli.php
+++ b/library/Icinga/Application/Cli.php
@@ -151,8 +151,8 @@ class Cli extends ApplicationBootstrap
         if ($this->showBenchmark) {
             Benchmark::dump();
         }
-        if (false === $result) {
-            exit(1);
+        if ($result === false) {
+            exit(3);
         }
     }
 

--- a/library/Icinga/Application/Cli.php
+++ b/library/Icinga/Application/Cli.php
@@ -146,11 +146,12 @@ class Cli extends ApplicationBootstrap
     {
         $loader = $this->cliLoader();
         $loader->parseParams();
-        $loader->dispatch();
+        $result = $loader->dispatch();
         Benchmark::measure('All done');
         if ($this->showBenchmark) {
             Benchmark::dump();
         }
+        if ($result === FALSE) exit(1);
     }
 
     protected function dispatchEndless()

--- a/library/Icinga/Cli/Command.php
+++ b/library/Icinga/Cli/Command.php
@@ -197,6 +197,7 @@ abstract class Command
             $this->commandName,
             $action
         );
+        return false;
     }
 
     public function init()


### PR DESCRIPTION
`Icingacli` should return non-zeno status code when display usage messages
 for example with invalid commands

https://github.com/Icinga/icinga2/issues/6585

It is good for automation and helps mitigate typing errors