### PR TITLE
Fix confusing downtime notification history

### DIFF
--- a/modules/monitoring/application/views/scripts/partials/event-history.phtml
+++ b/modules/monitoring/application/views/scripts/partials/event-history.phtml
@@ -179,38 +179,47 @@ $rowAction = Url::fromPath('monitoring/event/show');
                 <div class="state-meta"><?= $this->formatTime($event->timestamp) ?></div>
             </td>
             <td>
-                <?php if ($this->isOverview): ?>
-                    <?= $this->qlink(
-                        $event->host_display_name,
-                        'monitoring/host/show',
-                        array(
-                            'host' => $event->host_name,
-                        ),
-                        array('title' => sprintf(
-                            $this->translate('Show detailed information for host %s'),
-                            $event->host_display_name
-                        ))
-                    ) ?><?php if ($isService): ?>&#58;
+                <div class="history-message-container">
+                <?php if ($icon): ?>
+                    <div class="history-message-icon">
+                        <?= $this->icon($icon, $iconTitle) ?>
+                    </div>
+                <?php endif ?>
+                    <div class="history-message-output">
+                    <?php if ($this->isOverview): ?>
                         <?= $this->qlink(
-                            $event->service_display_name,
-                            'monitoring/service/show',
-                            array(
-                                'host'      => $event->host_name,
-                                'service'   => $event->service_description
-                            ),
-                            array(
+                            $event->host_display_name,
+                            'monitoring/host/show',
+                            [
+                                'host' => $event->host_name,
+                            ],
+                            [
                                 'title' => sprintf(
-                                    $this->translate('Show detailed information for service %s on host %s'),
-                                    $event->service_display_name,
+                                    $this->translate('Show detailed information for host %s'),
                                     $event->host_display_name
                                 )
-                            )
-                        ) ?>
+                            ]
+                        ) ?><?php if ($isService): ?>&#58;
+                            <?= $this->qlink(
+                                $event->service_display_name,
+                                'monitoring/service/show',
+                                [
+                                    'host'    => $event->host_name,
+                                    'service' => $event->service_description
+                                ],
+                                [
+                                    'title' => sprintf(
+                                        $this->translate('Show detailed information for service %s on host %s'),
+                                        $event->service_display_name,
+                                        $event->host_display_name
+                                    )
+                                ]
+                            ) ?>
+                        <?php endif ?>
                     <?php endif ?>
-                <?php endif ?>
-                <?php if ($icon) {
-                    echo $this->icon($icon, $iconTitle);
-                } ?><?= $this->nl2br($this->createTicketLinks($this->markdown($msg, ['class' => 'overview-plugin-output']))) ?>
+                        <?= $this->nl2br($this->createTicketLinks($this->markdown($msg, ['class' => 'overview-plugin-output']))) ?>
+                    </div>
+                </div>
             </td>
         </tr>
         <?php endforeach ?>

--- a/modules/monitoring/application/views/scripts/partials/event-history.phtml
+++ b/modules/monitoring/application/views/scripts/partials/event-history.phtml
@@ -53,16 +53,44 @@ $rowAction = Url::fromPath('monitoring/event/show');
             'id' => $event->id
         ));
         switch ($event->type) {
-            case 'notify':
+            case substr($event->type, 0, 13) === 'notification_':
                 $icon = 'bell';
-                $iconTitle = $this->translate('Notification', 'tooltip');
-                $label = $this->translate('NOTIFICATION');
+                switch (substr($event->type, 13)) {
+                    case 'state':
+                        $iconTitle = $this->translate('State notification', 'tooltip');
+                        $label = $this->translate('NOTIFICATION');
+                        $stateName = $isService ? Service::getStateText($event->state) : Host::getStateText($event->state);
+                        break;
+                    case 'ack':
+                        $iconTitle = $this->translate('Ack Notification', 'tooltip');
+                        $label = $this->translate('ACK NOTIFICATION');
+                        break;
+                    case 'dt_start':
+                        $iconTitle = $this->translate('Downtime start notification', 'tooltip');
+                        $label = $this->translate('DOWNTIME START NOTIFICATION');
+                        break;
+                    case 'dt_end':
+                        $iconTitle = $this->translate('Downtime end notification', 'tooltip');
+                        $label = $this->translate('DOWNTIME END NOTIFICATION');
+                        break;
+                    case 'flapping':
+                        $iconTitle = $this->translate('Flapping notification', 'tooltip');
+                        $label = $this->translate('FLAPPING NOTIFICATION');
+                        break;
+                    case 'flapping_end':
+                        $iconTitle = $this->translate('Flapping end notification', 'tooltip');
+                        $label = $this->translate('FLAPPING END NOTIFICATION');
+                        break;
+                    case 'custom':
+                        $iconTitle = $this->translate('Custom notification', 'tooltip');
+                        $label = $this->translate('CUSTOM NOTIFICATION');
+                        break;
+                }
                 $msg = $msg ? preg_replace_callback(
                     '/^\[([^\]]+)\]/',
                     function($match) use ($self) { return contactsLink($match, $self); },
                     $msg
                 ) : $this->translate('This notification was not sent out to any contact.');
-                $stateName = $isService ? Service::getStateText($event->state) : Host::getStateText($event->state);
                 break;
             case 'comment':
                 $icon = 'comment-empty';

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/EventhistoryQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/EventhistoryQuery.php
@@ -59,12 +59,12 @@ class EventhistoryQuery extends IdoQuery
             'service_display_name'
         );
         $this->subQueries = array(
+            $this->createSubQuery('Notificationhistory', $columns),
             $this->createSubQuery('Statehistory', $columns),
             $this->createSubQuery('Downtimestarthistory', $columns),
             $this->createSubQuery('Downtimeendhistory', $columns),
             $this->createSubQuery('Commenthistory', $columns),
             $this->createSubQuery('Commentdeletionhistory', $columns),
-            $this->createSubQuery('Notificationhistory', $columns),
             $this->createSubQuery('Flappingstarthistory', $columns),
             $this->createSubQuery('Flappingendhistory', $columns)
         );

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/HostnotificationQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/HostnotificationQuery.php
@@ -38,7 +38,17 @@ class HostnotificationQuery extends IdoQuery
             'output'    => null,
             'state'     => 'hn.state',
             'timestamp' => 'UNIX_TIMESTAMP(hn.start_time)',
