### PR TITLE
Use continue <N> in case statements to fix ErrorException with PHP 7.3.

### DIFF
--- a/library/Icinga/Application/Modules/Module.php
+++ b/library/Icinga/Application/Modules/Module.php
@@ -686,7 +686,7 @@ class Module
                         case 'depends':
                             if (strpos($val, ' ') === false) {
                                 $metadata->depends[$val] = true;
-                                continue;
+                                continue 2;
                             }
 
                             $parts = preg_split('/,\s+/', $val);

--- a/library/Icinga/File/Ini/IniParser.php
+++ b/library/Icinga/File/Ini/IniParser.php
@@ -64,7 +64,7 @@ class IniParser
             switch ($state) {
                 case self::LINE_START:
                     if (ctype_space($s)) {
-                        continue;
+                        continue 2;
                     }
                     switch ($s) {
                         case '[':
@@ -130,7 +130,7 @@ class IniParser
 
                 case self::DIRECTIVE_VALUE_START:
                     if (ctype_space($s)) {
-                        continue;
+                        continue 2;
                     } elseif ($s === '"') {
                         $state = self::DIRECTIVE_VALUE_QUOTED;
                     } else {


### PR DESCRIPTION
As reported by Max in [Debian Bug #914457 - icingacli: any command issued to icingacli rise an exception](https://bugs.debian.org/914457):
> an example:
> ```
> icingacli --help
>
> Fatal error: Uncaught ErrorException: "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in /usr/share/php/Icinga/File/Ini/IniParser.php:67
> Stack trace:
> #0 /usr/share/php/Icinga/Application/ClassLoader.php(303): Icinga\Application\ApplicationBootstrap->Icinga\Application\{closure}(2, '"continue" targ...', '/usr/share/php/...', 67, Array)
> #1 /usr/share/php/Icinga/Application/ClassLoader.php(303): require()
> #2 [internal function]: Icinga\Application\ClassLoader->loadClass('Icinga\\File\\Ini...')
> #3 /usr/share/php/Icinga/Application/Config.php(326): spl_autoload_call('Icinga\\File\\Ini...')
> #4 /usr/share/php/Icinga/Application/Config.php(397): Icinga\Application\Config::fromIni('/etc/icingaweb2...')
> #5 /usr/share/php/Icinga/Application/ApplicationBootstrap.php(522): Icinga\Application\Config::app()
> #6 /usr/share/php/Icinga/Application/Cli.php(39): Icinga\Application\ApplicationBootstrap->loadConfig()
> #7 /usr/share/php/Icinga/Application/ApplicationBootstrap.php(369): Icinga\Application\Cl in /usr/share/php/Icinga/File/Ini/IniParser.php on line 67
> ```

This is caused by changes in PHP 7.3 (see: [PHP Bug #76753 | 'Warning: "continue" targeting switch' uncatchable](https://bugs.php.net/bug.php?id=76753)).

I've replaced `continue` with `continue <N>` in `case` statements to continue the enclosing loop as was most likely the intention. If this is not the case, `break` should be used instead.

Note that a few occurrences of this issue are also present in the `vendor` directory, which I haven't touched.