### PR TITLE
Forms: Distinguish placeholders from real values

### DIFF
--- a/public/css/icinga/forms.less
+++ b/public/css/icinga/forms.less
@@ -453,22 +453,16 @@ form.icinga-form .form-info {
 // Placeholder styles
 
 .icinga-controls {
-  input:-moz-placeholder { // FF 18-
-    color: @gray;
-    opacity: 1;
-  }
-
-  input::-moz-placeholder { // FF 19+
-    color: @gray;
+  input::placeholder {
+    color: @disabled-gray;
+    font-style: italic;
     opacity: 1;
   }
 
   input:-ms-input-placeholder {
-    color: @gray;
-  }
-
-  input::-webkit-input-placeholder {
-    color: @gray;
+    color: @disabled-gray;
+    font-style: italic;
+    opacity: 1;
   }
 }
 


### PR DESCRIPTION
We now also use the ::placeholder pseudo-element selector instead of
several vendor prefixes.

fixes #3847 