### PR TITLE
Fix view compact handling

### DIFF
--- a/doc/80-Upgrading.md
+++ b/doc/80-Upgrading.md
@@ -45,6 +45,11 @@ Please consider an upgrade of your central Icinga system to a newer distribution
 [icinga.com](https://icinga.com/subscription/support-details/) provides an overview about
 currently supported distributions.
 
+**Framework changes affecting third-party code**
+
+* Url parameter `view=compact` is now deprecated. `showCompact` should be used instead.
+  Details are in pull request [#4164](https://github.com/Icinga/icingaweb2/pull/4164).
+
 ## Upgrading to Icinga Web 2 2.7.x <a id="upgrading-to-2.7.x"></a>
 
 **Breaking changes**

--- a/library/Icinga/Web/Controller.php
+++ b/library/Icinga/Web/Controller.php
@@ -235,7 +235,7 @@ class Controller extends ModuleActionController
             'sort', // setupSortControl()
             'dir', // setupSortControl()
             'backend', // Framework
-            'view', // Framework
+            'showCompact', // Framework
             '_dev' // Framework
         );
 

--- a/library/Icinga/Web/Controller/ActionController.php
+++ b/library/Icinga/Web/Controller/ActionController.php
@@ -129,7 +129,10 @@ class ActionController extends Zend_Controller_Action
         $this->_helper->layout()->showFullscreen = $request->getUrl()->shift('showFullscreen');
         $this->_helper->layout()->moduleName = $moduleName;
 
-        $this->view->compact = $request->getParam('view') === 'compact';
+        if ($request->getUrl()->getParam('view') === 'compact') {
+            $request->getUrl()->remove('view');
+            $this->view->compact = true;
+        }
         if ($request->getUrl()->shift('showCompact')) {
             $this->view->compact = true;
         }

--- a/library/Icinga/Web/Url.php
+++ b/library/Icinga/Web/Url.php
@@ -828,6 +828,32 @@ class Url
         return $url;
     }
 
+    /**
+     * Return a copy of this url with only the given parameter(s)
+     *
+     * The argument can be either a single query parameter name or
+     * an array of parameter names to keep on on the query
+     *
+     * @param string|array $keyOrArrayOfKeys
+     *
+     * @return static
+     */
+    public function onlyWith($keyOrArrayOfKeys)
+    {
+        if (! is_array($keyOrArrayOfKeys)) {
+            $keyOrArrayOfKeys = [$keyOrArrayOfKeys];
+        }
+
+        $url = clone $this;
+        foreach ($url->getParams()->toArray(false) as $key => $_) {
+            if (! in_array($key, $keyOrArrayOfKeys, true)) {
+                $url->remove($key);
+            }
+        }
+
+        return $url;
+    }
+
     public function __clone()
     {
         $this->params = clone $this->params;

--- a/library/Icinga/Web/Widget/FilterEditor.php
+++ b/library/Icinga/Web/Widget/FilterEditor.php
@@ -285,12 +285,10 @@ class FilterEditor extends AbstractWidget
                 }
             }
 
-            $url = $this->url()->setQueryString(
-                $filter->toQueryString()
-            )->addParams($preserve);
-            if ($modify) {
-                $url->getParams()->add('modifyFilter');
-            }
+            $url = Url::fromRequest()->onlyWith($this->preserveParams);
+            $urlParams = $url->getParams();
+            $url->setQueryString($filter->toQueryString());
+            $url->getParams()->mergeValues($urlParams->toArray(false));
             $this->redirectNow($url);
         }
 

--- a/modules/monitoring/application/controllers/ListController.php
+++ b/modules/monitoring/application/controllers/ListController.php
@@ -355,7 +355,7 @@ class ListController extends Controller
         $this->view->form = $form;
 
         $this->params
