### PR TITLE
Add tactical overview to global search

### DIFF
--- a/modules/monitoring/application/views/scripts/tactical/index.phtml
+++ b/modules/monitoring/application/views/scripts/tactical/index.phtml
@@ -1,4 +1,4 @@
-<?php if (!$this->compact): ?>
+<?php if (! $this->compact): ?>
 <div class="controls">
     <?= $this->tabs ?>
     <?= $this->filterEditor ?>
@@ -15,116 +15,128 @@
             <div class="donut">
                 <?= $hostStatusSummaryChart ?>
             </div>
-            <table class="donut-table">
-            <tbody>
-                <?php if ($statusSummary->hosts_up): ?>
-                <tr href="<?= $this->filteredUrl('monitoring/list/hosts', array('host_state' => 0, 'sort' => 'host_last_check', 'dir' => 'asc')) ?>">
-                    <th class="state state-ok badge"><?= $statusSummary->hosts_up ?></th>
-                    <td><?= $this->translate('Up') ?></td>
-                </tr>
-                <?php endif;
-                if ($statusSummary->hosts_down_handled):?>
-                <tr href="<?= $this->filteredUrl('monitoring/list/hosts', array('host_state' => 1, 'host_handled' => 1, 'sort' => 'host_last_check', 'dir' => 'asc')) ?>">
-                    <th class="state state-critical handled badge"><?= $statusSummary->hosts_down_handled ?></th>
-                    <td><?= $this->translate('Down') ?> (<?= $this->translate('Handled') ?>)</td>
-                </tr>
-                <?php endif;
-                if ($statusSummary->hosts_down_unhandled):?>
-                <tr href="<?= $this->filteredUrl('monitoring/list/hosts', array('host_state' => 1, 'host_handled' => 0, 'sort' => 'host_last_check', 'dir' => 'asc')) ?>">
-                    <th class="state state-critical badge"><?= $statusSummary->hosts_down_unhandled ?></th>
-                    <td><?= $this->translate('Down') ?></td>
-                </tr>
-                <?php endif;
-                if ($statusSummary->hosts_unreachable_handled):?>
-                <tr href="<?= $this->filteredUrl('monitoring/list/hosts', array('host_state' => 2, 'host_handled' => 1, 'sort' => 'host_last_check', 'dir' => 'asc')) ?>">
-                    <th class="state state-unreachable handled badge"><?= $statusSummary->hosts_unreachable_handled ?></th>
-                    <td><?= $this->translate('Unreachable') ?> (<?= $this->translate('Handled') ?>)</td>
-                </tr>
-                <?php endif;
-                if ($statusSummary->hosts_unreachable_unhandled):?>
-                <tr href="<?= $this->filteredUrl('monitoring/list/hosts', array('host_state' => 2, 'host_handled' => 0, 'sort' => 'host_last_check', 'dir' => 'asc')) ?>">
-                    <th class="state state-unreachable badge"><?= $statusSummary->hosts_unreachable_unhandled ?></th>
-                    <td><?= $this->translate('Unreachable') ?></td>
-                </tr>
-                <?php endif;
-                if ($statusSummary->hosts_pending):?>
-                <tr href="<?= $this->filteredUrl('monitoring/list/hosts', array('host_state' => 99, 'sort' => 'host_last_check', 'dir' => 'asc')) ?>">
-                    <th class="state state-pending badge"><?= $statusSummary->hosts_pending ?></th>
-                    <td><?= $this->translate('Pending') ?></td>
-                </tr>
-                <?php endif;
-                if ($statusSummary->hosts_not_checked):?>
-                <tr href="<?= $this->filteredUrl('monitoring/list/hosts', array('host_active_checks_enabled' => 0, 'host_passive_checks_enabled' => 0, 'sort' => 'host_last_check', 'dir' => 'asc')) ?>">
-                    <th class="state slice-state-not-checked badge"><?= $statusSummary->hosts_not_checked ?></th>
-                    <td><?= $this->translate('Not Checked') ?></td>
-                </tr>
+            <ul class="donut-legend">
+            <?php if ($statusSummary->hosts_up): ?>
+                <li>
+                    <a href="<?= $this->filteredUrl('monitoring/list/hosts', array('host_state' => 0, 'sort' => 'host_last_check', 'dir' => 'asc')) ?>">
+                        <span class="state state-ok badge"><?= $statusSummary->hosts_up ?></span><?= $this->translate('Up') ?>
+                    </a>
+                </li>
             <?php endif ?>
