### PR TITLE
Fix the CreateMembershipForm to respect the users domain on adding as member

### DIFF
--- a/application/controllers/UserController.php
+++ b/application/controllers/UserController.php
@@ -247,7 +247,8 @@ class UserController extends AuthBackendController
         }
 
         $form = new CreateMembershipForm();
-        $form->setBackends($backends)
+        $form->setUserBackend($backend)
+            ->setBackends($backends)
             ->setUsername($userName)
             ->setRedirectUrl(Url::fromPath('user/show', array('backend' => $backend->getName(), 'user' => $userName)))
             ->handleRequest();


### PR DESCRIPTION
When adding a Ldap user with an domain to a DbGroupBackend we need to include the domain into the stored username.

At the moment, the user is stored as `mfrosch` and not `mfrosch@NETWAYS`.

This PR tries to fix this, it should fix the current situation, but should be revised when implementing #4033 

ref/NC/627897