### PR TITLE
Move form colours to the base.less

### DIFF
--- a/public/css/icinga/base.less
+++ b/public/css/icinga/base.less
@@ -9,10 +9,10 @@
 @gray-light: #C9C9C9;
 @gray-lighter: #EEEEEE;
 @gray-lightest: #F7F7F7;
+@disabled-gray: #9a9a9a;
 
-// Icinga colors
-@icinga-blue: #0095BF;
-@icinga-secondary: #EF4F98;
+
+// State colors
 @color-ok: #44bb77;
 @color-up: @color-ok;
 @color-warning: #ffaa44;
@@ -26,6 +26,14 @@
 @color-unreachable: @color-unknown;
 @color-unreachable-handled: @color-unknown-handled;
 @color-pending: #77aaff;
+
+// Icinga colors
+@icinga-blue: #0095BF;
+@icinga-secondary: #EF4F98;
+@low-sat-blue: #dae3e6;
+@low-sat-blue-dark: #becbcf;
+@icinga-blue-light: #a5c4cd;
+@icinga-blue-dark: #0081a6;
 
 // Notification colors
 @color-notification-error: @color-critical;

--- a/public/css/icinga/forms.less
+++ b/public/css/icinga/forms.less
@@ -9,14 +9,6 @@
      this class gets our design applied
  */
 
-// Used colors
-
-@disabled-gray: #9a9a9a;
-@low-sat-blue: #dae3e6;
-@low-sat-blue-dark: #becbcf;
-@icinga-blue-light: #a5c4cd;
-@icinga-blue-dark: #0081a6;
-
 // General form layout
 
 form.icinga-form {


### PR DESCRIPTION
Move colours to base less, so people who build themes have a better overview over which colours can and should be changed.
Especially since those colours are not form-exclusive anymore in Icinga DB.