-            </tbody>
-            </table>
+            <?php if ($statusSummary->hosts_down_handled): ?>
+                <li>
+                    <a href="<?= $this->filteredUrl('monitoring/list/hosts', array('host_state' => 1, 'host_handled' => 1, 'sort' => 'host_last_check', 'dir' => 'asc')) ?>">
+                        <span class="state state-critical handled badge"><?= $statusSummary->hosts_down_handled ?></span><?= $this->translate('Down') ?> (<?= $this->translate('Handled') ?>)
+                    </a>
+                </li>
+            <?php endif ?>
+            <?php if ($statusSummary->hosts_down_unhandled): ?>
+                <li>
+                    <a href="<?= $this->filteredUrl('monitoring/list/hosts', array('host_state' => 1, 'host_handled' => 0, 'sort' => 'host_last_check', 'dir' => 'asc')) ?>">
+                        <span class="state state-critical badge"><?= $statusSummary->hosts_down_unhandled ?></span><?= $this->translate('Down') ?>
+                    </a>
+                </li>
+            <?php endif ?>
+            <?php if ($statusSummary->hosts_unreachable_handled): ?>
+                <li>
+                    <a href="<?= $this->filteredUrl('monitoring/list/hosts', array('host_state' => 2, 'host_handled' => 1, 'sort' => 'host_last_check', 'dir' => 'asc')) ?>">
+                        <span class="state state-unreachable handled badge"><?= $statusSummary->hosts_unreachable_handled ?></span><?= $this->translate('Unreachable') ?> (<?= $this->translate('Handled') ?>)
+                    </a>
+                </li>
+            <?php endif ?>
+            <?php if ($statusSummary->hosts_unreachable_unhandled): ?>
+                <li>
+                    <a href="<?= $this->filteredUrl('monitoring/list/hosts', array('host_state' => 2, 'host_handled' => 0, 'sort' => 'host_last_check', 'dir' => 'asc')) ?>">
+                        <span class="state state-unreachable badge"><?= $statusSummary->hosts_unreachable_unhandled ?></span><?= $this->translate('Unreachable') ?>
+                    </a>
+                </li>
+            <?php endif ?>
+            <?php if ($statusSummary->hosts_pending): ?>
+                <li>
+                    <a href="<?= $this->filteredUrl('monitoring/list/hosts', array('host_state' => 99, 'sort' => 'host_last_check', 'dir' => 'asc')) ?>">
+                        <span class="state state-pending badge"><?= $statusSummary->hosts_pending ?></span><?= $this->translate('Pending') ?>
+                    </a>
+                </li>
+            <?php endif ?>
+            <?php if ($statusSummary->hosts_not_checked): ?>
+                <li>
+                    <a href="<?= $this->filteredUrl('monitoring/list/hosts', array('host_active_checks_enabled' => 0, 'host_passive_checks_enabled' => 0, 'sort' => 'host_last_check', 'dir' => 'asc')) ?>">
+                        <span class="state slice-state-not-checked badge"><?= $statusSummary->hosts_not_checked ?></span><?= $this->translate('Not Checked') ?>
+                    </a>
+                </li>
+            <?php endif ?>
+            </ul>
         </div>
         <div class="donut-container">
             <h2><?= $this->translate('Service Summary') ?></h2>
             <div class="donut">
                 <?= $serviceStatusSummaryChart ?>
             </div>
-            <table class="donut-table">
-            <tbody>
+            <ul class="donut-legend">
             <?php if ($statusSummary->services_ok):?>
-                <tr href="<?= $this->filteredUrl('monitoring/list/services', array('service_state' => 0, 'sort' => 'service_last_check', 'dir' => 'asc')) ?>">
-                    <th class="state state-ok badge"><?= $statusSummary->services_ok ?></th>
-                    <td><?= $this->translate('Ok') ?></td>
-                </tr>
+                <li>
+                    <a href="<?= $this->filteredUrl('monitoring/list/services', array('service_state' => 0, 'sort' => 'service_last_check', 'dir' => 'asc')) ?>">
+                        <span class="state state-ok badge"><?= $statusSummary->services_ok ?></span><?= $this->translate('Ok') ?>
+                    </a>
+                </li>
             <?php endif;
             if ($statusSummary->services_warning_handled):?>
