### PR TITLE
Bugfix/indicate empty values in detail view 3907

### DIFF
--- a/modules/monitoring/application/views/scripts/list/hosts.phtml
+++ b/modules/monitoring/application/views/scripts/list/hosts.phtml
@@ -89,7 +89,8 @@ if (! $this->compact): ?>
                 <?php endif ?>
                     <span class="state-icons"><?= $this->hostFlags($host) ?></span>
                 </div>
-                <p class="overview-plugin-output"><?= $this->pluginOutput($this->ellipsis($host->host_output, 10000), true, $host->host_check_command) ?></p>
+                <?php $output = $host->host_output ?>
+                <p class="overview-plugin-output<?= strlen($output) == 0 ? ' empty': '' ?>"><?= strlen($output) == 0 ? $this->translate('This check has not returned any output') : $this->pluginOutput($this->ellipsis($output, 10000), true, $host->host_check_command) ?></p>
             </td>
         <?php foreach($this->addColumns as $col): ?>
             <td><?= $this->escape($host->$col) ?></td>

--- a/modules/monitoring/application/views/scripts/list/services.phtml
+++ b/modules/monitoring/application/views/scripts/list/services.phtml
@@ -116,7 +116,8 @@ if (! $this->compact): ?>
                     <div class="overview-performance-data">
                         <?= $this->perfdata($service->service_perfdata, true, 5) ?>
                     </div>
-                    <p class="overview-plugin-output"><?= $this->pluginOutput($this->ellipsis($service->service_output, 10000), true, $service->service_check_command) ?></p>
+                    <?php $output = $service->service_output ?>
+                    <p class="overview-plugin-output<?= strlen($output) == 0 ? ' empty': '' ?>"><?= strlen($output) == 0 ? $this->translate('This check has not returned any output') : $this->pluginOutput($this->ellipsis($output, 10000), true, $service->service_check_command) ?></p>
                 </div>
             </td>
         <?php foreach($this->addColumns as $col): ?>

--- a/modules/monitoring/application/views/scripts/show/components/output.phtml
+++ b/modules/monitoring/application/views/scripts/show/components/output.phtml
@@ -1,5 +1,9 @@
 <h2><?= $this->translate('Plugin Output') ?></h2>
 <div id="check-output-<?= $this->escape(str_replace(' ', '-', $object->check_command)) ?>" class="collapsible" data-visible-height="100">
+    <?php if (strlen($object->output) == 0 && strlen($object->long_output) == 0) {?>
+        <div class="plugin-output empty"><?= $this->translate('This check has not returned any output') ?></div>
+    <?php } else { ?>
     <?= $this->pluginOutput($object->output, false, $object->check_command) ?>
     <?= $this->pluginOutput($object->long_output, false, $object->check_command) ?>
+    <?php } ?>
 </div>

--- a/modules/monitoring/public/css/module.less
+++ b/modules/monitoring/public/css/module.less
@@ -652,6 +652,22 @@ form.instance-features span.description, form.object-features span.description {
     color: @body-bg-color;
     padding: 0.2em;
   }
+
+  &.empty {
+    opacity: .6;
+    border-left-color: @gray-lighter;
+    background: @gray-lighter;
+    .rounded-corners()
+  }
+}
+
+.plugin-output,
+.overview-plugin-output {
+  &.empty {
+    font-style: italic;
+    opacity: .6;
+    font-family: @font-family;
+  }
 }
 
 .go-ahead,


### PR DESCRIPTION
Here's my draft for #3907 .

I opted for having the empty state in list view as well. Since it makes it clearer, that there's no output.

I see the argument of reduced information density in edge cases. But it also helps to make objects stand out better if there's an additional lack of plugin output. We should chose better over more.