### PR TITLE
Improve LDAP/ActiveDirectory authentication

### DIFF
--- a/application/forms/Config/UserBackend/LdapBackendForm.php
+++ b/application/forms/Config/UserBackend/LdapBackendForm.php
@@ -262,6 +262,7 @@ class LdapBackendForm extends Form
                     . ' authenticating the user based on the username without the domain part.'
                     . ' If your LDAP backend holds usernames with a domain part or if it is not necessary in your setup'
                     . ' to authenticate users based on their domains, leave this field empty.'
+                    . ' (Can be a comma separated list)'
                 ),
                 'preserveDefault' => true,
                 'value'         => $this->getSuggestion('domain')
@@ -378,14 +379,16 @@ class LdapBackendForm extends Form
     {
         $cap = $this->getLdapCapabilities($formData);
 
+        $domain = $this->defaultNamingContextToFQDN($cap);
+
         if ($cap->isActiveDirectory()) {
             $netBiosName = $cap->getNetBiosName();
             if ($netBiosName !== null) {
-                return $netBiosName;
+                $domain .= ',' . $netBiosName;
             }
         }
 
-        return $this->defaultNamingContextToFQDN($cap);
+        return $domain;
     }
 
     /**

--- a/application/forms/Config/UserBackend/LdapBackendForm.php
+++ b/application/forms/Config/UserBackend/LdapBackendForm.php
@@ -121,11 +121,13 @@ class LdapBackendForm extends Form
             $userClass = 'user';
             $filter = '!(objectClass=computer)';
             $userNameAttribute = 'sAMAccountName';
+            $userNameLookup = 'userPrincipalName';
         } else {
             // OpenLDAP defaults
             $userClass = 'inetOrgPerson';
             $filter = null;
             $userNameAttribute = 'uid';
+            $userNameLookup = '';
         }
 
         $this->addElement(
@@ -191,6 +193,23 @@ class LdapBackendForm extends Form
                     'The attribute name used for storing the user name on the LDAP server.'
                 ),
                 'value'             => $this->getSuggestion('user_name_attribute', $userNameAttribute)
+            )
+        );
+
+        $this->addElement(
+            'text',
+            'user_name_lookup',
+            array(
+                'preserveDefault'   => true,
+                'label'             => $this->translate('LDAP User Name Lookup'),
+                'description'       => $this->translate(
+                    'Alternative attributes to check for the username.'
+                    . ' This will search for users where this field is the entered username oder user@domain.'
+                    . ' Can be used for matching with a Kerberos principal or email addresses.'
+                    . ' The authenticated username will be taken from the User Name Attribute.'
+                    . ' (Can be a list of comma separated attributes)'
+                ),
+                'value'             => $this->getSuggestion('user_name_lookup', $userNameLookup)
             )
         );
         $this->addElement(

--- a/application/forms/Config/UserBackend/LdapBackendForm.php
+++ b/application/forms/Config/UserBackend/LdapBackendForm.php
@@ -217,6 +217,20 @@ class LdapBackendForm extends Form
         );
 
         $this->addElement(
+            'checkbox',
+            'external_auth',
+            array(
+                'label'           => $this->translate('External Auth'),
+                'description'     => $this->translate(
+                    'Handle external authentication via the REMOTE_USER variable.'
+                    . ' This will only accept users found in the backend to be authenticated via external auth.'
+                ),
+                'preserveDefault' => true,
+                'value'           => $this->getSuggestion('external_auth')
+            )
+        );
+
+        $this->addElement(
             'text',
             'domain',
             array(

--- a/library/Icinga/Authentication/Auth.php
+++ b/library/Icinga/Authentication/Auth.php
@@ -8,6 +8,7 @@ use Icinga\Application\Config;
 use Icinga\Application\Hook\AuditHook;
 use Icinga\Application\Icinga;
 use Icinga\Application\Logger;
+use Icinga\Authentication\User\ExternalAuthInterface;
 use Icinga\Authentication\User\ExternalBackend;
 use Icinga\Authentication\UserGroup\UserGroupBackend;
 use Icinga\Data\ConfigObject;
@@ -283,7 +284,7 @@ class Auth
     {
         $user = new User('');
         foreach ($this->getAuthChain() as $userBackend) {
-            if ($userBackend instanceof ExternalBackend) {
+            if ($userBackend instanceof ExternalAuthInterface) {
                 if ($userBackend->authenticate($user)) {
                     if (! $user->hasDomain()) {
                         $user->setDomain(Config::app()->get('authentication', 'default_domain'));

--- a/library/Icinga/Authentication/User/ExternalAuthInterface.php
+++ b/library/Icinga/Authentication/User/ExternalAuthInterface.php
@@ -1,0 +1,16 @@
+<?php
+/* Icinga Web 2 | (c) 2019 Icinga Development Team | GPLv2+ */
+
+namespace Icinga\Authentication\User;
+
+use Icinga\User;
+
+/**
+ * Test login with external authentication mechanism, e.g. Apache
+ */
+interface ExternalAuthInterface extends UserBackendInterface
+{
+    public function authenticateExternal(User $user);
+
+    public function authenticate(User $user, $password = null);
+}