-                <tr href="<?= $this->filteredUrl('monitoring/list/services', array('service_state' => 1, 'service_handled' => 1, 'sort' => 'service_last_check', 'dir' => 'asc')) ?>">
-                    <th class="state state-warning handled badge"><?= $statusSummary->services_warning_handled ?></th>
-                    <td><?= $this->translate('Warning') ?> (<?= $this->translate('Handled') ?>)</td>
-                </tr>
+                <li>
+                    <a href="<?= $this->filteredUrl('monitoring/list/services', array('service_state' => 1, 'service_handled' => 1, 'sort' => 'service_last_check', 'dir' => 'asc')) ?>">
+                        <span class="state state-warning handled badge"><?= $statusSummary->services_warning_handled ?></span><?= $this->translate('Warning') ?> (<?= $this->translate('Handled') ?>)
+                    </a>
+                </li>
             <?php endif;
             if ($statusSummary->services_warning_unhandled):?>
-                <tr href="<?= $this->filteredUrl('monitoring/list/services', array('service_state' => 1, 'service_handled' => 0, 'sort' => 'service_last_check', 'dir' => 'asc')) ?>">
-                    <th class="state state-warning badge"><?= $statusSummary->services_warning_unhandled ?></th>
-                    <td><?= $this->translate('Warning') ?></td>
-                </tr>
+                <li>
+                    <a href="<?= $this->filteredUrl('monitoring/list/services', array('service_state' => 1, 'service_handled' => 0, 'sort' => 'service_last_check', 'dir' => 'asc')) ?>">
+                        <span class="state state-warning badge"><?= $statusSummary->services_warning_unhandled ?></span><?= $this->translate('Warning') ?>
+                    </a>
+                </li>
             <?php endif;
             if ($statusSummary->services_critical_handled):?>
-                <tr href="<?= $this->filteredUrl('monitoring/list/services', array('service_state' => 2, 'service_handled' => 1, 'sort' => 'service_last_check', 'dir' => 'asc')) ?>">
-                    <th class="state state-critical handled badge"><?= $statusSummary->services_critical_handled ?></th>
-                    <td><?= $this->translate('Critical') ?> (<?= $this->translate('Handled') ?>)</td>
-                </tr>
+                <li>
+                    <a href="<?= $this->filteredUrl('monitoring/list/services', array('service_state' => 2, 'service_handled' => 1, 'sort' => 'service_last_check', 'dir' => 'asc')) ?>">
+                        <span class="state state-critical handled badge"><?= $statusSummary->services_critical_handled ?></span><?= $this->translate('Critical') ?> (<?= $this->translate('Handled') ?>)
+                    </a>
+                </li>
             <?php endif;
             if ($statusSummary->services_critical_unhandled):?>
-                <tr href="<?= $this->filteredUrl('monitoring/list/services', array('service_state' => 2, 'service_handled' => 0, 'sort' => 'service_last_check', 'dir' => 'asc')) ?>">
-                    <th class="state state-critical badge"><?= $statusSummary->services_critical_unhandled ?></th>
-                    <td><?= $this->translate('Critical') ?></td>
-                </tr>
+                <li>
+                    <a href="<?= $this->filteredUrl('monitoring/list/services', array('service_state' => 2, 'service_handled' => 0, 'sort' => 'service_last_check', 'dir' => 'asc')) ?>">
+                        <span class="state state-critical badge"><?= $statusSummary->services_critical_unhandled ?></span><?= $this->translate('Critical') ?>
+                    </a>
+                </li>
             <?php endif;
             if ($statusSummary->services_unknown_handled):?>
-                <tr href="<?= $this->filteredUrl('monitoring/list/services', array('service_state' => 3, 'service_handled' => 1, 'sort' => 'service_last_check', 'dir' => 'asc')) ?>">
-                    <th class="state state-unknown handled badge"><?= $statusSummary->services_unknown_handled ?></th>
-                    <td><?= $this->translate('Unknown') ?> (<?= $this->translate('Handled') ?>)</td>
-                </tr>
+                <li>
+                    <a href="<?= $this->filteredUrl('monitoring/list/services', array('service_state' => 3, 'service_handled' => 1, 'sort' => 'service_last_check', 'dir' => 'asc')) ?>">
+                        <span class="state state-unknown handled badge"><?= $statusSummary->services_unknown_handled ?></span><?= $this->translate('Unknown') ?> (<?= $this->translate('Handled') ?>)
+                    </a>
+                </li>
             <?php endif;
             if ($statusSummary->services_unknown_unhandled):?>
-                <tr href="<?= $this->filteredUrl('monitoring/list/services', array('service_state' => 3, 'service_handled' => 0, 'sort' => 'service_last_check', 'dir' => 'asc')) ?>">
-                    <th class="state state-unknown badge"><?= $statusSummary->services_unknown_unhandled ?></th>
-                    <td><?= $this->translate('Unknown') ?></td>
-                </tr>
+                <li>
+                    <a href="<?= $this->filteredUrl('monitoring/list/services', array('service_state' => 3, 'service_handled' => 0, 'sort' => 'service_last_check', 'dir' => 'asc')) ?>">
+                        <span class="state state-unknown badge"><?= $statusSummary->services_unknown_unhandled ?></span><?= $this->translate('Unknown') ?>
+                    </a>
+                </li>
             <?php endif;
             if ($statusSummary->services_pending):?>
