### PR TITLE
auth/external: Use a stripped down layout for the logout workaround

### DIFF
--- a/application/controllers/AuthenticationController.php
+++ b/application/controllers/AuthenticationController.php
@@ -74,6 +74,7 @@ class AuthenticationController extends Controller
         AuthenticationHook::triggerLogout($auth->getUser());
         $auth->removeAuthorization();
         if ($isExternalUser) {
+            $this->view->layout()->setLayout('external-logout');
             $this->getResponse()->setHttpResponseCode(401);
         } else {
             $this->redirectToLogin();

--- a/application/layouts/scripts/external-logout.phtml
+++ b/application/layouts/scripts/external-logout.phtml
@@ -1,0 +1,33 @@
+<?php
+
+use Icinga\Util\Translator;
+
+$lang = Translator::splitLocaleCode()->language;
+$showFullscreen = $this->layout()->showFullscreen;
+$innerLayoutScript = $this->layout()->innerLayout . '.phtml';
+
+?><!DOCTYPE html>
+<!--[if IE 8]>
+<html class="no-js ie8" lang="<?= $lang ?>"> <![endif]-->
+<!--[if gt IE 8]><!-->
+<html class="no-js" lang="<?= $lang ?>"> <!--<![endif]-->
+<head>
+    <meta charset="utf-8">
+    <meta name="google" value="notranslate">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta http-equiv="cleartype" content="on">
+    <title><?= $this->title ? $this->escape($this->title) : $this->defaultTitle ?></title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="application-name" content="Icinga Web 2">
+    <meta name="apple-mobile-web-app-title" content="Icinga">
+    <link rel="mask-icon" href="<?= $this->baseUrl('img/website-icon.svg') ?>" color="#0096BF">
+    <link type="image/png" rel="shortcut icon" href="<?= $this->baseUrl('img/favicon.png') ?>" />
+    <link rel="apple-touch-icon" href="<?= $this->baseUrl('img/touch-icon.png') ?>">
+</head>
+<body id="body">
+<div id="layout" class="default-layout<?php if ($showFullscreen): ?> fullscreen-layout<?php endif ?>">
+    <?= $this->render($innerLayoutScript); ?>
+</div>
+</body>
+</html>

--- a/application/views/scripts/authentication/logout.phtml
+++ b/application/views/scripts/authentication/logout.phtml
@@ -8,6 +8,7 @@
     logged-in user this JavaScript provides a workaround to force a new authentication prompt in most browsers.
 -->
 <div class="content">
+    <div id="icinga-logo" aria-hidden="true"></div>
     <div class="alert alert-warning" id="logout-status">
         <b><?= $this->translate('Logging out...'); ?></b>
         <br>
@@ -19,7 +20,7 @@
     </div>
 
     <div class="container">
-        <a href="<?= $this->href('dashboard/index?renderLayout'); ?>"><?= $this->translate('Login'); ?></a>
+        <a href="<?= $this->href('dashboard'); ?>"><?= $this->translate('Login'); ?></a>
     </div>
 </div>
 <script type="text/javascript">
@@ -45,3 +46,34 @@
         msg.className = 'alert alert-success';
     });
 </script>
+<style type="text/css">
+    body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        background-color: #0095bf;
+        color: white;
+    }
+    .content {
+        text-align: center;
+    }
+
+    #icinga-logo {
+        background-image: url('../img/icinga-logo-big.svg');
+        background-position: center bottom;
+        background-repeat: no-repeat;
+        background-size: contain;
+        height: 177px;
+        margin-top: 10em;
+        width: 100%;
+    }
+
+    #logout-status {
+        margin: 2em 0 1em;
+        font-size: 2em;
+        font-weight: bold;
+    }
+
+    .container a {
+        color: white;
+        font-size: 1.5em;
+    }
+</style>


### PR DESCRIPTION
We've used the standard layout before which caused a automatic login.
Automatic because the browser saw our js/css <link> tags and accessed
the routes which in turn logged in the user, but only if there's a
enabled module which's configuration.php (or run.php) accesses the
Auth singleton. The stripped down layout provides its own js/css so
there's no need for our full-blown resources.

fixes #3583