### PR TITLE
Revert "Fix double query execution"

### DIFF
--- a/library/Icinga/Data/SimpleQuery.php
+++ b/library/Icinga/Data/SimpleQuery.php
@@ -450,17 +450,7 @@ class SimpleQuery implements QueryInterface, Queryable, Iterator
      */
     public function hasResult()
     {
-        if ($this->iteratorPosition !== null) {
-            return true;
-        }
-
-        $hasResult = false;
-        foreach ($this as $row) {
-            $hasResult = true;
-            break;
-        }
-
-        return $hasResult;
+        return $this->iteratorPosition !== null || $this->fetchRow() !== false;
     }
 
     /**


### PR DESCRIPTION
The reverted commit fixed a double query execution bug by only executing
the query once in either SimpleQuery::hasResult() or upon iteration.

But the fix  introduced two problems:

* Default sort rules no longer work
* Show more links missing

We work with DataView objects in our controllers and views. When
iterating over a DataView, it applies its default sort rules and then
returns the underlying query, see DataView::getIterator().

DataView::hasResult() on the other hand does not apply the default sort
rules. So, if hasResult() is called first, the default sort rules are no
longer applied because the query will be executed only once.
The fix would be as easy as to apply sorting in DataView::hasResult() as
well.

But now the show more part kicks in. We know whether there are more
results because we execute queries with $limit + 1. This is enabled via
SimpleQuery::peekAhead(). Unfortunately, we call
SimpleQuery::peekAhead() ALWAYS after SimpleQuery::hasResult(). And
that's why the show more links are missing because the query is executed
only once with the "wrong" limit.

For now, we just revert the commit in question and postpone a proper fix
for the double execution.

fixes #3891

Reverts Icinga/icingaweb2#3836