### PR TITLE
host downtimes: set the all_services flag default to true

### DIFF
--- a/modules/monitoring/application/forms/Command/Object/ScheduleHostDowntimeCommandForm.php
+++ b/modules/monitoring/application/forms/Command/Object/ScheduleHostDowntimeCommandForm.php
@@ -33,7 +33,7 @@ class ScheduleHostDowntimeCommandForm extends ScheduleServiceDowntimeCommandForm
                     'Schedule downtime for all services on the hosts and the hosts themselves.'
                 ),
                 'label'         => $this->translate('All Services'),
-                'value'         => (bool) $config->get('settings', 'hostdowntime_all_services', false)
+                'value'         => (bool) $config->get('settings', 'hostdowntime_all_services', true)
             )
         );
 


### PR DESCRIPTION
I realized, that in our company nobody wants to set a downtime only for a host. We set only downtime for hosts with all services.

So I think other company's and Icingaweb2 users have the same problem. We have a lot of admins which forget to set this flag and then the monitoring notifies falsely.

Since we have changed this flag locally, we save a lot of time. I think it would be helpful for other users too, so I thought it would be nice to share this with others.