### PR TITLE
LDAP: Add option to disable server side sorting

### DIFF
--- a/doc/04-Resources.md
+++ b/doc/04-Resources.md
@@ -88,6 +88,15 @@ bind\_dn                 | **Required.** The user to use when connecting to the 
 bind\_pw                 | **Required.** The password to use when connecting to the server.
 encryption               | **Optional.** Type of encryption to use: `none` (default), `starttls`, `ldaps`.
 timeout                  | **Optional.** Connection timeout for every LDAP connection. Defaults to `5`.
+disable_server_side_sort | **Optional.** Disable server side sorting. Defaults to automatic detection whether the server supports this.
+
+#### Server Side Sorting <a id="ldap-server-side-sort"></a>
+
+Icinga Web automatically detects whether the LDAP server supports server side sorting.
+If that is not the case, results get sorted on the client side.
+There are LDAP servers though which report that they support this feature in general but have it disabled for certain
+fields. This may lead to failures. With `disable_server_side_sort` it is possible to disable server side sorting and it
+has precedence over the automatic detection.
 
 #### Example <a id="resources-configuration-ldap-example"></a>
 

--- a/library/Icinga/Protocol/Ldap/LdapConnection.php
+++ b/library/Icinga/Protocol/Ldap/LdapConnection.php
@@ -77,6 +77,9 @@ class LdapConnection implements Selectable, Inspectable
      */
     const LDAPS = 'ldaps';
 
+    /** @var ConfigObject Connection configuration */
+    protected $config;
+
     /**
      * Encryption for the connection if any
      *
@@ -182,6 +185,7 @@ class LdapConnection implements Selectable, Inspectable
      */
     public function __construct(ConfigObject $config)
     {
+        $this->config = $config;
         $this->hostname = $config->hostname;
         $this->bindDn = $config->bind_dn;
         $this->bindPw = $config->bind_pw;
@@ -739,7 +743,8 @@ class LdapConnection implements Selectable, Inspectable
 
         $ds = $this->getConnection();
 
-        $serverSorting = $this->getCapabilities()->hasOid(LdapCapabilities::LDAP_SERVER_SORT_OID);
+        $serverSorting = ! $this->config->disable_server_side_sort
+            && $this->getCapabilities()->hasOid(LdapCapabilities::LDAP_SERVER_SORT_OID);
 
         if ($query->hasOrder()) {
             if ($serverSorting) {


### PR DESCRIPTION
We automatically detect whether the server supports server side sorting
and sort manually if that is not the case. But there are LDAP servers
which report that they support this feature in general but have it
disabled for certain fields.

If we send the server side control for any field that has server side
sort disabled, the LDAP server will abort the query.

With the new configuration option it is possible to disable server side
sorting and it has precedence over our automatic detection.
Since this is a very special LDAP server configuration, there is no GUI
option for this.

ref/IP/24737