### PR TITLE
Fix typos: consecutive use of 'the'

### DIFF
--- a/library/Icinga/Application/Web.php
+++ b/library/Icinga/Application/Web.php
@@ -494,7 +494,7 @@ class Web extends EmbeddedWeb
      *
      * @return  string                      Detected locale code
      *
-     * @see     Translator::DEFAULT_LOCALE  For the the default locale code.
+     * @see     Translator::DEFAULT_LOCALE  For the default locale code.
      */
     protected function detectLocale()
     {

--- a/library/Icinga/Chart/Primitive/Text.php
+++ b/library/Icinga/Chart/Primitive/Text.php
@@ -113,7 +113,7 @@ class Text extends Styleable implements Drawable
     }
 
     /**
-     * Set the the text alignment with one of the ALIGN_* constants
+     * Set the text alignment with one of the ALIGN_* constants
      *
      * @param   String $align   Value how to align
      *

--- a/modules/monitoring/application/forms/Command/Object/AcknowledgeProblemCommandForm.php
+++ b/modules/monitoring/application/forms/Command/Object/AcknowledgeProblemCommandForm.php
@@ -53,7 +53,7 @@ class AcknowledgeProblemCommandForm extends ObjectsCommandForm
                     'required'      => true,
                     'label'         => $this->translate('Comment'),
                     'description'   => $this->translate(
-                        'If you work with other administrators, you may find it useful to share information about the'
+                        'If you work with other administrators, you may find it useful to share information about'
                         . ' the host or service that is having problems. Make sure you enter a brief description of'
                         . ' what you are doing.'
                     ),

--- a/modules/monitoring/application/forms/Command/Object/AddCommentCommandForm.php
+++ b/modules/monitoring/application/forms/Command/Object/AddCommentCommandForm.php
@@ -42,7 +42,7 @@ class AddCommentCommandForm extends ObjectsCommandForm
                 'required'      => true,
                 'label'         => $this->translate('Comment'),
                 'description'   => $this->translate(
-                    'If you work with other administrators, you may find it useful to share information about the'
+                    'If you work with other administrators, you may find it useful to share information about'
                     . ' the host or service that is having problems. Make sure you enter a brief description of'
                     . ' what you are doing.'
                 ),

--- a/modules/monitoring/application/forms/Command/Object/ScheduleServiceDowntimeCommandForm.php
+++ b/modules/monitoring/application/forms/Command/Object/ScheduleServiceDowntimeCommandForm.php
@@ -64,7 +64,7 @@ class ScheduleServiceDowntimeCommandForm extends ObjectsCommandForm
                     'required'      => true,
                     'label'         => $this->translate('Comment'),
                     'description'   => $this->translate(
-                        'If you work with other administrators, you may find it useful to share information about the'
+                        'If you work with other administrators, you may find it useful to share information about'
                         . ' the host or service that is having problems. Make sure you enter a brief description of'
                         . ' what you are doing.'
                     ),

--- a/modules/monitoring/application/forms/Command/Object/SendCustomNotificationCommandForm.php
+++ b/modules/monitoring/application/forms/Command/Object/SendCustomNotificationCommandForm.php
@@ -45,7 +45,7 @@ class SendCustomNotificationCommandForm extends ObjectsCommandForm
                     'required'      => true,
                     'label'         => $this->translate('Comment'),
                     'description'   => $this->translate(
-                        'If you work with other administrators, you may find it useful to share information about the'
+                        'If you work with other administrators, you may find it useful to share information about'
                         . ' the host or service that is having problems. Make sure you enter a brief description of'
                         . ' what you are doing.'
                     )

--- a/modules/monitoring/application/locale/ar_SA/LC_MESSAGES/monitoring.po
+++ b/modules/monitoring/application/locale/ar_SA/LC_MESSAGES/monitoring.po
@@ -2236,7 +2236,7 @@ msgstr ""
 #: ../../../../application/forms/Command/Object/AddCommentCommandForm.php:45
 msgid ""
 "If you work with other administrators, you may find it useful to share "
-"information about the the host or service that is having problems. Make sure "
+"information about the host or service that is having problems. Make sure "
 "you enter a brief description of what you are doing."
 msgstr ""
 "إذا كنت تعمل مع المسؤولين الآخرين، قد تجد أنه من المفيد تبادل المعلومات حول "

--- a/modules/monitoring/application/locale/de_DE/LC_MESSAGES/monitoring.po
+++ b/modules/monitoring/application/locale/de_DE/LC_MESSAGES/monitoring.po
@@ -2238,7 +2238,7 @@ msgstr ""
 #: ../../../../application/forms/Command/Object/AddCommentCommandForm.php:45
 msgid ""
 "If you work with other administrators, you may find it useful to share "
-"information about the the host or service that is having problems. Make sure "
+"information about the host or service that is having problems. Make sure "
 "you enter a brief description of what you are doing."
 msgstr ""
 "Bei Zusammenarbeit mit anderen Administratoren, hat es sich als nützlich "

--- a/modules/monitoring/application/locale/it_IT/LC_MESSAGES/monitoring.po
+++ b/modules/monitoring/application/locale/it_IT/LC_MESSAGES/monitoring.po
@@ -2253,7 +2253,7 @@ msgstr ""
 #, fuzzy
 msgid ""
 "If you work with other administrators, you may find it useful to share "
-"information about the the host or service that is having problems. Make sure "
+"information about the host or service that is having problems. Make sure "
 "you enter a brief description of what you are doing."
 msgstr ""
 "Se lavori con altri amministratori potresti trovare utile condividere le "

--- a/modules/monitoring/application/locale/ja_JP/LC_MESSAGES/monitoring.po
+++ b/modules/monitoring/application/locale/ja_JP/LC_MESSAGES/monitoring.po
@@ -2198,7 +2198,7 @@ msgstr ""
 #: ../../../../application/forms/Command/Object/AddCommentCommandForm.php:45
 msgid ""
 "If you work with other administrators, you may find it useful to share "
-"information about the the host or service that is having problems. Make sure "
+"information about the host or service that is having problems. Make sure "
 "you enter a brief description of what you are doing."
 msgstr ""
 "他の管理者と仕事をしている場合は、障害のあるホストまたはサービスに関する情報"

--- a/modules/monitoring/application/locale/pt_BR/LC_MESSAGES/monitoring.po
+++ b/modules/monitoring/application/locale/pt_BR/LC_MESSAGES/monitoring.po
@@ -2330,7 +2330,7 @@ msgstr ""
 #, fuzzy
 msgid ""
 "If you work with other administrators, you may find it useful to share "
-"information about the the host or service that is having problems. Make sure "
+"information about the host or service that is having problems. Make sure "
 "you enter a brief description of what you are doing."
 msgstr ""
 "Se você trabalha com outros administradores, você pode achar isso útil para "

--- a/modules/monitoring/application/locale/ru_RU/LC_MESSAGES/monitoring.po
+++ b/modules/monitoring/application/locale/ru_RU/LC_MESSAGES/monitoring.po
@@ -2174,7 +2174,7 @@ msgstr ""
 #: ../../../../application/forms/Command/Object/AddCommentCommandForm.php:45
 msgid ""
 "If you work with other administrators, you may find it useful to share "
-"information about the the host or service that is having problems. Make sure "
+"information about the host or service that is having problems. Make sure "
 "you enter a brief description of what you are doing."
 msgstr ""
 

--- a/modules/monitoring/application/locale/uk_UA/LC_MESSAGES/monitoring.po
+++ b/modules/monitoring/application/locale/uk_UA/LC_MESSAGES/monitoring.po
@@ -2268,7 +2268,7 @@ msgstr ""
 #: ../../../../application/forms/Command/Object/AddCommentCommandForm.php:45
 msgid ""
 "If you work with other administrators, you may find it useful to share "
-"information about the the host or service that is having problems. Make sure "
+"information about the host or service that is having problems. Make sure "
 "you enter a brief description of what you are doing."
 msgstr ""
 "Якщо ви працюєте з іншими адміністраторами, ви можете поділитися з ними "

--- a/modules/translation/doc/03-Translation.md
+++ b/modules/translation/doc/03-Translation.md
@@ -135,7 +135,7 @@ And when you want to test your changes, please read more about under the chapter
 
 ## Testing Translations <a id="module-translation-tests"></a>
 
-If you want to try out your translation changes in Icinga Web 2, you can make use of the the CLI translations commands.
+If you want to try out your translation changes in Icinga Web 2, you can make use of the CLI translations commands.
 
 > **Note**:
 >


### PR DESCRIPTION
Remove consecutive occurrences of 'the'
`s/the the /the /g`