### PR TITLE
Add error message to webrouter.php for custom setups

### DIFF
--- a/library/Icinga/Application/webrouter.php
+++ b/library/Icinga/Application/webrouter.php
@@ -15,7 +15,7 @@ if (isset($_SERVER['REQUEST_URI'])) {
     return false;
 }
 
-// Workaround, PHPs internal Webserver seems to mess up SCRIPT_FILENAME
+// Workaround, PHPs built-in web server seems to mess up SCRIPT_FILENAME
 // as it prefixes it's absolute path with DOCUMENT_ROOT
 if (preg_match('/^PHP .* Development Server/', $_SERVER['SERVER_SOFTWARE'])) {
     $script = basename($_SERVER['SCRIPT_FILENAME']);

--- a/library/Icinga/Application/webrouter.php
+++ b/library/Icinga/Application/webrouter.php
@@ -25,21 +25,19 @@ if (preg_match('/^PHP .* Development Server/', $_SERVER['SERVER_SOFTWARE'])) {
       . $script;
 }
 
-$baseDir = $_SERVER['DOCUMENT_ROOT'];
 $baseDir = dirname($_SERVER['SCRIPT_FILENAME']);
 
 // Fix aliases
 $remove = str_replace('\\', '/', dirname($_SERVER['PHP_SELF']));
-if (substr($ruri, 0, strlen($remove)) !== $remove) {
+if (strpos($ruri, $remove) !== 0) {
     return false;
 }
 $ruri = ltrim(substr($ruri, strlen($remove)), '/');
 
 if (strpos($ruri, '?') === false) {
-    $params = '';
     $path = $ruri;
 } else {
-    list($path, $params) = preg_split('/\?/', $ruri, 2);
+    list($path) = explode("?", $ruri, 2);
 }
 
 $special = array(

--- a/library/Icinga/Application/webrouter.php
+++ b/library/Icinga/Application/webrouter.php
@@ -30,6 +30,12 @@ $baseDir = dirname($_SERVER['SCRIPT_FILENAME']);
 // Fix aliases
 $remove = str_replace('\\', '/', dirname($_SERVER['PHP_SELF']));
 if (strpos($ruri, $remove) !== 0) {
+    $error_msg = sprintf(
+        'The first path segment was expected to start with "%s", but "%s" was found instead. ' .
+        'To fix this, check your web server configuration, not the Icinga Web 2 configuration.',
+        $remove,
+        $ruri);
+    trigger_error($error_msg, E_USER_NOTICE);
     return false;
 }
 $ruri = ltrim(substr($ruri, strlen($remove)), '/');


### PR DESCRIPTION
This pull requests adds a message for broken HTTP configurations to save administrators time. In a typical configuration, the new message will be added to the error log of the HTTP server, for example Apache or NGINX.

I lost a few hours trying to figure out the Apache2 configuration that Icinga Web 2 expects.