### PR TITLE
Also trim trailing whitespace from search values

### DIFF
--- a/library/Icinga/Web/Widget/FilterEditor.php
+++ b/library/Icinga/Web/Widget/FilterEditor.php
@@ -274,7 +274,7 @@ class FilterEditor extends AbstractWidget
                         $filter = Filter::matchAll();
                     }
                     $filters = array();
-                    $search = ltrim($search);
+                    $search = trim($search);
                     foreach ($this->searchColumns as $searchColumn) {
                         $filters[] = Filter::expression($searchColumn, '=', "*$search*");
                     }


### PR DESCRIPTION
Simple values are wrapped with `*` anyway, so trimming all
whitespace doesn't pose an issue. (Even if inserted intentionally)
This doesn't apply to qualified search values. (e.g. `host = abc `)

resolves #4002