### PR TITLE
Fix Icinga 2 version detection

### DIFF
--- a/modules/monitoring/library/Monitoring/Backend/MonitoringBackend.php
+++ b/modules/monitoring/library/Monitoring/Backend/MonitoringBackend.php
@@ -354,7 +354,7 @@ class MonitoringBackend implements Selectable, Queryable, ConnectionInterface
             $programVersion = $this->select()->from('programstatus', array('program_version'))->fetchOne();
         }
         return (bool) preg_match(
-            '/^[vr]2\.\d+\.\d+.*$/',
+            '/^[vr]?2\.\d+\.\d+.*$/',
             $programVersion
         );
     }


### PR DESCRIPTION
With this commit the version prefix character is treated as optional
which always used to be 'r' or 'v'. But this is gone since Icinga 2
version 2.11.0 RC1.