### PR TITLE
Query\*notificationQuery: add missing host_alias

### DIFF
--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/HostnotificationQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/HostnotificationQuery.php
@@ -31,7 +31,8 @@ class HostnotificationQuery extends IdoQuery
             'hostgroup_name'    => 'hgo.name1'
         ),
         'hosts' => array(
-            'host_display_name' => 'h.display_name COLLATE latin1_general_ci'
+            'host_display_name' => 'h.display_name COLLATE latin1_general_ci',
+            'host_alias'        => 'h.alias COLLATE latin1_general_ci',
         ),
         'history' => array(
             'output'    => null,

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/ServicenotificationQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/ServicenotificationQuery.php
@@ -47,7 +47,8 @@ class ServicenotificationQuery extends IdoQuery
             'hostgroup_alias'   => 'hg.alias COLLATE latin1_general_ci',
         ),
         'hosts' => array(
-            'host_display_name' => 'h.display_name COLLATE latin1_general_ci'
+            'host_display_name' => 'h.display_name COLLATE latin1_general_ci',
+            'host_alias'        => 'h.alias COLLATE latin1_general_ci',
         ),
         'instances' => array(
             'instance_name' => 'i.instance_name'


### PR DESCRIPTION
Fixes an Exception when searching for a specific alias (as offered in
the filter form)