-                <tr href="<?= $this->filteredUrl('monitoring/list/services', array('service_state' => 99, 'sort' => 'service_last_check', 'dir' => 'asc')) ?>">
-                    <th class="state state-pending badge"><?= $statusSummary->services_pending ?></th>
-                    <td><?= $this->translate('Pending') ?></td>
-                </tr>
+                <li>
+                    <a href="<?= $this->filteredUrl('monitoring/list/services', array('service_state' => 99, 'sort' => 'service_last_check', 'dir' => 'asc')) ?>">
+                        <span class="state state-pending badge"><?= $statusSummary->services_pending ?></span><?= $this->translate('Pending') ?>
+                    </a>
+                </li>
             <?php endif;
             if ($statusSummary->services_not_checked):?>
-                <tr href="<?= $this->filteredUrl('monitoring/list/services', array('service_active_checks_enabled' => 0, 'service_passive_checks_enabled' => 0, 'sort' => 'service_last_check', 'dir' => 'asc')) ?>">
-                    <th class="state slice-state-not-checked badge"><?= $statusSummary->services_not_checked ?></th>
-                    <td><?= $this->translate('Not Checked') ?></td>
-                </tr>
+                <li>
+                    <a href="<?= $this->filteredUrl('monitoring/list/services', array('service_active_checks_enabled' => 0, 'service_passive_checks_enabled' => 0, 'sort' => 'service_last_check', 'dir' => 'asc')) ?>">
+                        <span class="state slice-state-not-checked badge"><?= $statusSummary->services_not_checked ?></span><?= $this->translate('Not Checked') ?>
+                    </a>
+                </li>
             <?php endif?>
-            </tbody>
-            </table>
+            </ul>
         </div>
     </div>
 </div>

--- a/modules/monitoring/configuration.php
+++ b/modules/monitoring/configuration.php
@@ -108,6 +108,7 @@ $this->provideSetupWizard('Icinga\Module\Monitoring\MonitoringWizard');
 /*
  * Available Search Urls
  */
+$this->provideSearchUrl($this->translate('Tactical Overview'), 'monitoring/tactical', 100);
 $this->provideSearchUrl($this->translate('Hosts'), 'monitoring/list/hosts?sort=host_severity&limit=10', 99);
 $this->provideSearchUrl($this->translate('Services'), 'monitoring/list/services?sort=service_severity&limit=10', 98);
 $this->provideSearchUrl($this->translate('Hostgroups'), 'monitoring/list/hostgroups?limit=10', 97);

--- a/public/css/icinga/widgets.less
+++ b/public/css/icinga/widgets.less
@@ -491,22 +491,28 @@ ul.tree li a.error:hover {
 }
 
 .donut-container {
-  display: inline-block;
   width: 36em;
-  height: 36em;
-  position: relative;
+  float: left;
 }
 
-.donut-table {
-  max-width: 45%;
-  display: inline-block;
-  position: absolute;
-  top: 23em;
-  left: 17.5em;
+.donut-legend {
+  width: 50%;
+  padding: 0;
+  margin: 0 0 0 auto;
+  list-style-type: none;
 
-  & > tbody > tr:hover {
-    text-decoration: underline;
-    cursor: pointer;
+  li {
+    vertical-align: middle;
+
+    &:not(:last-child) {
+      margin-bottom: .5em;
+    }
+
+    .badge {
+      font-weight: bold;
+      margin-right: .5em;
+      vertical-align: initial;
+    }
   }
 }
 

--- a/public/css/icinga/widgets.less
+++ b/public/css/icinga/widgets.less
@@ -495,10 +495,19 @@ ul.tree li a.error:hover {
   float: left;
 }
 
+.dashboard .donut-container {
+  width: 50%;
+  font-size: 80%;
+
+  .donut-legend {
+    margin-left: auto;
+  }
+}
+
 .donut-legend {
   width: 50%;
   padding: 0;
-  margin: 0 0 0 auto;
+  margin-left: 18em;
   list-style-type: none;
 
   li {


### PR DESCRIPTION

![Bildschirmfoto von 2019-07-04 15-13-51](https://user-images.githubusercontent.com/16668527/60669368-74856080-9e6e-11e9-99d2-81e65b1d1eb3.png)


resolves #2529