### PR TITLE
Fix Event Grid PostgreSQL error

### DIFF
--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/EventgridQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/EventgridQuery.php
@@ -3,7 +3,7 @@
 
 namespace Icinga\Module\Monitoring\Backend\Ido\Query;
 
-class EventgridQuery extends StatehistoryQuery
+abstract class EventgridQuery extends StatehistoryQuery
 {
     /**
      * The columns additionally provided by this query
@@ -12,19 +12,19 @@ class EventgridQuery extends StatehistoryQuery
      */
     protected $additionalColumns = array(
         'day'                   => 'DATE(FROM_UNIXTIME(sth.timestamp))',
-        'cnt_up'                => "SUM(CASE WHEN sth.object_type = 'host' AND sth.state = 0 THEN 1 ELSE 0 END)",
-        'cnt_down_hard'         => "SUM(CASE WHEN sth.object_type = 'host' AND sth.state = 1 AND sth.type = 'hard_state' THEN 1 ELSE 0 END)",
-        'cnt_down'              => "SUM(CASE WHEN sth.object_type = 'host' AND sth.state = 1 THEN 1 ELSE 0 END)",
-        'cnt_unreachable_hard'  => "SUM(CASE WHEN sth.object_type = 'host' AND sth.state = 2 AND sth.type = 'hard_state' THEN 1 ELSE 0 END)",
-        'cnt_unreachable'       => "SUM(CASE WHEN sth.object_type = 'host' AND sth.state = 2 THEN 1 ELSE 0 END)",
-        'cnt_unknown_hard'      => "SUM(CASE WHEN sth.object_type = 'service' AND sth.state = 3 AND sth.type = 'hard_state' THEN 1 ELSE 0 END)",
-        'cnt_unknown'           => "SUM(CASE WHEN sth.object_type = 'service' AND sth.state = 3 THEN 1 ELSE 0 END)",
-        'cnt_unknown_hard'      => "SUM(CASE WHEN sth.object_type = 'service' AND sth.state = 3 AND sth.type = 'hard_state' THEN 1 ELSE 0 END)",
-        'cnt_critical'          => "SUM(CASE WHEN sth.object_type = 'service' AND sth.state = 2 THEN 1 ELSE 0 END)",
-        'cnt_critical_hard'     => "SUM(CASE WHEN sth.object_type = 'service' AND sth.state = 2 AND sth.type = 'hard_state' THEN 1 ELSE 0 END)",
-        'cnt_warning'           => "SUM(CASE WHEN sth.object_type = 'service' AND sth.state = 1 THEN 1 ELSE 0 END)",
-        'cnt_warning_hard'      => "SUM(CASE WHEN sth.object_type = 'service' AND sth.state = 1 AND sth.type = 'hard_state' THEN 1 ELSE 0 END)",
-        'cnt_ok'                => "SUM(CASE WHEN sth.object_type = 'service' AND sth.state = 0 THEN 1 ELSE 0 END)"
+        'cnt_up'                => "SUM(CASE WHEN sth.state = 0 THEN 1 ELSE 0 END)",
+        'cnt_down_hard'         => "SUM(CASE WHEN sth.state = 1 AND sth.type = 'hard_state' THEN 1 ELSE 0 END)",
+        'cnt_down'              => "SUM(CASE WHEN sth.state = 1 THEN 1 ELSE 0 END)",
+        'cnt_unreachable_hard'  => "SUM(CASE WHEN sth.state = 2 AND sth.type = 'hard_state' THEN 1 ELSE 0 END)",
+        'cnt_unreachable'       => "SUM(CASE WHEN sth.state = 2 THEN 1 ELSE 0 END)",
+        'cnt_unknown_hard'      => "SUM(CASE WHEN sth.state = 3 AND sth.type = 'hard_state' THEN 1 ELSE 0 END)",
+        'cnt_unknown'           => "SUM(CASE WHEN sth.state = 3 THEN 1 ELSE 0 END)",
+        'cnt_unknown_hard'      => "SUM(CASE WHEN sth.state = 3 AND sth.type = 'hard_state' THEN 1 ELSE 0 END)",
+        'cnt_critical'          => "SUM(CASE WHEN sth.state = 2 THEN 1 ELSE 0 END)",
+        'cnt_critical_hard'     => "SUM(CASE WHEN sth.state = 2 AND sth.type = 'hard_state' THEN 1 ELSE 0 END)",
+        'cnt_warning'           => "SUM(CASE WHEN sth.state = 1 THEN 1 ELSE 0 END)",
+        'cnt_warning_hard'      => "SUM(CASE WHEN sth.state = 1 AND sth.type = 'hard_state' THEN 1 ELSE 0 END)",
+        'cnt_ok'                => "SUM(CASE WHEN sth.state = 0 THEN 1 ELSE 0 END)"
     );
 
     /**


### PR DESCRIPTION
PostgreSQL fails with failed to find conversion function from
unknown to text. PostgreSQL won't detect the type of object_type.
Most likely because it's used in a CASE statement and provided by a
subquery:

select case when s.object_type = 'service' then 1 else 0 end from
(select ('service') as object_type) as s;

This commit just removes object_type from the CASE statements because we
don't need them anyway. Recently we've changed the event grid query to
only select hosts or services and not both.