### PR TITLE
Order the programdata table by last status update

### DIFF
--- a/modules/monitoring/application/controllers/HealthController.php
+++ b/modules/monitoring/application/controllers/HealthController.php
@@ -84,6 +84,7 @@ class HealthController extends Controller
                     'process_performance_data'
                 )
             )
+            ->order('status_update_time', 'DESC')
             ->getQuery();
         $this->handleFormatRequest($programStatus);
         $programStatus = $programStatus->fetchRow();

--- a/modules/monitoring/library/Monitoring/ProvidedHook/ApplicationState.php
+++ b/modules/monitoring/library/Monitoring/ProvidedHook/ApplicationState.php
@@ -18,6 +18,7 @@ class ApplicationState extends ApplicationStateHook
                 'programstatus',
                 ['is_currently_running', 'status_update_time']
             )
+            ->order('status_update_time', 'DESC')
             ->fetchRow();
 
         if ($programStatus === false || ! (bool) $programStatus->is_currently_running) {

--- a/modules/monitoring/library/Monitoring/Web/Navigation/Renderer/BackendAvailabilityNavigationItemRenderer.php
+++ b/modules/monitoring/library/Monitoring/Web/Navigation/Renderer/BackendAvailabilityNavigationItemRenderer.php
@@ -30,6 +30,7 @@ class BackendAvailabilityNavigationItemRenderer extends BadgeNavigationItemRende
                 'programstatus',
                 array('is_currently_running', 'notifications_enabled')
             )
+            ->order('status_update_time', 'DESC')
             ->fetchRow();
 
         if ($programStatus === false) {


### PR DESCRIPTION
This ensures the master with the latest state is used instead of the
master that wrote its row first.