### PR TITLE
Fixes 2266.  Special handling of notification 'output' field.

### DIFF
--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/HostnotificationQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/HostnotificationQuery.php
@@ -68,6 +68,8 @@ class HostnotificationQuery extends IdoQuery
     {
         if ($col === 'UNIX_TIMESTAMP(hn.start_time)') {
             return 'hn.start_time ' . $sign . ' ' . $this->timestampForSql($this->valueToTimestamp($expression));
+        } elseif ($col === $this->columnMap['history']['output']) {
+            return parent::whereToSql('hn.output', $sign, $expression);
         } else {
             return parent::whereToSql($col, $sign, $expression);
         }

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/ServicenotificationQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/ServicenotificationQuery.php
@@ -68,6 +68,8 @@ class ServicenotificationQuery extends IdoQuery
     {
         if ($col === 'UNIX_TIMESTAMP(sn.start_time)') {
             return 'sn.start_time ' . $sign . ' ' . $this->timestampForSql($this->valueToTimestamp($expression));
+        } elseif ($col === $this->columnMap['history']['output']) {
+            return parent::whereToSql('sn.output', $sign, $expression);
         } else {
             return parent::whereToSql($col, $sign, $expression);
         }


### PR DESCRIPTION
I'd like to submit this pull request for consideration to address a problem (Issue 2266) where attempts to filter the "Output" field in the "Event Overview" cause an error to be dumped to the interface (SQLSTATE[HY000]: General error: 1111 Invalid use of group function, query was:....)

Implements a special handling of notification 'output' field to avoid using aggregate function in WHERE clause of query.

fixes #2266