### PR TITLE
Automatically preserve showCompact parameter when redirecting

### DIFF
--- a/library/Icinga/Web/Response.php
+++ b/library/Icinga/Web/Response.php
@@ -287,6 +287,10 @@ class Response extends Zend_Controller_Response_Http
         $redirectUrl = $this->getRedirectUrl();
         if ($this->getRequest()->isXmlHttpRequest()) {
             if ($redirectUrl !== null) {
+                if (Icinga::app()->getViewRenderer()->view->compact) {
+                    $redirectUrl->getParams()->set('showCompact', true);
+                }
+
                 $this->setHeader('X-Icinga-Redirect', rawurlencode($redirectUrl->getAbsoluteUrl()), true);
                 if ($this->getRerenderLayout()) {
                     $this->setHeader('X-Icinga-Rerender-Layout', 'yes', true);


### PR DESCRIPTION
If compact layout has been requested (`View::$compact === true`), `showCompact=1` is now automatically added to the target url.

This is based on the assumption that a request that is expected to return compact content, should do so even in case of a redirect. Without the client having to detect the redirect and re-request compact content. I also made this part of `Response` as handling this parameter (in this way) shouldn't be part of a module, but the framework itself.

refs #4164
fixes Icinga/icingadb-web#125