### PR TITLE
CLI: Fix CSS path

### DIFF
--- a/library/Icinga/Web/StyleSheet.php
+++ b/library/Icinga/Web/StyleSheet.php
@@ -83,7 +83,7 @@ class StyleSheet
         $app = Icinga::app();
         $this->app = $app;
         $this->lessCompiler = new LessCompiler();
-        $this->pubPath = $app->getBootstrapDirectory();
+        $this->pubPath = $app->getBaseDir('public');
         $this->collect();
     }
 


### PR DESCRIPTION
CLI commands which require our LESS parser had no access to our CSS
because the public path was set to the path of the icingacli executable
which is most likely bin.