### PR TITLE
Shared navigation url bug

### DIFF
--- a/library/Icinga/Web/Url.php
+++ b/library/Icinga/Web/Url.php
@@ -866,6 +866,6 @@ class Url
      */
     public function __toString()
     {
-        return $this->getAbsoluteUrl('&amp;');
+        return htmlspecialchars($this->getAbsoluteUrl(), ENT_COMPAT | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8', true);
     }
 }


### PR DESCRIPTION
**The bug**

The self created navigation URL was displayed in plain text as you can see on the screenshot.

![Screenshot 2020-11-05 at 11 36 31](https://user-images.githubusercontent.com/54990055/98231659-fef73c00-1f5c-11eb-9c64-537be20c3af7.png)

**Why this happend?**

This happened because the url was not escaped correctly for html special characters and if there was a special character in the url, it was displayed as plain text.

We have fixed this bug and also made changes in other places where such behavior might occur.