### PR TITLE
Setup: Allow to enable FPM

### DIFF
--- a/modules/setup/application/clicommands/ConfigCommand.php
+++ b/modules/setup/application/clicommands/ConfigCommand.php
@@ -121,7 +121,6 @@ class ConfigCommand extends Command
      *
      *  icingacli setup config webserver nginx \
      *    --root=/usr/share/icingaweb2/public \
-     *    --enable-fpm
      *    --fpm-uri=unix:/var/run/php5-fpm.sock
      */
     public function webserverAction()

--- a/modules/setup/application/clicommands/ConfigCommand.php
+++ b/modules/setup/application/clicommands/ConfigCommand.php
@@ -99,6 +99,8 @@ class ConfigCommand extends Command
      *  --root|--document-root=<directory>  The directory from which the webserver will serve files
      *                                      [/path/to/icingaweb2/public]
      *
+     *  --enable-fpm                        Enable FPM handler for Apache (Nginx is always enabled)
+     *
      *  --fpm-uri=<uri>                     Address or path where to pass requests to FPM [127.0.0.1:9000]
      *
      *  --config=<directory>                Path to Icinga Web 2's configuration files [/etc/icingaweb2]
@@ -119,6 +121,7 @@ class ConfigCommand extends Command
      *
      *  icingacli setup config webserver nginx \
      *    --root=/usr/share/icingaweb2/public \
+     *    --enable-fpm
      *    --fpm-uri=unix:/var/run/php5-fpm.sock
      */
     public function webserverAction()
@@ -149,6 +152,9 @@ class ConfigCommand extends Command
                 'The argument --config expects a path to Icinga Web 2\'s configuration files'
             ));
         }
