### PR TITLE
Highlight links in monitoring's markdown content

### DIFF
--- a/modules/monitoring/public/css/module.less
+++ b/modules/monitoring/public/css/module.less
@@ -654,12 +654,16 @@ form.instance-features span.description, form.object-features span.description {
   }
 }
 
-.go-ahead a {
-   border-bottom: 1px @gray-light dotted;
+.go-ahead,
+.markdown,
+.plugin-output {
+  a {
+     border-bottom: 1px @gray-light dotted;
 
-  &:hover {
-    border-bottom: 1px @text-color solid;
-    text-decoration: none;
+    &:hover {
+      border-bottom: 1px @text-color solid;
+      text-decoration: none;
+    }
   }
 }
 


### PR DESCRIPTION
Doesn't apply to all markdown content. Our only use-case is in the monitoring module and this already got known style for external/custom links.

![Bildschirmfoto von 2019-08-01 13-29-08](https://user-images.githubusercontent.com/16668527/62290060-aafbce80-b460-11e9-9280-1695c5b4d55c.png)
![Bildschirmfoto von 2019-08-01 13-30-21](https://user-images.githubusercontent.com/16668527/62290061-aafbce80-b460-11e9-8fbd-c18643cacd1a.png)

Other modules may want to apply a different style or possibly none at all.

resolves #3888