### PR TITLE
Icinga.Loader#onFailure(): treat 5xx response as connection failure

### DIFF
--- a/public/js/icinga/loader.js
+++ b/public/js/icinga/loader.js
@@ -939,7 +939,7 @@
                 this.icinga.timer.unregister(req.progressTimer);
             }
 
-            if (req.status > 0) {
+            if (req.status > 0 && req.status < 501) {
                 this.icinga.logger.error(
                     req.status,
                     errorThrown + ':',


### PR DESCRIPTION
... not to break the container with the reverse proxy's response not fitting into our layout.

fixes #1092
fixes #4133