### PR TITLE
Introduce option to hide specific customvars in web

### DIFF
--- a/modules/monitoring/application/forms/Config/SecurityConfigForm.php
+++ b/modules/monitoring/application/forms/Config/SecurityConfigForm.php
@@ -61,6 +61,21 @@ class SecurityConfigForm extends ConfigForm
                 )
             )
         );
+
+        $this->addElement(
+            'text',
+            'hidden_customvars',
+            array(
+                'allowEmpty'    => true,
+                'attribs'       => array('placeholder' => $this->getDefaultProtectedCustomvars()),
+                'label'         => $this->translate('Hidden Custom Variables'),
+                'description'   => $this->translate(
+                    'Comma separated case insensitive list of hidden custom variables.'
+                    . ' Use * as a placeholder for zero or more wildcard characters.'
+                    . ' Existence of those custom variables will not be shown, but remain usable for modules.'
+                )
+            )
+        );
     }
 
     /**

--- a/modules/monitoring/library/Monitoring/Object/MonitoredObject.php
+++ b/modules/monitoring/library/Monitoring/Object/MonitoredObject.php
@@ -419,7 +419,9 @@ abstract class MonitoredObject implements Filterable
     public function fetchCustomvars()
     {
         $blacklist = array();
+        $hidden = array();
         $blacklistPattern = '';
+        $hiddenPattern = '';
 
         if (($blacklistConfig = Config::module('monitoring')->get('security', 'protected_customvars', '')) !== '') {
             foreach (explode(',', $blacklistConfig) as $customvar) {
@@ -430,6 +432,17 @@ abstract class MonitoredObject implements Filterable
                 $blacklist[] = implode('.*', $nonWildcards);
             }
             $blacklistPattern = '/^(' . implode('|', $blacklist) . ')$/i';
+        }
+
+        if (($hiddenConfig = Config::module('monitoring')->get('security', 'hidden_customvars', '')) !== '') {
+            foreach (explode(',', $hiddenConfig) as $customvar) {
+                $nonWildcards = array();
+                foreach (explode('*', $customvar) as $nonWildcard) {
+                    $nonWildcards[] = preg_quote($nonWildcard, '/');
+                }
+                $hidden[] = implode('.*', $nonWildcards);
+            }
+            $hiddenPattern = '/^(' . implode('|', $hidden) . ')$/i';
         }
 
         if ($this->type === self::TYPE_SERVICE) {
@@ -445,6 +458,12 @@ abstract class MonitoredObject implements Filterable
 
         if ($blacklistPattern) {
             $this->customvars = $this->obfuscateCustomVars($this->customvars, $blacklistPattern);
+        }
+
+        if ($hiddenPattern) {
+            $this->customvars = array_filter($this->customvars, function ($elem) use ($hiddenPattern) {
+                return  !($hiddenPattern && preg_match($hiddenPattern, $elem));
+            },ARRAY_FILTER_USE_KEY);
         }
 
         return $this;

--- a/modules/monitoring/library/Monitoring/Object/MonitoredObject.php
+++ b/modules/monitoring/library/Monitoring/Object/MonitoredObject.php
@@ -463,7 +463,7 @@ abstract class MonitoredObject implements Filterable
         if ($hiddenPattern) {
             $this->customvars = array_filter($this->customvars, function ($elem) use ($hiddenPattern) {
                 return  !($hiddenPattern && preg_match($hiddenPattern, $elem));
-            },ARRAY_FILTER_USE_KEY);
+            }, ARRAY_FILTER_USE_KEY);
         }
 
         return $this;


### PR DESCRIPTION
This PR introduces a new configuration option and filter for hiding specific customvars in the detail view of a host or service. It uses the same matching syntax as the existing blacklist feature.

Should be useful in environments which make heavy use of apply rules on customvars, which are often cryptic and bloat the customvar section in web. 

