### PR TITLE
Don't escape html entities in plugin output twice

### DIFF
--- a/modules/monitoring/application/views/helpers/PluginOutput.php
+++ b/modules/monitoring/application/views/helpers/PluginOutput.php
@@ -2,6 +2,7 @@
 /* Icinga Web 2 | (c) 2013 Icinga Development Team | GPLv2+ */
 
 use Icinga\Web\Dom\DomNodeIterator;
+use Icinga\Web\View;
 use Icinga\Module\Monitoring\Web\Helper\PluginOutputPurifier;
 
 /**
@@ -115,7 +116,8 @@ class Zend_View_Helper_PluginOutput extends Zend_View_Helper_Abstract
             $output = preg_replace(
                 self::$txtPatterns,
                 self::$txtReplacements,
-                $this->view->escape($output)
+                // Not using the view here to escape this. The view sets `double_encode` to true
+                htmlspecialchars($output, ENT_COMPAT | ENT_SUBSTITUTE | ENT_HTML5, View::CHARSET, false)
             );
             $isHtml = false;
         }

--- a/modules/monitoring/test/php/application/views/helpers/PluginOutputTest.php
+++ b/modules/monitoring/test/php/application/views/helpers/PluginOutputTest.php
@@ -65,6 +65,14 @@ class PluginOutputTest extends BaseTestCase
         );
     }
 
+    public function testOutputWithHtmlEntities()
+    {
+        $this->checkOutput(
+            'foo&nbsp;&amp;&nbsp;bar',
+            'foo&nbsp;&amp;&nbsp;bar'
+        );
+    }
+
     public function testSimpleHtmlOutput()
     {
         /** @noinspection HtmlUnknownAttribute */


### PR DESCRIPTION
fixes #3707