### PR TITLE
Do not abort LESS compilation due to missing variables and mixins

### DIFF
--- a/icingaweb2.ruleset.xml
+++ b/icingaweb2.ruleset.xml
@@ -22,6 +22,7 @@
         <exclude-pattern>library/Icinga/Application/LegacyWeb.php</exclude-pattern>
         <exclude-pattern>library/Icinga/Application/Web.php</exclude-pattern>
         <exclude-pattern>library/Icinga/File/Pdf.php</exclude-pattern>
+        <exclude-pattern>library/Icinga/Util/LessParser.php</exclude-pattern>
         <exclude-pattern>modules/doc/library/Doc/Renderer/DocSectionRenderer.php</exclude-pattern>
         <exclude-pattern>modules/monitoring/library/Monitoring/Plugin.php</exclude-pattern>
     </rule>

--- a/library/Icinga/Util/LessParser.php
+++ b/library/Icinga/Util/LessParser.php
@@ -1,0 +1,38 @@
+<?php
+/* Icinga Web 2 | (c) 2021 Icinga GmbH | GPLv2+ */
+
+namespace Icinga\Util;
+
+use Exception;
+use lessc;
+use Icinga\Application\Logger;
+
+require_once 'lessphp/lessc.inc.php';
+
+class LessParser extends lessc
+{
+    protected function get($name)
+    {
+        try {
+            return parent::get($name);
+        } catch (Exception $e) {
+            Logger::error($e->getMessage());
+        }
+
+        return ['string', '', []];
+    }
+
+    protected function compileProp($prop, $block, $out)
+    {
+        try {
+            parent::compileProp($prop, $block, $out);
+        } catch (Exception $e) {
+            if (strpos($e->getMessage(), 'is undefined:') === false) {
+                // We silence mixin errors only
+                throw $e;
+            }
+
+            Logger::error($e->getMessage());
+        }
+    }
+}

--- a/library/Icinga/Web/LessCompiler.php
+++ b/library/Icinga/Web/LessCompiler.php
@@ -4,7 +4,7 @@
 namespace Icinga\Web;
 
 use Icinga\Application\Logger;
-use lessc;
+use Icinga\Util\LessParser;
 
 /**
  * Compile LESS into CSS
@@ -16,7 +16,7 @@ class LessCompiler
     /**
      * lessphp compiler
      *
-     * @var lessc
+     * @var LessParser
      */
     protected $lessc;
 
@@ -60,8 +60,7 @@ class LessCompiler
      */
     public function __construct()
     {
-        require_once 'lessphp/lessc.inc.php';
-        $this->lessc = new lessc();
+        $this->lessc = new LessParser();
         // Discourage usage of import because we're caching based on an explicit list of LESS files to compile
         $this->lessc->importDisabled = true;
     }


### PR DESCRIPTION
Since the latest update of lessphp the compiler spit out fatal errors if it encountered missing variables or mixins. We accepted this because these are errors/bugs after all.

Though since we added support for libraries in #4271 we may face a bigger problem with this. A library may depend on a variable or even a mixin and if that's missing, katsching. This can always happen and even might not be due to a configuration error or forgotten installation.

Just consider a module that requires a library for which it has to provide a specific variable to initialize it correctly. And what happens if the user installs said library and tries to enable the module using the UI? Correct, katsching. (Though, only if there's no cache hit, but anyway..)

This PR now provides a subclass of `lessc` which only logs errors about missing vars and mixins. The resulting CSS may be partly invalid, but 99.9% of the UI is working and the user can enable modules without a hassle. Developers wondering why their elements miss a specific style just have to take a look into the log.