### PR TITLE
Don't add form submits other than `GET`s to the history

### DIFF
--- a/public/js/icinga/loader.js
+++ b/public/js/icinga/loader.js
@@ -183,6 +183,7 @@
 
             var req = this.loadUrl(url, $target, data, method);
             req.forceFocus = $autoSubmittedBy ? $autoSubmittedBy : $button.length ? $button : null;
+            req.addToHistory = method === 'GET';
             req.progressTimer = progressTimer;
             return req;
         },


### PR DESCRIPTION
This has previously not been an issue, as form submits seem to have
never targeted another url than their container's current one.
Though any form that did this, was pushed to history upon submit.
This happens now only for `GET` forms.