### PR TITLE
Add notification beads for disabled active checks

### DIFF
--- a/modules/monitoring/library/Monitoring/Web/Navigation/Renderer/BackendAvailabilityNavigationItemRenderer.php
+++ b/modules/monitoring/library/Monitoring/Web/Navigation/Renderer/BackendAvailabilityNavigationItemRenderer.php
@@ -28,7 +28,12 @@ class BackendAvailabilityNavigationItemRenderer extends BadgeNavigationItemRende
             ->select()
             ->from(
                 'programstatus',
-                array('is_currently_running', 'notifications_enabled')
+                array(
+                  'active_host_checks_enabled',
+                  'active_service_checks_enabled',
+                  'is_currently_running',
+                  'notifications_enabled'
+                )
             )
             ->fetchRow();
 
@@ -59,13 +64,23 @@ class BackendAvailabilityNavigationItemRenderer extends BadgeNavigationItemRende
             }
             $count = 0;
             $titles = array();
+            if (! (bool) $programStatus->active_host_checks_enabled) {
+                $count++;
+                $this->state = static::STATE_WARNING;
+                $titles[] = mt('monitoring', 'Active host checks are disabled');
+            }
+            if (! (bool) $programStatus->active_service_checks_enabled) {
+                $count++;
+                $this->state = static::STATE_WARNING;
+                $titles[] = mt('monitoring', 'Active service checks are disabled');
+            }
             if (! (bool) $programStatus->notifications_enabled) {
-                $count = 1;
+                $count++;
                 $this->state = static::STATE_WARNING;
                 $titles[] = mt('monitoring', 'Notifications are disabled');
             }
             if (! (bool) $programStatus->is_currently_running) {
-                $count = 1;
+                $count++;
                 $this->state = static::STATE_CRITICAL;
                 array_unshift($titles, sprintf(
                     mt('monitoring', 'Monitoring backend %s is not running'),


### PR DESCRIPTION
We mistakenly disabled active checks in our Icinga environment and did
not notice for some time. This commit hooks into the badge mechanic used
when notifications are turned off, and also provides beads when active
host checks and active service checks are disabled.