-            'type'      => '(\'notify\')'
+            'type'      => '
+                CASE hn.notification_reason
+                    WHEN 1 THEN \'notification_ack\'
+                    WHEN 2 THEN \'notification_flapping\'
+                    WHEN 3 THEN \'notification_flapping_end\'
+                    WHEN 5 THEN \'notification_dt_start\'
+                    WHEN 6 THEN \'notification_dt_end\'
+                    WHEN 7 THEN \'notification_dt_end\'
+                    WHEN 8 THEN \'notification_custom\'
+                    ELSE \'notification_state\'
+                END',
         ),
         'instances' => array(
             'instance_name' => 'i.instance_name'

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/NotificationhistoryQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/NotificationhistoryQuery.php
@@ -27,7 +27,7 @@ class NotificationhistoryQuery extends IdoQuery
             'output'        => 'n.output',
             'state'         => 'n.state',
             'timestamp'     => 'n.timestamp',
-            'type'          => "('notify')"
+            'type'          => 'n.type'
         ),
         'hosts' => array(
             'host_display_name' => 'n.host_display_name',
@@ -79,9 +79,6 @@ class NotificationhistoryQuery extends IdoQuery
                 $columns[$column] = new Zend_Db_Expr('NULL');
             }
         }
-        if (isset($columns['type'])) {
-            unset($columns['type']);
-        }
         $hosts = $this->createSubQuery('hostnotification', $columns);
         $this->subQueries[] = $hosts;
         $this->notificationQuery->union(array($hosts), Zend_Db_Select::SQL_UNION_ALL);
@@ -93,9 +90,6 @@ class NotificationhistoryQuery extends IdoQuery
     protected function joinServices()
     {
         $columns = array_flip($this->desiredColumns);
-        if (isset($columns['type'])) {
-            unset($columns['type']);
-        }
         $services = $this->createSubQuery('servicenotification', array_flip($columns));
         $this->subQueries[] = $services;
         $this->notificationQuery->union(array($services), Zend_Db_Select::SQL_UNION_ALL);

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/ServicenotificationQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/ServicenotificationQuery.php
@@ -30,7 +30,17 @@ class ServicenotificationQuery extends IdoQuery
             'output'    => null,
             'state'     => 'sn.state',
             'timestamp' => 'UNIX_TIMESTAMP(sn.start_time)',
-            'type'      => '(\'notify\')'
+            'type'      => '
+                CASE sn.notification_reason
+                    WHEN 1 THEN \'notification_ack\'
+                    WHEN 2 THEN \'notification_flapping\'
+                    WHEN 3 THEN \'notification_flapping_end\'
+                    WHEN 5 THEN \'notification_dt_start\'
+                    WHEN 6 THEN \'notification_dt_end\'
+                    WHEN 7 THEN \'notification_dt_end\'
+                    WHEN 8 THEN \'notification_custom\'
+                    ELSE \'notification_state\'
+                END',
         ),
         'hostgroups' => array(
             'hostgroup_name'    => 'hgo.name1',

--- a/modules/monitoring/public/css/tables.less
+++ b/modules/monitoring/public/css/tables.less
@@ -241,3 +241,18 @@
     cursor: pointer;
   }
 }
+
+// Event history
+.history-message-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  > .history-message-icon {
+    padding: 0.25em;
+  }
+
+  > .history-message-output {
+    flex: 1;
+  }
+}


### PR DESCRIPTION
fixes #2963 

@nilmerg This depends on the Markdown `<p>` in `<p>` rendering fix and should be reviewed once we have this.