### PR TITLE
Fixed %s database name in DE translation

### DIFF
--- a/modules/setup/application/locale/de_DE/LC_MESSAGES/setup.po
+++ b/modules/setup/application/locale/de_DE/LC_MESSAGES/setup.po
@@ -1113,7 +1113,7 @@ msgstr ""
 
 #: ../../../../library/Setup/Steps/DatabaseStep.php:252
 msgid "The database has been fully set up!"
-msgstr "Die Datenbank \"%s\" wurde vollständig eingerichtet!"
+msgstr "Die Datenbank wurde vollständig eingerichtet!"
 
 #: ../../../../library/Setup/Steps/DatabaseStep.php:216
 #, php-format


### PR DESCRIPTION
At the end of the Icinga Web 2 setup procedure, there's a nice welcome greeting.

Since there's no database name in the [original message], there's no text that could be replaced by the %s.

This is untested. Please let me know if there are other lines/files that have to be changed in order to make this work.

Kind regards,
Bernd

[original message] https://github.com/Icinga/icingaweb2/blob/81bb5272b59491ad021bcf0a5fefc582ce0112c4/modules/setup/library/Setup/Steps/DatabaseStep.php#L252