### PR TITLE
Allow multipart updates rewrite the query string

### DIFF
--- a/public/js/icinga/loader.js
+++ b/public/js/icinga/loader.js
@@ -762,6 +762,14 @@
 
             var contentSeparator = req.getResponseHeader('X-Icinga-Multipart-Content');
             if (!! contentSeparator) {
+                var locationQuery = req.getResponseHeader('X-Icinga-Location-Query');
+                if (locationQuery !== null) {
+                    var a = this.icinga.utils.getUrlHelper();
+                    a.search = locationQuery ? '?' + locationQuery : '';
+                    req.$target.data('icingaUrl', a.href);
+                    this.icinga.history.replaceCurrentState();
+                }
+
                 $.each(req.responseText.split(contentSeparator), function (idx, el) {
                     var match = el.match(/for=(\S+)\s+(.*)/m);
                     if (!! match) {


### PR DESCRIPTION
This header is only used in case the response includes
multipart content. It's meant to provide a new query
string that replaces the one of the targeted container
and the resulting change also replaces the current
history entry.