### PR TITLE
JS: Respect container in Icinga.Ui.focusElement()

### DIFF
--- a/public/js/icinga/ui.js
+++ b/public/js/icinga/ui.js
@@ -153,7 +153,11 @@
             var $element = element;
 
             if (typeof element === 'string') {
-                $element = $('#' + element);
+                if ($container && $container.length) {
+                    $element = $container.find('#' + element);
+                } else {
+                    $element = $('#' + element);
+                }
 
                 if (! $element.length) {
                     // The name attribute is actually deprecated, on anchor tags,


### PR DESCRIPTION
Though IDs should be unique across the whole page, focusElement() must
not fail if there is the same anchor in the left and right column.
focusElement() now also respects the container when searching the
element to focus by ID.