### PR TITLE
IDO: Add config option to use the customvariables table for fetching …

### DIFF
--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/IdoQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/IdoQuery.php
@@ -8,6 +8,7 @@ use Zend_Db_Expr;
 use Icinga\Application\Icinga;
 use Icinga\Application\Hook;
 use Icinga\Application\Logger;
+use Icinga\Application\Config;
 use Icinga\Data\Db\DbQuery;
 use Icinga\Data\Filter\Filter;
 use Icinga\Data\Filter\FilterExpression;
@@ -1216,8 +1217,14 @@ abstract class IdoQuery extends DbQuery
             $this->db->quote($name)
         );
 
+        if (! (bool) Config::module('monitoring')->get('ido', 'use_customvar_status_table', true)) {
+            $table = 'customvariables';
+        } else {
+            $table = 'customvariablestatus';
+        }
+        
         $this->select->joinLeft(
-            array($alias => $this->prefix . 'customvariablestatus'),
+            array($alias => $this->prefix . $table),
             $joinOn,
             array()
         );


### PR DESCRIPTION
workaround for icinga2 issue #5621

same solution as
https://github.com/Icinga/icingaweb2/commit/1ed2ebc1916d6d83a62cf649de0f5b981c27fc4b


This commit introduces a config option to use the customvariables table instead:
/etc/icingaweb2/modules/monitoring/config.ini

[ido]
use_customvar_status_table = 0