### PR TITLE
Added info about icingaweb endpoint into "System -> Monitoring Health" section

### DIFF
--- a/modules/monitoring/application/views/scripts/health/info.phtml
+++ b/modules/monitoring/application/views/scripts/health/info.phtml
@@ -57,11 +57,9 @@ if (! $this->compact): ?>
                             : $this->translate('N/A') ?></td>
                 </tr>
                 <tr>
-                    <th><?= $this->translate('Active IcingaWeb Endpoint'); ?></th>
-                    <td><?= gethostname()
-                            ? gethostname()
-                            : $this->translate('N/A') ?></td>
-                    </tr>
+                    <th><?= $this->translate('Active Icinga Web 2 Endpoint'); ?></th>
+                    <td><?= gethostname() ?: $this->translate('N/A') ?></td>
+                </tr>
                 </tbody>
             </table>
             <?php if ((bool) $this->programStatus->is_currently_running === true): ?>

--- a/modules/monitoring/application/views/scripts/health/info.phtml
+++ b/modules/monitoring/application/views/scripts/health/info.phtml
@@ -56,6 +56,12 @@ if (! $this->compact): ?>
                             ? $this->programStatus->endpoint_name
                             : $this->translate('N/A') ?></td>
                 </tr>
+                <tr>
+                    <th><?= $this->translate('Active IcingaWeb Endpoint'); ?></th>
+                    <td><?= gethostname()
+                            ? gethostname()
+                            : $this->translate('N/A') ?></td>
+                    </tr>
                 </tbody>
             </table>
             <?php if ((bool) $this->programStatus->is_currently_running === true): ?>


### PR DESCRIPTION
We have infrastructure like this:
<img width="1062" alt="Screenshot  о 21 28 05" src="https://user-images.githubusercontent.com/16512299/57986426-78575200-7a7d-11e9-908e-59c648eca4a9.png">

And when I'm gonna to explore IcingaWeb logs it becomes a real pain to find proper node.

So I added info about icingaweb endpoint when using IcingaWeb in HA mode and it works for us.

In UI it looks like this:
<img width="541" alt="Screenshot  о 21 33 52" src="https://user-images.githubusercontent.com/16512299/57986454-e734ab00-7a7d-11e9-91d9-5e00002534e2.png">

I hope it is usefull. 
Please let me know if you think it should be another page to display that info.

Thanks,
Ivan