### PR TITLE
Set background color on Fullscreen Layout ul.tabs

### DIFF
--- a/public/css/icinga/layout-structure.less
+++ b/public/css/icinga/layout-structure.less
@@ -101,6 +101,7 @@ html {
     height: 1.5em;
     font-size: 0.75em;
     padding: 0.2em 0 0;
+    background-color: @icinga-blue;
   }
 
   .controls > ul.tabs > li > a {


### PR DESCRIPTION
Fix for ul.tabs links not being visible in showFullscreen mode (white links on white background)