### PR TITLE
CLI: Setup fake auth

### DIFF
--- a/library/Icinga/Application/Cli.php
+++ b/library/Icinga/Application/Cli.php
@@ -5,6 +5,7 @@ namespace Icinga\Application;
 
 use Icinga\Application\Platform;
 use Icinga\Application\ApplicationBootstrap;
+use Icinga\Authentication\Auth;
 use Icinga\Cli\Params;
 use Icinga\Cli\Loader;
 use Icinga\Cli\Screen;
@@ -12,6 +13,7 @@ use Icinga\Application\Logger;
 use Icinga\Application\Benchmark;
 use Icinga\Data\ConfigObject;
 use Icinga\Exception\ProgrammingError;
+use Icinga\User;
 
 require_once __DIR__ . '/ApplicationBootstrap.php';
 
@@ -43,7 +45,8 @@ class Cli extends ApplicationBootstrap
             ->setupLogger()
             ->setupModuleManager()
             ->setupUserBackendFactory()
-            ->loadSetupModuleIfNecessary();
+            ->loadSetupModuleIfNecessary()
+            ->setupFakeAuthentication();
     }
 
     /**
@@ -84,6 +87,13 @@ class Cli extends ApplicationBootstrap
         }
 
         Logger::create($config);
+        return $this;
+    }
+
+    protected function setupFakeAuthentication()
+    {
+        Auth::getInstance()->setUser(new User('cli'));
+
         return $this;
     }
 

--- a/library/Icinga/Authentication/Auth.php
+++ b/library/Icinga/Authentication/Auth.php
@@ -257,6 +257,23 @@ class Auth
     }
 
     /**
+     * Set the authenticated user
+     *
+     * Note that this method just sets the authenticated user and thus bypasses our default authentication process in
+     * {@link setAuthenticated()}.
+     *
+     * @param User $user
+     *
+     * @return $this
+     */
+    public function setUser(User $user)
+    {
+        $this->user = $user;
+
+        return $this;
+    }
+
+    /**
      * Try to authenticate the user with the current session
      *
      * Authentication for externally-authenticated users will be revoked if the username changed or external


### PR DESCRIPTION
Since version 2.7.x CLI actions load all enabled modules automatically.
This includes launching configuration.php and run.php. Though code
in those files should be restricted to a supported set of functions,
module devs may write any code here. If a module requires authentication
in those files, CLI actions fail because there is no auth possible.
With this patch, we setup a fake user named "cli" w/o any permission when
running CLI actions.