### PR TITLE
Drop new parameter from ActionController::setAutorefreshInterval()

### DIFF
--- a/application/controllers/ApplicationStateController.php
+++ b/application/controllers/ApplicationStateController.php
@@ -17,6 +17,8 @@ class ApplicationStateController extends Controller
 {
     protected $requiresAuthentication = false;
 
+    protected $autorefreshInterval = 60;
+
     public function init()
     {
         $this->_helper->layout->disableLayout();
@@ -63,8 +65,6 @@ class ApplicationStateController extends Controller
                 }
             }
         }
-
-        $this->setAutorefreshInterval(60, true);
     }
 
     public function summaryAction()
@@ -72,8 +72,6 @@ class ApplicationStateController extends Controller
         if ($this->Auth()->isAuthenticated()) {
             $this->getResponse()->setBody((string) Widget::create('ApplicationStateMessages'));
         }
-
-        $this->setAutorefreshInterval(60, true);
     }
 
     public function acknowledgeMessageAction()

--- a/library/Icinga/Web/Controller/ActionController.php
+++ b/library/Icinga/Web/Controller/ActionController.php
@@ -356,14 +356,14 @@ class ActionController extends Zend_Controller_Action
         }
 
         $this->autorefreshInterval = $interval;
-        $this->_helper->layout()->autorefreshInterval = $interval;
+
         return $this;
     }
 
     public function disableAutoRefresh()
     {
         $this->autorefreshInterval = null;
-        $this->_helper->layout()->autorefreshInterval = null;
+
         return $this;
     }
 
@@ -478,6 +478,10 @@ class ActionController extends Zend_Controller_Action
             if (! (bool) $user->getPreferences()->getValue('icingaweb', 'auto_refresh', true)) {
                 $this->disableAutoRefresh();
             }
+        }
+
+        if ($this->autorefreshInterval !== null) {
+            $layout->autorefreshInterval = $this->autorefreshInterval;
         }
 
         if ($req->getParam('error_handler') === null && $req->getParam('format') === 'pdf') {

--- a/library/Icinga/Web/Controller/ActionController.php
+++ b/library/Icinga/Web/Controller/ActionController.php
@@ -341,7 +341,7 @@ class ActionController extends Zend_Controller_Action
         }
     }
 
-    public function setAutorefreshInterval($interval, $bypassUserPreferences = false)
+    public function setAutorefreshInterval($interval)
     {
         if (! is_int($interval) || $interval < 1) {
             throw new ProgrammingError(
@@ -349,13 +349,10 @@ class ActionController extends Zend_Controller_Action
             );
         }
 
-        if (! $bypassUserPreferences) {
-            $user = $this->getRequest()->getUser();
-
-            if ($user !== null) {
-                $speed = (float) $user->getPreferences()->getValue('icingaweb', 'auto_refresh_speed', 1.0);
-                $interval = max(round($interval * $speed), min($interval, 5));
-            }
+        $user = $this->getRequest()->getUser();
+        if ($user !== null) {
+            $speed = (float) $user->getPreferences()->getValue('icingaweb', 'auto_refresh_speed', 1.0);
+            $interval = max(round($interval * $speed), min($interval, 5));
         }
 
         $this->autorefreshInterval = $interval;

--- a/library/Icinga/Web/Controller/ActionController.php
+++ b/library/Icinga/Web/Controller/ActionController.php
@@ -64,6 +64,13 @@ class ActionController extends Zend_Controller_Action
      */
     protected $moduleName;
 
+    /**
+     * A page's automatic refresh interval
+     *
+     * The initial value will not be subject to a user's preferences.
+     *
+     * @var int
+     */
     protected $autorefreshInterval;
 
     protected $reloadCss = false;
@@ -341,6 +348,18 @@ class ActionController extends Zend_Controller_Action
         }
     }
 
+    /**
+     * Set the interval (in seconds) at which the page should automatically refresh
+     *
+     * This may be adjusted based on the user's preferences. The result could be a
+     * lower or higher rate of the page's automatic refresh. If this is not desired,
+     * the only way to bypass this is to initialize the {@see ActionController::$autorefreshInterval}
+     * property or to set the `autorefreshInterval` property of the layout directly.
+     *
+     * @param int $interval
+     *
+     * @return $this
+     */
     public function setAutorefreshInterval($interval)
     {
         if (! is_int($interval) || $interval < 1) {


### PR DESCRIPTION
We can't change its interface because the Director [overrides it](https://github.com/Icinga/icingaweb2-module-director/blob/master/library/Director/Web/Controller/ActionController.php#L132-L143) to accomplish something that could have also been patched into Icinga Web 2, but nvm..

The alternative solution for controllers not wanting to be subjected to the user's preferences is the one proposed here. Though, it requires to bypass the setter, of which I'm not a huge fan of. Though, it's the only *not-awkward* (without an over-complicated interface) solution I have.

I'm open for other alternatives.