-            ->remove('view')
+            ->remove('showCompact')
             ->remove('format');
         $orientation = $this->params->shift('vertical', 0) ? 'vertical' : 'horizontal';
 /*

--- a/modules/monitoring/application/controllers/ServicesController.php
+++ b/modules/monitoring/application/controllers/ServicesController.php
@@ -35,7 +35,7 @@ class ServicesController extends Controller
         $serviceList = new ServiceList($this->backend);
         $this->applyRestriction('monitoring/filter/objects', $serviceList);
         $serviceList->addFilter(Filter::fromQueryString(
-            (string) $this->params->without(array('service_problem', 'service_handled', 'view'))
+            (string) $this->params->without(array('service_problem', 'service_handled', 'showCompact'))
         ));
         $this->serviceList = $serviceList;
         $this->serviceList->setColumns(array(

--- a/modules/monitoring/application/views/scripts/list/comments.phtml
+++ b/modules/monitoring/application/views/scripts/list/comments.phtml
@@ -43,7 +43,7 @@
     <div class="action-links">
         <?= $this->qlink(
             $this->translate('Show More'),
-            $this->url()->without(array('view', 'limit')),
+            $this->url()->without(array('showCompact', 'limit')),
             null,
             array(
                 'class'               => 'action-link',

--- a/modules/monitoring/application/views/scripts/list/contacts.phtml
+++ b/modules/monitoring/application/views/scripts/list/contacts.phtml
@@ -71,7 +71,7 @@
     <div class="action-links">
         <?= $this->qlink(
             $this->translate('Show More'),
-            $this->url()->without(array('view', 'limit')),
+            $this->url()->without(array('showCompact', 'limit')),
             null,
             array(
                 'class'             => 'action-link',

--- a/modules/monitoring/application/views/scripts/list/downtimes.phtml
+++ b/modules/monitoring/application/views/scripts/list/downtimes.phtml
@@ -46,7 +46,7 @@ if (! $this->compact): ?>
     <div class="action-links">
         <?= $this->qlink(
             $this->translate('Show More'),
-            $this->url()->without(array('view', 'limit')),
+            $this->url()->without(array('showCompact', 'limit')),
             null,
             array(
                 'class'             => 'action-link',

--- a/modules/monitoring/application/views/scripts/list/hostgroups.phtml
+++ b/modules/monitoring/application/views/scripts/list/hostgroups.phtml
@@ -284,7 +284,7 @@ if (! $this->compact): ?>
     <div class="action-links">
         <?= $this->qlink(
             $this->translate('Show More'),
-            $this->url()->without(array('view', 'limit')),
+            $this->url()->without(array('showCompact', 'limit')),
             null,
             array(
                 'class'             => 'action-link',

--- a/modules/monitoring/application/views/scripts/list/hosts.phtml
+++ b/modules/monitoring/application/views/scripts/list/hosts.phtml
@@ -102,7 +102,7 @@ if (! $this->compact): ?>
     <div class="action-links">
         <?= $this->qlink(
             $this->translate('Show More'),
-            $this->url()->without(array('view', 'limit')),
+            $this->url()->without(array('showCompact', 'limit')),
             null,
             array(
                 'class'             => 'action-link',

--- a/modules/monitoring/application/views/scripts/list/notifications.phtml
+++ b/modules/monitoring/application/views/scripts/list/notifications.phtml
@@ -112,7 +112,7 @@ if (! $this->compact): ?>
     <div class="action-links">
         <?= $this->qlink(
             $this->translate('Show More'),
-            $this->url(isset($notificationsUrl) ? $notificationsUrl : null)->without(array('view', 'limit')),
+            $this->url(isset($notificationsUrl) ? $notificationsUrl : null)->without(array('showCompact', 'limit')),
             null,
             array(
                 'class'             => 'action-link',

--- a/modules/monitoring/application/views/scripts/list/servicegroups.phtml
+++ b/modules/monitoring/application/views/scripts/list/servicegroups.phtml
@@ -172,7 +172,7 @@ if (! $this->compact): ?>
 <div class="action-links">
     <?= $this->qlink(
         $this->translate('Show More'),
-        $this->url()->without(array('view', 'limit')),
+        $this->url()->without(array('showCompact', 'limit')),
         null,
         array(
             'class'             => 'action-link',

--- a/modules/monitoring/application/views/scripts/list/services.phtml
+++ b/modules/monitoring/application/views/scripts/list/services.phtml
@@ -130,7 +130,7 @@ if (! $this->compact): ?>
 <div class="action-links">
     <?= $this->qlink(
         $this->translate('Show More'),
-        $this->url()->without(array('view', 'limit')),
+        $this->url()->without(array('showCompact', 'limit')),
         null,
         array(
             'class'             => 'action-link',

--- a/modules/monitoring/application/views/scripts/partials/event-history.phtml
+++ b/modules/monitoring/application/views/scripts/partials/event-history.phtml
@@ -247,7 +247,7 @@ $rowAction = Url::fromPath('monitoring/event/show');
     <?php if ($this->compact) {
         echo $this->qlink(
             $this->translate('Show More'),
-            $url->without(array('view', 'limit')),
+            $url->without(array('showCompact', 'limit')),
             null,
             array(
                 'class'             => 'action-link',

--- a/modules/monitoring/application/views/scripts/partials/show-more.phtml
+++ b/modules/monitoring/application/views/scripts/partials/show-more.phtml
@@ -4,7 +4,7 @@ if ($dataView->hasMore()): ?>
 <div class="text-right">
     <?= $this->qlink(
         $this->translate('Show More'),
-        $this->url()->without(array('view', 'limit')),
+        $this->url()->without(array('showCompact', 'limit')),
         null,
         array(
             'data-base-target'  => '_next',

--- a/modules/monitoring/library/Monitoring/DataView/DataView.php
+++ b/modules/monitoring/library/Monitoring/DataView/DataView.php
@@ -147,7 +147,7 @@ abstract class DataView implements QueryInterface, SortRules, FilterColumns, Ite
         $dir = $url->shift('dir');
         $page = $url->shift('page');
         $format = $url->shift('format');
-        $view = $url->shift('view');
+        $view = $url->shift('showCompact');
         $view = $url->shift('backend');
         foreach ($url->getParams() as $k => $v) {
             $this->where($k, $v);

--- a/public/js/icinga/behavior/modal.js
+++ b/public/js/icinga/behavior/modal.js
@@ -42,8 +42,8 @@
         var $modal = _this.$ghost.clone();
         var $urlTarget = _this.icinga.loader.getLinkTargetFor($a);
 
-        // Add view=compact, we don't want controls in a modal
-        url = _this.icinga.utils.addUrlParams(url, { 'view': 'compact' });
+        // Add showCompact, we don't want controls in a modal
+        url = _this.icinga.utils.addUrlFlag(url, 'showCompact');
 
         // Set the toggle's base target on the modal to use it as redirect target
         $modal.data('redirectTarget', $urlTarget);


### PR DESCRIPTION
Changes how Icinga Web 2 handles compact layout requests.

Previously:
* Parameter `showCompact[=1]` allows to request compact layout but is available only to controller code accessing `$this->params`
* Parameter `view=compact` allows the same, but is also available to the global `Icinga\Web\Request` object

Changed:
* Parameter `showCompact[=1]` is left unchanged
* Parameter `view=compact` is now also only available to controller code accessing `$this->params`

`view=compact` is now also deprecated. Anyone using this parameter to request compact layouts should switch to `showCompact[=1]`.