### PR TITLE
history.js: Set `lastPushUrl` in method `replaceCurrentState()`

### DIFF
--- a/public/js/icinga/history.js
+++ b/public/js/icinga/history.js
@@ -126,6 +126,7 @@
 
             if (state.url) {
                 this.icinga.logger.debug('Replacing current history state');
+                this.lastPushUrl = state.url;
                 window.history.replaceState(
                     this.getBehaviorState(),
                     null,


### PR DESCRIPTION
Without this, any subsequent call to `pushCurrentState()` has no effect in case the same url is used that was replaced.