+
+        $enableFpm = $this->params->shift('enable-fpm', $webserver->getEnableFpm());
+
         $fpmUri = trim($this->params->get('fpm-uri', $webserver->getFpmUri()));
         if (empty($fpmUri)) {
             $this->fail($this->translate(
@@ -159,6 +165,7 @@ class ConfigCommand extends Command
             ->setDocumentRoot($documentRoot)
             ->setConfigDir($configDir)
             ->setUrlPath($urlPath)
+            ->setEnableFpm($enableFpm)
             ->setFpmUri($fpmUri);
         $config = $webserver->generate() . "\n";
         if (($file = $this->params->get('file')) !== null) {

--- a/modules/setup/library/Setup/Webserver.php
+++ b/modules/setup/library/Setup/Webserver.php
@@ -40,6 +40,13 @@ abstract class Webserver
     protected $fpmUri;
 
     /**
+     * Enable to pass requests to FPM
+     *
+     * @var bool
+     */
+    protected $enableFpm = false;
+
+    /**
      * Create instance by type name
      *
      * @param   string $type

--- a/modules/setup/library/Setup/Webserver.php
+++ b/modules/setup/library/Setup/Webserver.php
@@ -175,6 +175,30 @@ abstract class Webserver
     }
 
     /**
+     * Get whether FPM is enabled
+     *
+     * @return  bool
+     */
+    public function getEnableFpm()
+    {
+        return $this->enableFpm;
+    }
+
+    /**
+     * Set FPM enabled
+     *
+     * @param   bool  $flag
+     *
+     * @return  $this
+     */
+    public function setEnableFpm($flag)
+    {
+        $this->enableFpm = (bool) $flag;
+
+        return $this;
+    }
+
+    /**
      * Get the address or path where to pass requests to FPM
      *
      * @return  string

--- a/modules/setup/library/Setup/Webserver/Apache.php
+++ b/modules/setup/library/Setup/Webserver/Apache.php
@@ -10,8 +10,7 @@ use Icinga\Module\Setup\Webserver;
  */
 class Apache extends Webserver
 {
-    protected $fpmUri = 'fcgi://127.0.0.1:9000';
-    protected $enableFpm = false;
+    protected $fpmUri = '127.0.0.1:9000';
 
     protected function getTemplate()
     {
@@ -72,7 +71,7 @@ Alias {urlPath} "{documentRoot}"
 #        # Forward PHP requests to FPM
 #        SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
 #        <FilesMatch "\.php$">
-#            SetHandler "proxy:{fpmUri}"
+#            SetHandler "proxy:fcgi://{fpmUri}"
 #            ErrorDocument 503 {urlPath}/error_unavailable.html
 #        </FilesMatch>
 #    </IfVersion>
@@ -132,7 +131,7 @@ Alias {urlPath} "{documentRoot}"
         # Forward PHP requests to FPM
         SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
         <FilesMatch "\.php$">
-            SetHandler "proxy:{fpmUri}"
+            SetHandler "proxy:fcgi://{fpmUri}"
             ErrorDocument 503 {urlPath}/error_unavailable.html
         </FilesMatch>
     </IfVersion>

--- a/modules/setup/library/Setup/Webserver/Nginx.php
+++ b/modules/setup/library/Setup/Webserver/Nginx.php
@@ -12,6 +12,8 @@ class Nginx extends Webserver
 {
     protected $fpmUri = '127.0.0.1:9000';
 
+    protected $enableFpm = true;
+
     protected function getTemplate()
     {
         return <<<'EOD'


### PR DESCRIPTION
# Current behaviour

The FPM block is commented out every time, even when called with the option `--fpm-uri` introduced in 2a959af9c2054a014f0ea6e059df70e495f3d4a8

```
$ ./bin/icingacli setup config webserver apache --document-root /usr/local/icinga/icingaweb2/public --config /usr/local/icinga/icingaweb2/etc --fpm-uri 127.0.0.1:9000
Alias /icingaweb2 "/usr/local/icinga/icingaweb2/public"

# Remove comments if you want to use PHP FPM and your Apache version is older than 2.4
#<IfVersion < 2.4>
#    # Forward PHP requests to FPM
#    SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
#    <LocationMatch "^/icingaweb2/(.*\.php)$">
#        ProxyPassMatch "fcgi://127.0.0.1:9000//usr/local/icinga/icingaweb2/public/$1"
#    </LocationMatch>
#</IfVersion>

<Directory "/usr/local/icinga/icingaweb2/public">
    Options SymLinksIfOwnerMatch
    AllowOverride None

    DirectoryIndex index.php

    <IfModule mod_authz_core.c>
        # Apache 2.4
        <RequireAll>
            Require all granted
        </RequireAll>
    </IfModule>

    <IfModule !mod_authz_core.c>
        # Apache 2.2
        Order allow,deny
        Allow from all
    </IfModule>

    SetEnv ICINGAWEB_CONFIGDIR "/usr/local/icinga/icingaweb2/etc"

    EnableSendfile Off

    <IfModule mod_rewrite.c>
        RewriteEngine on
        RewriteBase /icingaweb2/
        RewriteCond %{REQUEST_FILENAME} -s [OR]
        RewriteCond %{REQUEST_FILENAME} -l [OR]
        RewriteCond %{REQUEST_FILENAME} -d
        RewriteRule ^.*$ - [NC,L]
        RewriteRule ^.*$ index.php [NC,L]
    </IfModule>

    <IfModule !mod_rewrite.c>
        DirectoryIndex error_norewrite.html
        ErrorDocument 404 /icingaweb2/error_norewrite.html
    </IfModule>

# Remove comments if you want to use PHP FPM and your Apache version
# is greater than or equal to 2.4
#    <IfVersion >= 2.4>
#        # Forward PHP requests to FPM
#        SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
#        <FilesMatch "\.php$">
#            SetHandler "proxy:127.0.0.1:9000"
#            ErrorDocument 503 /icingaweb2/error_unavailable.html
#        </FilesMatch>
#    </IfVersion>
</Directory>
```

# Fixed behaviour

The control block for FPM already contains detection for Apache versions, so both can be enabled at once. When the option `--fpm-uri` is used, the setup wizard now prints the FPM statements uncommented. 

I had to change the CLI parameter handling a bit, since it would always use the object's default value now being an empty string (which is essentially a fail then for the parameter which wasn't provided by the user, brainfuck).

```
$ ./bin/icingacli setup config webserver apache --document-root /usr/local/icinga/icingaweb2/public --config /usr/local/icinga/icingaweb2/etc --fpm-uri 127.0.0.1:9000
Alias /icingaweb2 "/usr/local/icinga/icingaweb2/public"
<IfVersion < 2.4>
    # Forward PHP requests to FPM
    SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
    <LocationMatch "^/icingaweb2/(.*\.php)$">
        ProxyPassMatch "fcgi://127.0.0.1:9000//usr/local/icinga/icingaweb2/public/$1"
    </LocationMatch>
</IfVersion>
<Directory "/usr/local/icinga/icingaweb2/public">
    Options SymLinksIfOwnerMatch
    AllowOverride None

    DirectoryIndex index.php

    <IfModule mod_authz_core.c>
        # Apache 2.4
        <RequireAll>
            Require all granted
        </RequireAll>
    </IfModule>

    <IfModule !mod_authz_core.c>
        # Apache 2.2
        Order allow,deny
        Allow from all
    </IfModule>

    SetEnv ICINGAWEB_CONFIGDIR "/usr/local/icinga/icingaweb2/etc"

    EnableSendfile Off

    <IfModule mod_rewrite.c>
        RewriteEngine on
        RewriteBase /icingaweb2/
        RewriteCond %{REQUEST_FILENAME} -s [OR]
        RewriteCond %{REQUEST_FILENAME} -l [OR]
        RewriteCond %{REQUEST_FILENAME} -d
        RewriteRule ^.*$ - [NC,L]
        RewriteRule ^.*$ index.php [NC,L]
    </IfModule>

    <IfModule !mod_rewrite.c>
Setup: Enable FPM statements when --fpm-uri is passed
        DirectoryIndex error_norewrite.html
        ErrorDocument 404 /icingaweb2/error_norewrite.html
    </IfModule>
    <IfVersion >= 2.4>
        # Forward PHP requests to FPM
        SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
        <FilesMatch "\.php$">
            SetHandler "proxy:127.0.0.1:9000"
            ErrorDocument 503 /icingaweb2/error_unavailable.html
        </FilesMatch>
    </IfVersion>
</Directory>
```

```
$ ./bin/icingacli setup config webserver apache --document-root /usr/local/icinga/icingaweb2/public --config /usr/local/icinga/icingaweb2/etc
Alias /icingaweb2 "/usr/local/icinga/icingaweb2/public"

<Directory "/usr/local/icinga/icingaweb2/public">
    Options SymLinksIfOwnerMatch
    AllowOverride None

    DirectoryIndex index.php

    <IfModule mod_authz_core.c>
        # Apache 2.4
        <RequireAll>
Setup: Enable FPM statements when --fpm-uri is passed
            Require all granted
        </RequireAll>
    </IfModule>

    <IfModule !mod_authz_core.c>
        # Apache 2.2
        Order allow,deny
        Allow from all
    </IfModule>

    SetEnv ICINGAWEB_CONFIGDIR "/usr/local/icinga/icingaweb2/etc"

    EnableSendfile Off

    <IfModule mod_rewrite.c>
        RewriteEngine on
        RewriteBase /icingaweb2/
        RewriteCond %{REQUEST_FILENAME} -s [OR]
        RewriteCond %{REQUEST_FILENAME} -l [OR]
        RewriteCond %{REQUEST_FILENAME} -d
        RewriteRule ^.*$ - [NC,L]
        RewriteRule ^.*$ index.php [NC,L]
    </IfModule>

    <IfModule !mod_rewrite.c>
        DirectoryIndex error_norewrite.html
        ErrorDocument 404 /icingaweb2/error_norewrite.html
    </IfModule>

</Directory>
```