### PR TITLE
CSV timestamps can be exported human readable

### DIFF
--- a/application/forms/PreferenceForm.php
+++ b/application/forms/PreferenceForm.php
@@ -13,7 +13,6 @@ use Icinga\User\Preferences;
 use Icinga\User\Preferences\PreferencesStore;
 use Icinga\Util\TimezoneDetect;
 use Icinga\Util\Translator;
-use Icinga\Web\Cookie;
 use Icinga\Web\Form;
 use Icinga\Web\Notification;
 use Icinga\Web\Session;
@@ -250,6 +249,25 @@ class PreferenceForm extends Form
             )
         );
 
+
+        $csvExportTimeZones = [
+            'timestamp' => $this->translate('UNIX Timestamp'),
+            'local'     => $this->translate('Local Timezone'),
+            'server'    => $this->translate('Server Timezone')
+        ];
+
+        $this->addElement(
+            'select',
+            'csv_export_time_format',
+            array(
+                'required'      => true,
+                'label'         => $this->translate('CSV Export Time Format'),
+                'description'   => $this->translate('Use the following timezone in CSV exports'),
+                'multiOptions'  => $csvExportTimeZones,
+                'value'         => $csvExportTimeZones
+            )
+        );
+
         if (Auth::getInstance()->hasPermission('application/stacktraces')) {
             $this->addElement(
                 'checkbox',
@@ -372,6 +390,7 @@ class PreferenceForm extends Form
      * Return the default global setting for show_stacktraces
      *
      * @return  bool
+     * @throws  \Icinga\Exception\NotReadableError
      */
     protected function getDefaultShowStacktraces()
     {

--- a/library/Icinga/Cli/Command.php
+++ b/library/Icinga/Cli/Command.php
@@ -3,15 +3,16 @@
 
 namespace Icinga\Cli;
 
-use Icinga\Cli\Screen;
+use Icinga\Application\Cli;
 use Icinga\Util\Translator;
-use Icinga\Cli\Params;
 use Icinga\Application\Config;
-use Icinga\Application\ApplicationBootstrap as App;
 use Icinga\Exception\IcingaException;
 
 abstract class Command
 {
+    /**
+     * @var Cli
+     */
     protected $app;
     protected $docs;
 
@@ -45,7 +46,7 @@ abstract class Command
 
     protected $defaultActionName = 'default';
 
-    public function __construct(App $app, $moduleName, $commandName, $actionName, $initialize = true)
+    public function __construct(Cli $app, $moduleName, $commandName, $actionName, $initialize = true)
     {
         $this->app = $app;
         $this->moduleName  = $moduleName;

--- a/library/Icinga/Cli/Documentation.php
+++ b/library/Icinga/Cli/Documentation.php
@@ -3,7 +3,7 @@
 
 namespace Icinga\Cli;
 
-use Icinga\Application\ApplicationBootstrap as App;
+use Icinga\Application\Cli;
 use Icinga\Cli\Documentation\CommentParser;
 use ReflectionClass;
 use ReflectionMethod;
@@ -12,7 +12,7 @@ class Documentation
 {
     protected $icinga;
 
-    public function __construct(App $app)
+    public function __construct(Cli $app)
     {
         $this->app = $app;
         $this->loader = $app->cliLoader();

--- a/library/Icinga/Data/DataArray/ArrayDatasource.php
+++ b/library/Icinga/Data/DataArray/ArrayDatasource.php
@@ -41,6 +41,13 @@ class ArrayDatasource implements Selectable
     protected $keyColumn;
 
     /**
+     * stores data type designation for specific columns
+     *
+     * @var array
+     */
+    protected $columnDataTypes = [];
+
+    /**
      * Create a new data source for the given array
      *
      * @param   array   $data   The array you're going to use as a data source
@@ -181,6 +188,63 @@ class ArrayDatasource implements Selectable
         }
 
         return $this->count;
+    }
+
+    /**
+     * sets the type for a specific column
+     *
+     * @param string $column
+     * @param string $type
+     */
+    public function setDataTypeForColumn($column, $type)
+    {
+        $this->columnDataTypes[$column] = $type;
+    }
+
+    /**
+     * gets the type of a specific column if a type is set
+     *
+     * @param string $column
+     * @return string|null
+     */
+    public function getDataTypeForColumn($column)
+    {
+        $return = null;
+
+        if (isset($this->columnDataTypes[$column])) {
+            $return = $this->columnDataTypes[$column];
+        }
+
+        return $return;
+    }
+
+    /**
+     * get all columns set to the specific data type
+     *
+     * @param string $typeNeedle
+     * @return array
+     */
+    public function getColumnsForDataType($typeNeedle)
+    {
+        $return = [];
+
+        foreach ($this->columnDataTypes as $column => $type) {
+            if ($typeNeedle === $type) {
+                $return[] = $column;
+            }
+        }
+
+        return $return;
+    }
+
+    /**
+     * get all data type definitions
+     *
+     * @return array
+     */
+    public function getColumnDataTypes()
+    {
+        return $this->columnDataTypes;
     }
 
     /**

--- a/library/Icinga/Data/SimpleQuery.php
+++ b/library/Icinga/Data/SimpleQuery.php
@@ -679,4 +679,14 @@ class SimpleQuery implements QueryInterface, Queryable, Iterator
     {
         $this->filter = clone $this->filter;
     }
+
+    /**
+     * get all columns defined as timestamps
+     *
+     * @return array
+     */
+    public function getTimestampColumns()
+    {
+        return $this->ds->getColumnsForDataType('timestamp');
+    }
 }

--- a/library/Icinga/File/Csv.php
+++ b/library/Icinga/File/Csv.php
@@ -3,26 +3,47 @@
 
 namespace Icinga\File;
 
+use http\Exception\InvalidArgumentException;
+use Icinga\Module\Monitoring\Backend\Ido\Query\IdoQuery;
 use Traversable;
 
 class Csv
 {
+    /**
+     * @var IdoQuery
+     */
     protected $query;
+
+    /**
+     * @var \DateTimeZone
+     */
+    protected $timezone;
+
+
 
     protected function __construct()
     {
     }
 
-    public static function fromQuery(Traversable $query)
+    /**
+     * @param Traversable $query
+     * @param null $timezone - using null will output unix timestamps
+     * @return Csv
+     */
+    public static function fromQuery(Traversable $query, $timezone = null)
     {
         $csv = new static();
         $csv->query = $query;
+        $csv->setTimezone($timezone);
+
         return $csv;
     }
 
     public function dump()
     {
-        header('Content-type: text/csv');
+        if ("cli" !== php_sapi_name()) {
+            header('Content-type: text/csv');
+        }
         echo (string) $this;
     }
 
@@ -30,18 +51,44 @@ class Csv
     {
         $first = true;
         $csv = '';
+
+        //timestamp strings won't be modified if $timestampColumns is empty
+        $timestampColumns = (null === $this->timezone) ?
+            [] :
+            $this->query->getTimestampColumns()
+        ;
+
         foreach ($this->query as $row) {
             if ($first) {
-                $csv .= implode(',', array_keys((array) $row)) . "\r\n";
+                $csv .= implode(',', array_keys((array)$row)) . "\r\n";
                 $first = false;
             }
-            $out = array();
-            foreach ($row as & $val) {
+            $out = [];
+            foreach ($row as $columnName => $val) {
+                $val = in_array($columnName, $timestampColumns) ?
+                    \DateTime::createFromFormat('U', $val)->setTimezone($this->timezone)->format(\DateTime::ISO8601) :
+                    $val;
+
                 $out[] = '"' . $val . '"';
             }
             $csv .= implode(',', $out) . "\r\n";
         }
 
         return $csv;
+    }
+
+    /**
+     * @param string|null $timezoneString
+     * @throws \InvalidArgumentException
+     */
+    public function setTimezone($timezoneString = null)
+    {
+        if (null === $timezoneString) {
+            $this->timezone = null;
+        } elseif (is_string($timezoneString) && in_array($timezoneString, \DateTimeZone::listIdentifiers())) {
+            $this->timezone = new \DateTimeZone($timezoneString);
+        } else {
+            throw new InvalidArgumentException("$timezoneString is not a valid timezone identifier.");
+        }
     }
 }

--- a/modules/monitoring/application/clicommands/ListCommand.php
+++ b/modules/monitoring/application/clicommands/ListCommand.php
@@ -441,7 +441,6 @@ class ListCommand extends Command
             case true:
                 $timezone = date_default_timezone_get();
                 break;
-
         }
 
         return $timezone;

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/IdoQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/IdoQuery.php
@@ -1518,11 +1518,12 @@ abstract class IdoQuery extends DbQuery
         $timestampColumns = [];
         array_walk_recursive(
             $this->columnMap,
-            function ($val, $key) use (&$timestampColumns){
-            if (is_string($val) && substr($val, 0, 14) == 'UNIX_TIMESTAMP') {
-                $timestampColumns[] = $key;
+            function ($val, $key) use (&$timestampColumns) {
+                if (is_string($val) && substr($val, 0, 14) == 'UNIX_TIMESTAMP') {
+                    $timestampColumns[] = $key;
+                }
             }
-        });
+        );
 
         return $timestampColumns;
     }

--- a/test/php/library/Icinga/File/CsvTest.php
+++ b/test/php/library/Icinga/File/CsvTest.php
@@ -31,4 +31,26 @@ class CsvTest extends BaseTestCase
             'Csv does not render valid/correct csv structured data'
         );
     }
+
+    public function testTimestampToDateString()
+    {
+        $firstOfSeptember2018timestamp = 1535760000;
+
+        $data = new ArrayDatasource([
+            [
+                'firstOfSeptember' => $firstOfSeptember2018timestamp,
+                'notimportant' => 'somestring'
+            ]
+        ]);
+
+        $data->setDataTypeForColumn('firstOfSeptember', 'timestamp');
+
+        $csv = Csv::fromQuery($data->select(), 'Europe/Berlin');
+
+        $this->assertEquals(
+            "firstOfSeptember,notimportant\r\n\"2018-09-01T02:00:00+0200\",\"somestring\"\r\n",
+            (string) $csv,
+            "Csv does not convert timestamps properly to ISO 8601"
+        );
+    }
 }


### PR DESCRIPTION
Timestamps in CSVs both from the WebUI and CLI can be exported as ISO8601 strings. The timezone can be configured under "My Account" or with the --timezone parameter.

Also minor annotation fixes.