### PR TITLE
DbResourceForm: Remove default value for host when not required

### DIFF
--- a/application/forms/Config/Resource/DbResourceForm.php
+++ b/application/forms/Config/Resource/DbResourceForm.php
@@ -114,7 +114,7 @@ class DbResourceForm extends Form
                     'label'         => $this->translate('Host'),
                     'description'   => $this->translate('The hostname of the database')
                         . ($socketInfo ? '. ' . $socketInfo : ''),
-                    'value'         => 'localhost'
+                    'value'         => $hostIsRequired ? 'localhost' : ''
                 )
             );
             $this->addElement(


### PR DESCRIPTION
Mainly used for Oracle

refs #3643

ref/NC/589845