### PR TITLE
JS/Modal: Use Icinga.Utils.addUrlFlag()

### DIFF
--- a/public/js/icinga/behavior/modal.js
+++ b/public/js/icinga/behavior/modal.js
@@ -42,8 +42,8 @@
         var $modal = _this.$ghost.clone();
         var $urlTarget = _this.icinga.loader.getLinkTargetFor($a);
 
-        // Add view=compact, we don't want controls in a modal
-        url = _this.icinga.utils.addUrlParams(url, { 'view': 'compact' });
+        // Add showCompact, we don't want controls in a modal
+        url = _this.icinga.utils.addUrlFlag(url, 'showCompact');
 
         // Set the toggle's base target on the modal to use it as redirect target
         $modal.data('redirectTarget', $urlTarget);


### PR DESCRIPTION
Icinga.utils.addUrlParams() is not capable of handling our URL filter
syntax but Icinga.Utils.addUrlFlag() is (kind of :D).

requires #4053