### PR TITLE
Add reset feature for user dashboards

### DIFF
--- a/application/controllers/DashboardController.php
+++ b/application/controllers/DashboardController.php
@@ -336,6 +336,38 @@ class DashboardController extends ActionController
         $this->view->dashboard = $this->dashboard;
     }
 
+    public function resetAction()
+    {
+        $this->createTabs();
+
+        $this->getTabs()->add('reset', array(
+            'active'    => true,
+            'label'     => $this->translate('Reset Dashboards'),
+            'url'       => Url::fromRequest()
+        ));
+
+        $dashboard = $this->dashboard;
+
+        $this->view->title = t('Reset all dashboards settings');
+        $this->view->description = t('Do you want to remove all custom dashboard configuration?');
+
+        $this->view->form = $form = new ConfirmRemovalForm();
+        $form->setSubmitLabel(t('Reset dashboards'));
+        $form->setRedirectUrl('dashboard/settings');
+        $form->setOnSuccess(function (ConfirmRemovalForm $form) use ($dashboard) {
+            try {
+                $dashboard->resetUserDashboards();
+            } catch (Exception $e) {
+                $form->error($e->getMessage());
+                return false;
+            }
+
+            Notification::success(t('User dashboard config has been reset!'));
+            return true;
+        });
+        $form->handleRequest();
+    }
+
     /**
      * Create tab aggregation
      */

--- a/application/controllers/UserController.php
+++ b/application/controllers/UserController.php
@@ -12,12 +12,13 @@ use Icinga\Exception\ConfigurationError;
 use Icinga\Exception\NotFoundError;
 use Icinga\Forms\Config\User\CreateMembershipForm;
 use Icinga\Forms\Config\User\UserForm;
+use Icinga\Forms\ConfirmRemovalForm;
 use Icinga\User;
 use Icinga\Web\Controller\AuthBackendController;
 use Icinga\Web\Form;
 use Icinga\Web\Notification;
 use Icinga\Web\Url;
