### PR TITLE
Fix that logins are not case-insensitive anymore

### DIFF
--- a/library/Icinga/Authentication/User/DbUserBackend.php
+++ b/library/Icinga/Authentication/User/DbUserBackend.php
@@ -184,9 +184,15 @@ class DbUserBackend extends DbRepository implements UserBackendInterface, Inspec
             $columns = array('password_hash');
         }
 
+        $nameColumn = 'name';
+        if ($this->ds->getDbType() === 'mysql') {
+            $username = strtolower($username);
+            $nameColumn = 'BINARY LOWER(name)';
+        }
+
         $query = $this->ds->select()
             ->from($this->prependTablePrefix('user'), $columns)
-            ->where(($this->ds->getDbType() === 'mysql' ? 'BINARY ' : '') . 'name', $username)
+            ->where($nameColumn, $username)
             ->where('active', true);
 
         $statement = $this->ds->getDbAdapter()->prepare($query->getSelectQuery());


### PR DESCRIPTION
The BINARY cast to make trailing spaces significant (#4030) also
made these queries case-sensitive. This wasn't identified at the
time because the query itself wasn't case-insensitive, but the
default collation on the `name` column. (Tests sometimes are the
perfect mitigation for this...)

fixes #4184