--- a/library/Icinga/Authentication/User/ExternalAuthTrait.php
+++ b/library/Icinga/Authentication/User/ExternalAuthTrait.php
@@ -1,0 +1,82 @@
+<?php
+/* Icinga Web 2 | (c) 2019 Icinga Development Team | GPLv2+ */
+
+namespace Icinga\Authentication\User;
+
+use Icinga\User;
+
+/**
+ * Test login with external authentication mechanism, e.g. Apache
+ */
+trait ExternalAuthTrait
+{
+    /**
+     * Possible variables where to read the user from
+     *
+     * @var string[]
+     */
+    public static $remoteUserEnvvars = array('REMOTE_USER', 'REDIRECT_REMOTE_USER');
+
+    /**
+     * Get the remote user from environment or $_SERVER, if any
+     *
+     * @param   string  $variable   The name of the variable where to read the user from
+     *
+     * @return  string|null
+     */
+    public static function getRemoteUser($variable = 'REMOTE_USER')
+    {
+        $username = getenv($variable);
+        if ($username !== false) {
+            return $username;
+        }
+
+        if (array_key_exists($variable, $_SERVER)) {
+            return $_SERVER[$variable];
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the remote user information from environment or $_SERVER, if any
+     *
+     * @return  array   Contains always two entries, the username and origin which may both set to null.
+     */
+    public static function getRemoteUserInformation()
+    {
+        foreach (static::$remoteUserEnvvars as $envVar) {
+            $username = static::getRemoteUser($envVar);
+            if ($username !== null) {
+                return [$username, $envVar];
+            }
+        }
+
+        return [null, null];
+    }
+
+    /**
+     * Try external authentication and set username
+     *
+     * Should be called from authenticate() to implement the support for external auth
+     *
+     * @param User $user
+     * @param bool $updateUser
+     *
+     * @return array|false with $username and $field
+     */
+    public function authenticateExternal(User $user, $updateUser = true)
+    {
+        list($username, $field) = static::getRemoteUserInformation();
+        if ($username !== null) {
+            if ($updateUser) {
+                $user->setExternalUserInformation($username, $field);
+                $user->setUsername($username);
+            }
+
+            return [$username, $field];
+        }
+
+        return false;
+    }
+}

--- a/library/Icinga/Authentication/User/ExternalBackend.php
+++ b/library/Icinga/Authentication/User/ExternalBackend.php
@@ -10,14 +10,9 @@ use Icinga\User;
 /**
  * Test login with external authentication mechanism, e.g. Apache
  */
-class ExternalBackend implements UserBackendInterface
+class ExternalBackend implements UserBackendInterface, ExternalAuthInterface
 {
-    /**
-     * Possible variables where to read the user from
-     *
-     * @var string[]
-     */
-    public static $remoteUserEnvvars = array('REMOTE_USER', 'REDIRECT_REMOTE_USER');
+    use ExternalAuthTrait;
 
     /**
      * The name of this backend
@@ -61,64 +56,25 @@ class ExternalBackend implements UserBackendInterface
     }
 
     /**
-     * Get the remote user from environment or $_SERVER, if any
-     *
-     * @param   string  $variable   The name of the variable where to read the user from
-     *
-     * @return  string|null
-     */
-    public static function getRemoteUser($variable = 'REMOTE_USER')
-    {
-        $username = getenv($variable);
-        if ($username !== false) {
-            return $username;
-        }
-
-        if (array_key_exists($variable, $_SERVER)) {
-            return $_SERVER[$variable];
-        }
-    }
-
-    /**
-     * Get the remote user information from environment or $_SERVER, if any
-     *
-     * @return  array   Contains always two entries, the username and origin which may both set to null.
-     */
-    public static function getRemoteUserInformation()
-    {
-        foreach (static::$remoteUserEnvvars as $envVar) {
-            $username = static::getRemoteUser($envVar);
-            if ($username !== null) {
-                return array($username, $envVar);
-            }
-        }
-
-        return array(null, null);
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function authenticate(User $user, $password = null)
     {
-        list($username, $field) = static::getRemoteUserInformation();
-        if ($username !== null) {
-            $user->setExternalUserInformation($username, $field);
-
-            if ($this->stripUsernameRegexp) {
-                $stripped = @preg_replace($this->stripUsernameRegexp, '', $username);
-                if ($stripped === false) {
-                    Logger::error('Failed to strip external username. The configured regular expression is invalid.');
-                    return false;
-                }
-
-                $username = $stripped;
-            }
-
-            $user->setUsername($username);
-            return true;
+        $external = $this->authenticateExternal($user);
+        if (! $external) {
+            return false;
         }
 
-        return false;
+        if ($this->stripUsernameRegexp) {
+            $stripped = @preg_replace($this->stripUsernameRegexp, '', $external[0]);
+            if ($stripped === false) {
+                Logger::error('Failed to strip external username. The configured regular expression is invalid.');
+                return false;
+            }
+
+            $user->setUsername($stripped);
+        }
+
+        return true;
     }
 }

--- a/library/Icinga/Authentication/User/LdapUserBackend.php
+++ b/library/Icinga/Authentication/User/LdapUserBackend.php
@@ -60,11 +60,11 @@ class LdapUserBackend extends LdapRepository implements
     protected $filter;
 
     /**
-     * The domain the backend is responsible for
+     * The domains the backend is responsible for
      *
-     * @var string
+     * @var array
      */
-    protected $domain;
+    protected $domains;
 
     /**
      * The columns which are not permitted to be queried
@@ -226,24 +226,43 @@ class LdapUserBackend extends LdapRepository implements
         return $this->filter;
     }
 
+    /**
+     * Return the primary domain for this backend, which is the first or only set
+     *
+     * @return string|null
+     */
     public function getDomain()
     {
-        return $this->domain;
+        if (empty($this->domains)) {
+            return null;
+        }
+        $domains = $this->domains;
+        return current($domains);
     }
 
     /**
-     * Set the domain the backend is responsible for
+     * Return all domains set for this backend
      *
-     * @param   string  $domain
+     * @return array|null
+     */
+    public function getDomains()
+    {
+        return $this->domains;
+    }
+
+    /**
+     * Set the domains the backend is responsible for
+     *
+     * @param   string|array  $domains
      *
      * @return  $this
      */
-    public function setDomain($domain)
+    public function setDomain($domains)
     {
-        $domain = trim($domain);
-
-        if (strlen($domain)) {
-            $this->domain = $domain;
+        if ($domains === null || is_array($domains)) {
+            $this->domains = $domains;
+        } else {
+            $this->domains = StringHelper::trimSplit($domains);
         }
 
         return $this;
@@ -439,8 +458,9 @@ class LdapUserBackend extends LdapRepository implements
         }
 
         $fullUsername = null;
-        if ($this->domain !== null) {
-            if (! $user->hasDomain() || strtolower($user->getDomain()) !== strtolower($this->domain)) {
+        if (! empty($this->domains)) {
+            $domains = array_map('strtolower', $this->domains);
+            if (! $user->hasDomain() || ! in_array(strtolower($user->getDomain()), $domains)) {
                 return false;
             }
 

--- a/library/Icinga/Authentication/User/UserBackend.php
+++ b/library/Icinga/Authentication/User/UserBackend.php
@@ -217,6 +217,7 @@ class UserBackend implements ConfigAwareFactory
                 $backend->setBaseDn($backendConfig->base_dn);
                 $backend->setUserClass($backendConfig->get('user_class', 'user'));
                 $backend->setUserNameAttribute($backendConfig->get('user_name_attribute', 'sAMAccountName'));
+                $backend->setExternalAuth($backendConfig->get('external_auth', false));
                 $backend->setFilter($backendConfig->filter);
                 $backend->setDomain($backendConfig->domain);
                 break;
@@ -225,6 +226,7 @@ class UserBackend implements ConfigAwareFactory
                 $backend->setBaseDn($backendConfig->base_dn);
                 $backend->setUserClass($backendConfig->get('user_class', 'inetOrgPerson'));
                 $backend->setUserNameAttribute($backendConfig->get('user_name_attribute', 'uid'));
+                $backend->setExternalAuth($backendConfig->get('external_auth', false));
                 $backend->setFilter($backendConfig->filter);
                 $backend->setDomain($backendConfig->domain);
                 break;

--- a/library/Icinga/Authentication/User/UserBackend.php
+++ b/library/Icinga/Authentication/User/UserBackend.php
@@ -217,6 +217,7 @@ class UserBackend implements ConfigAwareFactory
                 $backend->setBaseDn($backendConfig->base_dn);
                 $backend->setUserClass($backendConfig->get('user_class', 'user'));
                 $backend->setUserNameAttribute($backendConfig->get('user_name_attribute', 'sAMAccountName'));
+                $backend->setUserNameLookup($backendConfig->get('user_name_lookup', 'userPrincipalName'));
                 $backend->setExternalAuth($backendConfig->get('external_auth', false));
                 $backend->setFilter($backendConfig->filter);
                 $backend->setDomain($backendConfig->domain);
@@ -226,6 +227,7 @@ class UserBackend implements ConfigAwareFactory
                 $backend->setBaseDn($backendConfig->base_dn);
                 $backend->setUserClass($backendConfig->get('user_class', 'inetOrgPerson'));
                 $backend->setUserNameAttribute($backendConfig->get('user_name_attribute', 'uid'));
+                $backend->setUserNameLookup($backendConfig->get('user_name_lookup'));
                 $backend->setExternalAuth($backendConfig->get('external_auth', false));
                 $backend->setFilter($backendConfig->filter);
                 $backend->setDomain($backendConfig->domain);

--- a/library/Icinga/Authentication/User/UserBackendInterface.php
+++ b/library/Icinga/Authentication/User/UserBackendInterface.php
@@ -4,7 +4,6 @@
 namespace Icinga\Authentication\User;
 
 use Icinga\Authentication\Authenticatable;
-use Icinga\User;
 
 /**
  * Interface for user backends


### PR DESCRIPTION
This PR bundles several improvements for LDAP and ActiveDirectory

## Changes

- [x] Implement Interface and Trait for external auth
      So one can implement it in other backends - so the backend can verify the externally set user
- [x] Implement external auth for any LDAP backend
      A user will only be logged in if the account exists in LDAP
- [x] Allow alternative attributes (multiple) in LDAP to lookup the user
      `userPrincipalName` is look upped in addition to `sAMAccountName` to find a user, but the user attribute is used then to identify the user in Icinga Web 2
- [x] Allow multiple domains for the (LDAP) backends
      So LDAP Forest, Kerberos Realm and possible E-Mails can be matched
      Also detect LDAP Naming Context **and** NETBIOS name by default
- [ ] Update authentication documentation, especially with examples
- [ ] Review Auth forms and update translation

## Target Audience

* Multi-Domain authentication
* Kerberos users (on webserver in front of Icinga Web 2)
* LDAP or AD where sAMAccountName and LDAP Domain is not used to build the Kerberos principal
  Example (which is valid in ActiveDirectory):

## Examples

Usernames vs. Kerberos principal must not match, maybe an e-mail address could also be used.

```
LDAP Domain:       ad.company.net
sAMAccountName:    ABCDEF
userPrincipalName: john.doe@company.com
mail:              john@company.biz
```

## Benefits

* External Auth can depend on a user backend, which may verify the user exists or is in a required group
* External Auth can now fail back to a login form to ask for other credentials
* Other names can be assigned to a user, e.g. e-mail, Kerberos principal or alternative user names

## Tests

TBD

ref/NC/628947