### PR TITLE
Bugfix/duplicate ldap uri

### DIFF
--- a/library/Icinga/Protocol/Ldap/LdapConnection.php
+++ b/library/Icinga/Protocol/Ldap/LdapConnection.php
@@ -1181,7 +1181,15 @@ class LdapConnection implements Selectable, Inspectable
 
         $hostname = $this->normalizeHostname($this->hostname);
 
-        $ds = ldap_connect($hostname, $this->port);
+        try {
+            $ds = ldap_connect($hostname, $this->port);
+        } catch (\ErrorException $e) {
+            throw new LdapException(
+                'LDAP connection to %s failed (%s)',
+                $hostname,
+                $e->getMessage()
+            );
+        }
 
         // Set a proper timeout for each connection
         ldap_set_option($ds, LDAP_OPT_NETWORK_TIMEOUT, $this->timeout);

--- a/library/Icinga/Protocol/Ldap/LdapConnection.php
+++ b/library/Icinga/Protocol/Ldap/LdapConnection.php
@@ -1523,6 +1523,15 @@ class LdapConnection implements Selectable, Inspectable
 
     protected function normalizeHostname($hostname)
     {
+        if (strpos($hostname, '://') !== false) {
+            Logger::error(
+                'LDAP hostname: Please avoid using scheme ldap:// or ldaps://. We\'ll remove it for you without'
+                . ' consider encryption setting based on scheme'
+            );
+
+            $hostname = preg_replace('/^ldaps?:\/\//', '', $hostname, 2);
+        }
+
         $scheme = $this->encryption === static::LDAPS ? 'ldaps://' : 'ldap://';
         $normalizeHostname = function ($hostname) use ($scheme) {
             if (strpos($hostname, $scheme) === false) {


### PR DESCRIPTION
Hi,

users use the URI in LDAP resources. The first commit is just to see the normalised hostname. The second just a try fix - even if it is not the best one. Just to hint issues on that.

Cheers,
Marius
