### PR TITLE
DbConnection: Make host optional for Oracle connections

### DIFF
--- a/application/forms/Config/Resource/DbResourceForm.php
+++ b/application/forms/Config/Resource/DbResourceForm.php
@@ -58,6 +58,12 @@ class DbResourceForm extends Form
             $offerMysql = true;
         }
 
+        if ($dbChoice === 'oracle') {
+            $hostIsRequired = false;
+        } else {
+            $hostIsRequired = true;
+        }
+
         $socketInfo = '';
         if ($offerPostgres) {
             $socketInfo = $this->translate(
@@ -104,7 +110,7 @@ class DbResourceForm extends Form
                 'text',
                 'host',
                 array (
-                    'required'      => true,
+                    'required'      => $hostIsRequired,
                     'label'         => $this->translate('Host'),
                     'description'   => $this->translate('The hostname of the database')
                         . ($socketInfo ? '. ' . $socketInfo : ''),

--- a/library/Icinga/Data/Db/DbConnection.php
+++ b/library/Icinga/Data/Db/DbConnection.php
@@ -215,6 +215,11 @@ class DbConnection implements Selectable, Extensible, Updatable, Reducible, Insp
             case 'oracle':
                 $adapter = 'Pdo_Oci';
                 $defaultPort = 1521;
+
+                // remove host parameter when not configured
+                if (empty($this->config->host)) {
+                    unset($adapterParamaters['host']);
+                }
                 break;
             case 'pgsql':
                 $adapter = 'Pdo_Pgsql';
@@ -555,7 +560,7 @@ class DbConnection implements Selectable, Extensible, Updatable, Reducible, Insp
                 'Connection to %s as %s on %s:%s successful',
                 $config['dbname'],
                 $config['username'],
-                $config['host'],
+                array_key_exists('host', $config) ? $config['host'] : '(none)',
                 $config['port']
             ));
             switch ($this->dbType) {


### PR DESCRIPTION
When only a database name is specified, Oracle can use alternative methods to find the database.

ref/NC/588829