### PR TITLE
js: Fetch container id from real `.container`s

### DIFF
--- a/public/js/icinga/ui.js
+++ b/public/js/icinga/ui.js
@@ -728,6 +728,8 @@
                 return null;
             }
 
+            $cont = $cont.closest('.container');
+
             var containerId = $cont.data('icingaContainerId');
             if (typeof containerId === 'undefined') {
                 /**


### PR DESCRIPTION
If loading content to a custom `$target` the container id
of the current column will be ignored without this change.