-use Icinga\Web\Widget;
+use Icinga\Web\Widget\Dashboard;
 
 class UserController extends AuthBackendController
 {
@@ -260,6 +261,55 @@ class UserController extends AuthBackendController
 
         $this->view->form = $form;
         $this->render('form');
+    }
+
+    /**
+     * Reset a specific user's from an admin perspective
+     *
+     * @throws \Icinga\Exception\ProgrammingError
+     * @throws \Zend_Controller_Action_Exception
+     *
+     * @todo Needs to be refactored for a newer Dashboard implementation (#3809)
+     */
+    public function resetdashboardsAction()
+    {
+        $this->assertPermission('config/authentication/users/edit');
+
+        $userName = $this->params->getRequired('user');
+        $backendName = $this->params->getRequired('backend');
+        $backend = $this->getUserBackend($backendName);
+
+        $user = new User($userName);
+        if ($backend instanceof DomainAwareInterface) {
+            $user->setDomain($backend->getDomain());
+        }
+
+        $dashboard = new Dashboard();
+        $dashboard->setUser($user);
+
+        $this->view->form = $form = new ConfirmRemovalForm();
+        $form->setSubmitLabel(
+            t('Reset all dashboards settings')
+            . ' ' . sprintf(t('for user "%s"'), $user->getUsername())
+        );
+        $form->setRedirectUrl($this->view->url('user/show', [
+            'backend' => $backendName,
+            'user'    => $userName,
+        ]));
+        $form->setOnSuccess(function (ConfirmRemovalForm $form) use ($dashboard) {
+            try {
+                $dashboard->resetUserDashboards();
+            } catch (Exception $e) {
+                $form->error($e->getMessage());
+                return false;
+            }
+
+            Notification::success(t('User dashboard config has been reset!'));
+            return true;
+        });
+        $form->handleRequest();
+
+        $this->renderForm($form, $this->translate('Reset Dashboards'));
     }
 
     /**

--- a/application/views/scripts/dashboard/index.phtml
+++ b/application/views/scripts/dashboard/index.phtml
@@ -3,7 +3,13 @@
 <?= $this->tabs ?>
 <?php endif ?>
 </div>
-<?php if ($this->dashboard): ?>
+<?php if ($this->errors !== null): ?>
+    <div class="content">
+        <p class="error-message"><?= t('There was an error while parsing the dashboard config') ?></p>
+        <hr>
+        <pre><?= join('<br/>', array_map($this->escape, $this->errors)) ?></pre>
+    </div>
+<?php elseif ($this->dashboard): ?>
     <div class="dashboard content">
     <?= $this->dashboard ?>
     </div>

--- a/application/views/scripts/dashboard/reset.phtml
+++ b/application/views/scripts/dashboard/reset.phtml
@@ -1,0 +1,8 @@
+<div class="controls">
+    <?= $this->tabs ?>
+</div>
+<div class="content">
+    <h1><?= $this->title ?></h1>
+    <p><?= $this->description ?></p>
+    <?= $this->form ?>
+</div>

--- a/application/views/scripts/dashboard/settings.phtml
+++ b/application/views/scripts/dashboard/settings.phtml
@@ -4,6 +4,28 @@
 <div class="content">
     <h1><?= t('Dashboard Settings'); ?></h1>
 
+    <p>
+        <?= $this->qlink(
+            t('Add Dashlet'),
+            'dashboard/new-dashlet',
+            [],
+            array(
+                'class' => 'button-link',
+                'icon'  => 'plus',
+            )
+        ); ?>
+        <?= $this->qlink(
+            t('Reset dashboards'),
+            'dashboard/reset',
+            [],
+            array(
+                'class' => 'button-link',
+                'icon'  => 'rewind',
+                'title' => t('Reset all dashboards settings'),
+            )
+        ); ?>
+    </p>
+
     <table class="avp action" data-base-target="_next">
         <thead>
             <tr>

--- a/application/views/scripts/dashboard/settings.phtml
+++ b/application/views/scripts/dashboard/settings.phtml
@@ -26,6 +26,12 @@
         ); ?>
     </p>
 
+    <?php if ($this->errors !== null): ?>
+    <p class="error-message"><?= t('There was an error while parsing the dashboard config') ?></p>
+    <hr>
+    <pre><?= join('<br/>', array_map($this->escape, $this->errors)) ?></pre>
+    <?php else: ?>
+
     <table class="avp action" data-base-target="_next">
         <thead>
             <tr>
@@ -110,4 +116,7 @@
             <?php endforeach; ?>
         </tbody>
     </table>
+
+    <?php endif; ?>
+
 </div>

--- a/application/views/scripts/user/show.phtml
+++ b/application/views/scripts/user/show.phtml
@@ -25,6 +25,20 @@ use Icinga\Data\Selectable;
                 'title' => sprintf($this->translate('Edit user %s'), $user->user_name)
             )
         );
+        echo ' ';
+        // TODO: Needs to be refactored for a newer Dashboard implementation (#3809)
+        echo $this->qlink(
+            $this->translate('Reset dashboards'),
+            'user/resetdashboards',
+            array(
+                'backend'   => $backend->getName(),
+                'user'      => $user->user_name
+            ),
+            array(
+                'class' => 'button-link',
+                'icon'  => 'rewind',
+            )
+        );
     }
     ?>
     <table class="name-value-table">

--- a/library/Icinga/Web/Widget/Dashboard.php
+++ b/library/Icinga/Web/Widget/Dashboard.php
@@ -9,6 +9,7 @@ use Icinga\Exception\NotReadableError;
 use Icinga\Exception\ProgrammingError;
 use Icinga\Legacy\DashboardConfig;
 use Icinga\User;
+use Icinga\Util\File;
 use Icinga\Web\Navigation\DashboardPane;
 use Icinga\Web\Navigation\Navigation;
 use Icinga\Web\Url;
@@ -200,6 +201,27 @@ class Dashboard extends AbstractWidget
         $this->mergePanes($panes);
 
         return true;
+    }
+
+    /**
+     * Clears and resets any custom configuration for the set user
+     *
+     * @throws ProgrammingError
+     * @throws \Icinga\Exception\NotWritableError
+     */
+    public function resetUserDashboards()
+    {
+        if ($this->user === null) {
+            throw new ProgrammingError('Can\'t reset dashboards. User is not set');
+        }
+
+        $file = $this->getConfigFile();
+
+        if (file_exists($file)) {
+            unlink($file);
+            // recreate the file to it is visibly empty
+            File::create($file, 0660);
+        }
     }
 
     /**


### PR DESCRIPTION
This implements a few features to help reset a user his personal dashboard settings when:

* A user wants to restore the standard dashboards (they are hidden when manually deleted)
* Any configuration is broken

## Features

* Widget has a reset function to just purge the file contents for a user
* Settings gained buttons for actions, while asking for confirmation
* Any error is now handled gracefully and the essential navigation UI is rendered
* Admins can reset the dashboards for a particular user in the authentication area

## Screenshots

![Bildschirmfoto von 2020-04-07 18-34-58](https://user-images.githubusercontent.com/121874/78695589-97add680-78fe-11ea-98f5-6dccb66ba1c5.png)
![Bildschirmfoto von 2020-04-07 18-35-07](https://user-images.githubusercontent.com/121874/78695587-97154000-78fe-11ea-8716-a3fa2a6b2986.png)
![Bildschirmfoto von 2020-04-07 18-35-24](https://user-images.githubusercontent.com/121874/78695586-97154000-78fe-11ea-9650-4658bc4df644.png)
![Bildschirmfoto von 2020-04-07 18-35-30](https://user-images.githubusercontent.com/121874/78695582-967ca980-78fe-11ea-8065-de3a24eee5a3.png)

## Regarding error

Normally a user shouldn't be able to input broken stuff that is saved for dashboards. But I've seen it happen, and Dashboards have been fixed since.

The error is merely to ensure the user is always able to reach the UI.

Any thoughts?

ref/NC/664757