### PR TITLE
Add custom tab hook

### DIFF
--- a/modules/monitoring/application/views/scripts/object/detail-tabhook.phtml
+++ b/modules/monitoring/application/views/scripts/object/detail-tabhook.phtml
@@ -1,0 +1,21 @@
+<?php
+
+if (! $this->compact): ?>
+<div class="controls separated">
+    <?= $this->tabs ?>
+<?php
+if ($this->header === true) {
+    if ($object->type === 'service') {
+        echo $this->render('partials/object/service-header.phtml');
+    } else {
+        echo $this->render('partials/object/host-header.phtml');
+    }
+} elseif ($this->header !== false) {
+    echo $this->header;
+}
+?>
+</div>
+<?php endif ?>
+<div class="content">
+    <?= $this->content ?>
+</div>

--- a/modules/monitoring/library/Monitoring/Hook/ObjectDetailsTabHook.php
+++ b/modules/monitoring/library/Monitoring/Hook/ObjectDetailsTabHook.php
@@ -1,0 +1,60 @@
+<?php
+/* Icinga Web 2 | (c) 2016 Icinga Development Team | GPLv2+ */
+
+namespace Icinga\Module\Monitoring\Hook;
+
+use Icinga\Authentication\Auth;
+use Icinga\Module\Monitoring\Object\MonitoredObject;
+use Icinga\Web\Request;
+
+/**
+ * Base class for object host details custom tab hooks
+ */
+abstract class ObjectDetailsTabHook
+{
+    /**
+     * Return the tab name - it must be unique
+     *
+     * @return  string
+     */
+    abstract public function getName();
+
+    /**
+     * Return the tab label
+     *
+     * @return  string
+     */
+    abstract public function getLabel();
+
+    /**
+     * Return the tab header
+     *
+     * @param MonitoredObject $monitoredObject The monitored object related to that page
+     * @param Request $request
+     * @return  string/bool The HTML string that compose the tab header,
+     *          bool True if the default header should be shown, False to display nothing
+     */
+    public function getHeader(MonitoredObject $monitoredObject, Request $request)
+    {
+        return true;
+    }
+
+    /**
+     * Return the tab content
+     *
+     * @param MonitoredObject $monitoredObject The monitored object related to that page
+     * @param Request $request
+     * @return  string The HTML string that compose the tab content
+     */
+    abstract public function getContent(MonitoredObject $monitoredObject, Request $request);
+
+    /**
+     * This method returns true if the tab is visible for the logged user, otherwise false
+     *
+     * @return  bool True if the tab is visible for the logged user, otherwise false
+     */
+    public function shouldBeShown(MonitoredObject $monitoredObject, Auth $auth)
+    {
+        return true;
+    }
+}

--- a/modules/monitoring/library/Monitoring/Web/Controller/MonitoredObjectController.php
+++ b/modules/monitoring/library/Monitoring/Web/Controller/MonitoredObjectController.php
@@ -12,6 +12,7 @@ use Icinga\Module\Monitoring\Forms\Command\Object\ObjectsCommandForm;
 use Icinga\Module\Monitoring\Forms\Command\Object\RemoveAcknowledgementCommandForm;
 use Icinga\Module\Monitoring\Forms\Command\Object\ToggleObjectFeaturesCommandForm;
 use Icinga\Module\Monitoring\Hook\DetailviewExtensionHook;
+use Icinga\Module\Monitoring\Hook\ObjectDetailsTabHook;
 use Icinga\Web\Hook;
 use Icinga\Web\Url;
 use Icinga\Web\Widget\Tabextension\DashboardAction;
@@ -35,6 +36,13 @@ abstract class MonitoredObjectController extends Controller
      * @var string
      */
     protected $commandRedirectUrl;
+
+    /**
+     * List of visible hooked tabs
+     *
+     * @var ObjectDetailsTabHook[]
+     */
+    protected $tabHooks = [];
 
     /**
      * (non-PHPDoc)
@@ -115,6 +123,22 @@ abstract class MonitoredObjectController extends Controller
         $this->setupPaginationControl($this->view->history, 50);
         $this->view->object = $this->object;
         $this->render('object/detail-history', null, true);
+    }
+
+    /**
+     * Show the content of a custom tab
+     */
+    public function tabhookAction()
+    {
+        $hookName = $this->params->get('hook');
+        $this->getTabs()->activate($hookName);
+
+        $hook = $this->tabHooks[$hookName];
+
+        $this->view->header = $hook->getHeader($this->object, $this->getRequest());
+        $this->view->content = $hook->getContent($this->object, $this->getRequest());
+        $this->view->object = $this->object;
+        $this->render('object/detail-tabhook', null, true);
     }
 
     /**
@@ -262,6 +286,20 @@ abstract class MonitoredObjectController extends Controller
                 )
             );
         }
+
+        /** @var ObjectDetailsTabHook $hook */
+        foreach (Hook::all('Monitoring\\ObjectDetailsTab') as $hook) {
+            $hookName = $hook->getName();
+            if ($hook->shouldBeShown($object, $this->Auth())) {
+                $this->tabHooks[$hookName] = $hook;
+                $tabs->add($hookName, [
+                    'label' => $hook->getLabel(),
+                    'url'       => $isService ? 'monitoring/service/tabhook' : 'monitoring/host/tabhook',
+                    'urlParams' => $params + [ 'hook' => $hookName ]
+                ]);
+            }
+        }
+
         $tabs->extend(new DashboardAction())->extend(new MenuAction());
     }
 


### PR DESCRIPTION
This is an implementation of a new hook that allows to add custom tab to the detail view on monitoring for hosts and services.