### PR TITLE
Fix uninitialized array and module in Cli\Command

### DIFF
--- a/library/Icinga/Cli/Command.php
+++ b/library/Icinga/Cli/Command.php
@@ -48,14 +48,15 @@ abstract class Command
     public function __construct(App $app, $moduleName, $commandName, $actionName, $initialize = true)
     {
         $this->app = $app;
-        $this->moduleName  = $moduleName;
-        $this->commandName = $commandName;
-        $this->actionName  = $actionName;
-        $this->params     = $app->getParams();
-        $this->screen     = Screen::instance($app);
-        $this->trace      = $this->params->shift('trace', false);
-        $this->isVerbose  = $this->params->shift('verbose', false);
-        $this->isDebugging = $this->params->shift('debug', false);
+        $this->moduleName   = $moduleName;
+        $this->commandName  = $commandName;
+        $this->actionName   = $actionName;
+        $this->params       = $app->getParams();
+        $this->screen       = Screen::instance($app);
+        $this->trace        = $this->params->shift('trace', false);
+        $this->isVerbose    = $this->params->shift('verbose', false);
+        $this->isDebugging  = $this->params->shift('debug', false);
+        $this->configs      = [];
         if ($initialize) {
             $this->init();
         }
@@ -94,7 +95,7 @@ abstract class Command
             return $this->config;
         } else {
             if (! array_key_exists($file, $this->configs)) {
-                $this->configs[$file] = Config::module($module, $file);
+                $this->configs[$file] = Config::module($this->moduleName, $file);
             }
             return $this->configs[$file];
         }

--- a/library/Icinga/Cli/Command.php
+++ b/library/Icinga/Cli/Command.php
@@ -95,7 +95,7 @@ abstract class Command
             return $this->config;
         } else {
             if (! array_key_exists($file, $this->configs)) {
-                $this->configs[$file] = Config::module($this->moduleName, $file);
+                $this->configs[$file] = Config::app($file);
             }
             return $this->configs[$file];
         }


### PR DESCRIPTION
Can not do this in cli context:

    $this->Config('redis')

ERROR: ErrorException in /vagrant/icingaweb2/library/Icinga/Cli/Command.php:81 with message: array_key_exists() expects parameter 2 to be array, null given