### PR TITLE
Fix tactical overview legend badges not properly affected by themes

### DIFF
--- a/modules/monitoring/application/views/scripts/tactical/index.phtml
+++ b/modules/monitoring/application/views/scripts/tactical/index.phtml
@@ -25,7 +25,7 @@
                 <?php endif;
                 if ($statusSummary->hosts_down_handled):?>
                 <tr href="<?= $this->filteredUrl('monitoring/list/hosts', array('host_state' => 1, 'host_handled' => 1, 'sort' => 'host_last_check', 'dir' => 'asc')) ?>">
-                    <th class="state slice-state-critical-handled badge"><?= $statusSummary->hosts_down_handled ?></th>
+                    <th class="state state-critical handled badge"><?= $statusSummary->hosts_down_handled ?></th>
                     <td><?= $this->translate('Down') ?> (<?= $this->translate('Handled') ?>)</td>
                 </tr>
                 <?php endif;
@@ -37,7 +37,7 @@
                 <?php endif;
                 if ($statusSummary->hosts_unreachable_handled):?>
                 <tr href="<?= $this->filteredUrl('monitoring/list/hosts', array('host_state' => 2, 'host_handled' => 1, 'sort' => 'host_last_check', 'dir' => 'asc')) ?>">
-                    <th class="state slice-state-unreachable-handled badge"><?= $statusSummary->hosts_unreachable_handled ?></th>
+                    <th class="state state-unreachable handled badge"><?= $statusSummary->hosts_unreachable_handled ?></th>
                     <td><?= $this->translate('Unreachable') ?> (<?= $this->translate('Handled') ?>)</td>
                 </tr>
                 <?php endif;
@@ -77,7 +77,7 @@
             <?php endif;
             if ($statusSummary->services_warning_handled):?>
                 <tr href="<?= $this->filteredUrl('monitoring/list/services', array('service_state' => 1, 'service_handled' => 1, 'sort' => 'service_last_check', 'dir' => 'asc')) ?>">
-                    <th class="state slice-state-warning-handled badge"><?= $statusSummary->services_warning_handled ?></th>
+                    <th class="state state-warning handled badge"><?= $statusSummary->services_warning_handled ?></th>
                     <td><?= $this->translate('Warning') ?> (<?= $this->translate('Handled') ?>)</td>
                 </tr>
             <?php endif;
@@ -89,7 +89,7 @@
             <?php endif;
             if ($statusSummary->services_critical_handled):?>
                 <tr href="<?= $this->filteredUrl('monitoring/list/services', array('service_state' => 2, 'service_handled' => 1, 'sort' => 'service_last_check', 'dir' => 'asc')) ?>">
-                    <th class="state slice-state-critical-handled badge"><?= $statusSummary->services_critical_handled ?></th>
+                    <th class="state state-critical handled badge"><?= $statusSummary->services_critical_handled ?></th>
                     <td><?= $this->translate('Critical') ?> (<?= $this->translate('Handled') ?>)</td>
                 </tr>
             <?php endif;
@@ -101,19 +101,19 @@
             <?php endif;
             if ($statusSummary->services_unknown_handled):?>
                 <tr href="<?= $this->filteredUrl('monitoring/list/services', array('service_state' => 3, 'service_handled' => 1, 'sort' => 'service_last_check', 'dir' => 'asc')) ?>">
-                    <th class="state slice-state-unknown-handled badge"><?= $statusSummary->services_unknown_handled ?></th>
+                    <th class="state state-unknown handled badge"><?= $statusSummary->services_unknown_handled ?></th>
                     <td><?= $this->translate('Unknown') ?> (<?= $this->translate('Handled') ?>)</td>
                 </tr>
             <?php endif;
             if ($statusSummary->services_unknown_unhandled):?>
                 <tr href="<?= $this->filteredUrl('monitoring/list/services', array('service_state' => 3, 'service_handled' => 0, 'sort' => 'service_last_check', 'dir' => 'asc')) ?>">
-                    <th class="state slice-state-unknown badge"><?= $statusSummary->services_unknown_unhandled ?></th>
+                    <th class="state state-unknown badge"><?= $statusSummary->services_unknown_unhandled ?></th>
                     <td><?= $this->translate('Unknown') ?></td>
                 </tr>
             <?php endif;
             if ($statusSummary->services_pending):?>
                 <tr href="<?= $this->filteredUrl('monitoring/list/services', array('service_state' => 99, 'sort' => 'service_last_check', 'dir' => 'asc')) ?>">
-                    <th class="state slice-state-pending badge"><?= $statusSummary->services_pending ?></th>
+                    <th class="state state-pending badge"><?= $statusSummary->services_pending ?></th>
                     <td><?= $this->translate('Pending') ?></td>
                 </tr>
             <?php endif;


### PR DESCRIPTION
The legend badges used the same classes as the donuts - so the background colour could be set via ```@state-xxx``` but the font colour could not be overwritten unless the non-standard class ```.slice-state-xxx``` was overwritten.

Now it should have the normal theming behaviour.