### PR TITLE
enable modules with a relative path instead of absolute path

### DIFF
--- a/library/Icinga/Application/Modules/Manager.php
+++ b/library/Icinga/Application/Modules/Manager.php
@@ -285,7 +285,28 @@ class Manager
             return $this;
         }
 
-        if (! @symlink($target, $link)) {
+        $relTarget = explode("/", $target);
+        $relLink = explode("/", $link);
+        while (end($relTarget) === "") {
+            array_pop($relTarget);
+        }
+        while (end($relLink) === "") {
+            array_pop($relLink);
+        }
+        while (reset($relTarget) === reset($relLink)) {
+            array_shift($relTarget);
+            array_shift($relLink);
+        }
+        array_pop($relLink);
+        if (empty($relLink)) {
+            array_unshift($relTarget, ".");
+        } else {
+            while (array_shift($relLink)) {
+                array_unshift($relTarget, "..");
+            }
+        }
+        $relTarget = implode("/", $relTarget);
+        if (! @symlink($relTarget, $link)) {
             $error = error_get_last();
             if (strstr($error["message"], "File exists") === false) {
                 throw new SystemPermissionException(


### PR DESCRIPTION
OpenBSD and potentially other hosting platforms run php-fpm inside a chroot. This causes an issue when enabling a module in either the web interface or icingacli for its counterpart.
For example, under OpenBSD php-fpm is chrooted under /var/www, which causes icingacli to have it's configDir set to /var/www/etc/icingaweb2 and the web application /etc/icingaweb2. This results for a module enabled via the web interface to:
# ls -l /var/www/etc/icingaweb2/enabledModules/director
lrwxr-xr-x  1 _icingaweb2  _icingaweb2  37 Jan 22 14:52 /var/www/etc/icingaweb2/enabledModules/director -> /icinga-web2/modules/director
which clearly doesn't work for icingacli:
# icingacli
Found invalid module in enabledModule directory "/var/www/etc/icingaweb2/enabledModules": "/var/www/etc/icingaweb2/enabledModules/director" points to non existing path "false"

I just committed this diff to OpenBSD[0], so that absolute paths are turned into relative paths, which makes such a setup work:
# ls -l /var/www/etc/icingaweb2/enabledModules/director                                                                                                                                                                                                                                                             
lrwxr-xr-x  1 root  _icingaweb2  37 Jan 23 07:42 /var/www/etc/icingaweb2/enabledModules/director -> ../../../icinga-web2/modules/director

I read that Windows symlinks don't support relative paths[1], but I don't have any environment where I can test this, so an extra check might be desirable. I'm also not certain whether or not the current location is most suitable for this kind of code, or if it should have its own function somewhere else.

Could something like this be considered for inclusion?

[0] https://marc.info/?l=openbsd-ports-cvs&m=154822323602513&w=2
[1] https://secure.php.net/manual/en/function.symlink.php