### PR TITLE
Fix double query execution

### DIFF
--- a/library/Icinga/Data/SimpleQuery.php
+++ b/library/Icinga/Data/SimpleQuery.php
@@ -450,7 +450,17 @@ class SimpleQuery implements QueryInterface, Queryable, Iterator
      */
     public function hasResult()
     {
-        return $this->iteratorPosition !== null || $this->fetchRow() !== false;
+        if ($this->iteratorPosition !== null) {
+            return true;
+        }
+
+        $hasResult = false;
+        foreach ($this as $row) {
+            $hasResult = true;
+            break;
+        }
+
+        return $hasResult;
     }
 
     /**


### PR DESCRIPTION
Our monitoring list views call SimpleQuery::hasResult() first in
order to determine whether there are results to display. This calls
fetchRow() which executes the underlying query the first time. If there
are resulsts, the query is iterated which executes the query again.
With this patch, SimpleQuery::hasResult() makes use of the inner
iterator instead of calling fetchRow(). The query is now executed only
once.

<h1>Without patch</h1>

<table class="benchmark">
<tbody><tr><td align="left">Description</td><td align="right">Off (ms)</td><td align="right">Dur (ms)</td><td align="right">Mem (diff)</td><td align="right">Mem (total)</td></tr>
<tr><td align="left">Bootstrap, autoloader registered</td><td align="right">0.003</td><td align="right">0.003</td><td align="right">682.06 KiB</td><td align="right">682.06 KiB</td></tr>
<tr><td align="left">Action::postDispatch()</td><td align="right">260.597</td><td align="right">260.594</td><td align="right">7.01 MiB</td><td align="right">7.68 MiB</td></tr>
<tr><td align="left">Counting all results started</td><td align="right">263.438</td><td align="right">2.841</td><td align="right">51.38 KiB</td><td align="right">7.73 MiB</td></tr>
<tr><td align="left">Counting all results finished</td><td align="right">389.013</td><td align="right">125.575</td><td align="right">168.01 KiB</td><td align="right">7.89 MiB</td></tr>
<tr><td align="left">Fetching one row started</td><td align="right">474.784</td><td align="right">85.771</td><td align="right">1535.91 KiB</td><td align="right">9.39 MiB</td></tr>
<tr><td align="left">Fetching one row finished</td><td align="right">696.487</td><td align="right">221.703</td><td align="right">3.91 KiB</td><td align="right">9.40 MiB</td></tr>
<tr><td align="left">Query result iteration started</td><td align="right">882.543</td><td align="right">186.056</td><td align="right">63.67 KiB</td><td align="right">9.46 MiB</td></tr>
<tr><td align="left">Query result iteration finished</td><td align="right">911.221</td><td align="right">28.678</td><td align="right">391.45 KiB</td><td align="right">9.84 MiB</td></tr>
<tr><td align="left">Fetching one row started</td><td align="right">912.754</td><td align="right">1.533</td><td align="right">34.02 KiB</td><td align="right">9.87 MiB</td></tr>
<tr><td align="left">Fetching one row finished</td><td align="right">1003.547</td><td align="right">90.793</td><td align="right">2.43 KiB</td><td align="right">9.88 MiB</td></tr>
<tr><td align="left">Response ready</td><td align="right">1100.532</td><td align="right">96.985</td><td align="right">292.98 KiB</td><td align="right">10.16 MiB</td></tr>
</tbody></table>

<h1>With patch</h1>

<table class="benchmark">
<tbody><tr><td align="left">Description</td><td align="right">Off (ms)</td><td align="right">Dur (ms)</td><td align="right">Mem (diff)</td><td align="right">Mem (total)</td></tr>
<tr><td align="left">Bootstrap, autoloader registered</td><td align="right">0.004</td><td align="right">0.004</td><td align="right">682.06 KiB</td><td align="right">682.06 KiB</td></tr>
<tr><td align="left">Action::postDispatch()</td><td align="right">321.780</td><td align="right">321.776</td><td align="right">7.01 MiB</td><td align="right">7.68 MiB</td></tr>
<tr><td align="left">Counting all results started</td><td align="right">325.437</td><td align="right">3.657</td><td align="right">51.38 KiB</td><td align="right">7.73 MiB</td></tr>
<tr><td align="left">Counting all results finished</td><td align="right">471.803</td><td align="right">146.366</td><td align="right">168.01 KiB</td><td align="right">7.89 MiB</td></tr>
<tr><td align="left">Query result iteration started</td><td align="right">789.899</td><td align="right">318.096</td><td align="right">1602.69 KiB</td><td align="right">9.46 MiB</td></tr>
<tr><td align="left">Query result iteration started</td><td align="right">790.295</td><td align="right">0.396</td><td align="right">-8.55 KiB</td><td align="right">9.45 MiB</td></tr>
<tr><td align="left">Query result iteration finished</td><td align="right">818.666</td><td align="right">28.371</td><td align="right">400.41 KiB</td><td align="right">9.84 MiB</td></tr>
<tr><td align="left">Fetching one row started</td><td align="right">819.842</td><td align="right">1.176</td><td align="right">34.02 KiB</td><td align="right">9.87 MiB</td></tr>
<tr><td align="left">Fetching one row finished</td><td align="right">916.380</td><td align="right">96.538</td><td align="right">2.12 KiB</td><td align="right">9.88 MiB</td></tr>
<tr><td align="left">Response ready</td><td align="right">985.698</td><td align="right">69.318</td><td align="right">293.29 KiB</td><td align="right">10.16 MiB</td></tr>
</tbody></table>