### PR TITLE
loader.js: Return in onComplete upon handled redirects

### DIFF
--- a/public/js/icinga/loader.js
+++ b/public/js/icinga/loader.js
@@ -670,7 +670,9 @@
             delete this.requests[req.$target.attr('id')];
             this.icinga.ui.fadeNotificationsAway();
 
-            this.processRedirectHeader(req);
+            if (this.processRedirectHeader(req)) {
+                return;
+            }
 
             if (typeof req.loadNext !== 'undefined' && req.loadNext.length) {
                 if ($('#col2').length) {


### PR DESCRIPTION
Got changed with f12a5741b8a4c53b7e5d94e43094e18d5a946934. Triggering
rendered events for stuff that's never displayed doesn't seem right.