### PR TITLE
Set default IDO charset to latin1

### DIFF
--- a/modules/monitoring/library/Monitoring/Backend/MonitoringBackend.php
+++ b/modules/monitoring/library/Monitoring/Backend/MonitoringBackend.php
@@ -222,7 +222,11 @@ class MonitoringBackend implements Selectable, Queryable, ConnectionInterface
     public function getResource()
     {
         if ($this->resource === null) {
-            $this->resource = ResourceFactory::create($this->config->get('resource'));
+            $config = ResourceFactory::getResourceConfig($this->config->get('resource'));
+            if ($this->is('ido') && $config->type === 'db' && $config->db === 'mysql' && $config->charset === null) {
+                $config->charset = 'latin1';
+            }
+            $this->resource = ResourceFactory::createResource($config);
             if ($this->is('ido') && $this->resource->getDbType() !== 'oracle') {
                 // TODO(el): The resource should set the table prefix
                 $this->resource->setTablePrefix('icinga_');


### PR DESCRIPTION
latin1 seems to be the only supported charset for MySQL but the current upstream default charset is utf8mb4.

It would be preferable to switch the charset used by icinga to utf8mb4 and the corresponding collations but since there doesn't seem to be any intention of doing this, latin1 should be set explicitly.

This is even more important since the IdoMysqlConnection does not have an attribute to set the charset manually.

This does not seem to be the best place to set the charset but it does not seem that it is used by anything other than the MySQL adapter.

This fixes issues such as #3682 that have been closed prematurely and have nothing to do with the charset of the tables.

