### PR TITLE
CLI: Also register assets

### DIFF
--- a/library/Icinga/Application/Modules/Module.php
+++ b/library/Icinga/Application/Modules/Module.php
@@ -1308,7 +1308,7 @@ class Module
      */
     protected function registerAssets()
     {
-        if ($this->app->isCli() || ! is_dir($this->assetDir)) {
+        if (! is_dir($this->assetDir)) {
             return $this;
         }
 


### PR DESCRIPTION
Because assets are not registered in the CLI context,
CLI actions cannot access the full style sheet.
This is necessary for Icinga Reporting though in order to send PDF reports.