### PR TITLE
Compat: Provide empty LESS mixin .code()

### DIFF
--- a/public/css/icinga/compat.less
+++ b/public/css/icinga/compat.less
@@ -32,3 +32,9 @@ table.action {
 table.avp {
   .name-value-table()
 }
+
+.code() {
+  // Some 3rd party modules (e.g. vsphere) use this mixin (though we never had it)
+  // With lessphp version 0.5.0 using undefined mixins now throws exceptions
+  // Since we can't rely that users upgrade those modules first, we provide the mixin for compatibility here
+}


### PR DESCRIPTION
Some 3rd party modules (e.g. vsphere) use this mixin (though we never had it).
With lessphp version 0.5.0 using undefined mixins now throws exceptions.
Since we can't rely that users upgrade those modules first,
we provide the mixin for compatibility here.