### PR TITLE
Authorization enhancements

### DIFF
--- a/application/controllers/AccountController.php
+++ b/application/controllers/AccountController.php
@@ -43,7 +43,7 @@ class AccountController extends Controller
         $config = Config::app()->getSection('global');
         $user = $this->Auth()->getUser();
         if ($user->getAdditional('backend_type') === 'db') {
-            if ($user->can('*') || ! $user->can('no-user/password-change')) {
+            if ($user->can('user/password-change')) {
                 try {
                     $userBackend = UserBackend::create($user->getAdditional('backend_name'));
                 } catch (ConfigurationError $e) {

--- a/application/controllers/AnnouncementsController.php
+++ b/application/controllers/AnnouncementsController.php
@@ -61,7 +61,7 @@ class AnnouncementsController extends Controller
      */
     public function newAction()
     {
-        $this->assertPermission('admin');
+        $this->assertPermission('application/announcements');
 
         $form = $this->prepareForm()->add();
         $form->handleRequest();
@@ -73,7 +73,7 @@ class AnnouncementsController extends Controller
      */
     public function updateAction()
     {
-        $this->assertPermission('admin');
+        $this->assertPermission('application/announcements');
 
         $form = $this->prepareForm()->edit($this->params->getRequired('id'));
         try {
@@ -89,7 +89,7 @@ class AnnouncementsController extends Controller
      */
     public function removeAction()
     {
-        $this->assertPermission('admin');
+        $this->assertPermission('application/announcements');
 
         $form = $this->prepareForm()->remove($this->params->getRequired('id'));
         try {

--- a/application/controllers/GroupController.php
+++ b/application/controllers/GroupController.php
@@ -33,7 +33,7 @@ class GroupController extends AuthBackendController
      */
     public function listAction()
     {
-        $this->assertPermission('config/authentication/groups/show');
+        $this->assertPermission('config/access-control/groups');
         $this->createListTabs()->activate('group/list');
         $backendNames = array_map(
             function ($b) {
@@ -90,7 +90,7 @@ class GroupController extends AuthBackendController
      */
     public function showAction()
     {
-        $this->assertPermission('config/authentication/groups/show');
+        $this->assertPermission('config/access-control/groups');
         $groupName = $this->params->getRequired('group');
         $backend = $this->getUserGroupBackend($this->params->getRequired('backend'));
 
@@ -125,7 +125,7 @@ class GroupController extends AuthBackendController
         $this->view->members = $members;
         $this->createShowTabs($backend->getName(), $groupName)->activate('group/show');
 
-        if ($this->hasPermission('config/authentication/groups/edit') && $backend instanceof Reducible) {
+        if ($this->hasPermission('config/access-control/groups') && $backend instanceof Reducible) {
             $removeForm = new Form();
             $removeForm->setUidDisabled();
             $removeForm->setAttrib('class', 'inline');
@@ -161,7 +161,7 @@ class GroupController extends AuthBackendController
      */
     public function addAction()
     {
-        $this->assertPermission('config/authentication/groups/add');
+        $this->assertPermission('config/access-control/groups');
         $backend = $this->getUserGroupBackend($this->params->getRequired('backend'), 'Icinga\Data\Extensible');
         $form = new UserGroupForm();
         $form->setRedirectUrl(Url::fromPath('group/list', array('backend' => $backend->getName())));
@@ -176,7 +176,7 @@ class GroupController extends AuthBackendController
      */
     public function editAction()
     {
-        $this->assertPermission('config/authentication/groups/edit');
+        $this->assertPermission('config/access-control/groups');
         $groupName = $this->params->getRequired('group');
         $backend = $this->getUserGroupBackend($this->params->getRequired('backend'), 'Icinga\Data\Updatable');
 
@@ -200,7 +200,7 @@ class GroupController extends AuthBackendController
      */
     public function removeAction()
     {
-        $this->assertPermission('config/authentication/groups/remove');
+        $this->assertPermission('config/access-control/groups');
         $groupName = $this->params->getRequired('group');
         $backend = $this->getUserGroupBackend($this->params->getRequired('backend'), 'Icinga\Data\Reducible');
 
@@ -222,7 +222,7 @@ class GroupController extends AuthBackendController
      */
     public function addmemberAction()
     {
-        $this->assertPermission('config/authentication/groups/edit');
+        $this->assertPermission('config/access-control/groups');
         $groupName = $this->params->getRequired('group');
         $backend = $this->getUserGroupBackend($this->params->getRequired('backend'), 'Icinga\Data\Extensible');
 
@@ -249,7 +249,7 @@ class GroupController extends AuthBackendController
      */
     public function removememberAction()
     {
-        $this->assertPermission('config/authentication/groups/edit');
+        $this->assertPermission('config/access-control/groups');
         $this->assertHttpMethod('POST');
         $groupName = $this->params->getRequired('group');
         $backend = $this->getUserGroupBackend($this->params->getRequired('backend'), 'Icinga\Data\Reducible');
@@ -368,26 +368,32 @@ class GroupController extends AuthBackendController
     protected function createListTabs()
     {
         $tabs = $this->getTabs();
-        $tabs->add(
-            'role/list',
-            array(
-                'baseTarget'    => '_main',
-                'label'         => $this->translate('Roles'),
-                'title'         => $this->translate(
-                    'Configure roles to permit or restrict users and groups accessing Icinga Web 2'
-                ),
-                'url'           => 'role/list'
 
-            )
-        );
-        $tabs->add(
-            'user/list',
-            array(
-                'title'     => $this->translate('List users of authentication backends'),
-                'label'     => $this->translate('Users'),
-                'url'       => 'user/list'
-            )
-        );
+        if ($this->hasPermission('config/access-control/roles')) {
+            $tabs->add(
+                'role/list',
+                array(
+                    'baseTarget'    => '_main',
+                    'label'         => $this->translate('Roles'),
+                    'title'         => $this->translate(
+                        'Configure roles to permit or restrict users and groups accessing Icinga Web 2'
+                    ),
+                    'url'           => 'role/list'
+                )
+            );
+        }
+
+        if ($this->hasPermission('config/access-control/users')) {
+            $tabs->add(
+                'user/list',
+                array(
+                    'title'     => $this->translate('List users of authentication backends'),
+                    'label'     => $this->translate('Users'),
+                    'url'       => 'user/list'
+                )
+            );
+        }
+
         $tabs->add(
             'group/list',
             array(
@@ -396,6 +402,7 @@ class GroupController extends AuthBackendController
                 'url'       => 'group/list'
             )
         );
+
         return $tabs;
     }
 }

--- a/application/controllers/NavigationController.php
+++ b/application/controllers/NavigationController.php
@@ -161,7 +161,7 @@ class NavigationController extends Controller
      */
     public function sharedAction()
     {
-        $this->assertPermission('config/application/navigation');
+        $this->assertPermission('config/navigation');
         $ds = new ArrayDatasource($this->fetchSharedNavigationItemConfigs());
         $query = $ds->select();
 
@@ -259,7 +259,7 @@ class NavigationController extends Controller
         $referrer = $this->params->get('referrer', 'index');
 
         $user = $this->Auth()->getUser();
-        if ($user->can('config/application/navigation')) {
+        if ($user->can('config/navigation')) {
             $itemOwner = $this->params->get('owner', $user->getUsername());
         } else {
             $itemOwner = $user->getUsername();
@@ -354,7 +354,7 @@ class NavigationController extends Controller
      */
     public function unshareAction()
     {
-        $this->assertPermission('config/application/navigation');
+        $this->assertPermission('config/navigation');
         $this->assertHttpMethod('POST');
 
         // TODO: I'd like these being form fields

--- a/application/controllers/UserController.php
+++ b/application/controllers/UserController.php
@@ -33,7 +33,7 @@ class UserController extends AuthBackendController
      */
     public function listAction()
     {
-        $this->assertPermission('config/authentication/users/show');
+        $this->assertPermission('config/access-control/users');
         $this->createListTabs()->activate('user/list');
         $backendNames = array_map(
             function ($b) {
@@ -91,7 +91,7 @@ class UserController extends AuthBackendController
      */
     public function showAction()
     {
-        $this->assertPermission('config/authentication/users/show');
+        $this->assertPermission('config/access-control/users');
         $userName = $this->params->getRequired('user');
         $backend = $this->getUserBackend($this->params->getRequired('backend'));
 
@@ -127,7 +127,7 @@ class UserController extends AuthBackendController
             $memberships
         );
 
-        if ($this->hasPermission('config/authentication/groups/edit')) {
+        if ($this->hasPermission('config/access-control/groups')) {
             $extensibleBackends = $this->loadUserGroupBackends('Icinga\Data\Extensible');
             $this->view->showCreateMembershipLink = ! empty($extensibleBackends);
         } else {
@@ -139,7 +139,7 @@ class UserController extends AuthBackendController
         $this->view->memberships = $memberships;
         $this->createShowTabs($backend->getName(), $userName)->activate('user/show');
 
-        if ($this->hasPermission('config/authentication/groups/edit')) {
+        if ($this->hasPermission('config/access-control/groups')) {
             $removeForm = new Form();
             $removeForm->setUidDisabled();
             $removeForm->setAttrib('class', 'inline');
@@ -170,7 +170,7 @@ class UserController extends AuthBackendController
         $admissionLoader = new AdmissionLoader();
         $admissionLoader->applyRoles($userObj);
         $this->view->userObj = $userObj;
-        $this->view->allowedToEditRoles = $this->hasPermission('config/authentication/roles/edit');
+        $this->view->allowedToEditRoles = $this->hasPermission('config/access-control/groups');
     }
 
     /**
@@ -178,7 +178,7 @@ class UserController extends AuthBackendController
      */
     public function addAction()
     {
-        $this->assertPermission('config/authentication/users/add');
+        $this->assertPermission('config/access-control/users');
         $backend = $this->getUserBackend($this->params->getRequired('backend'), 'Icinga\Data\Extensible');
         $form = new UserForm();
         $form->setRedirectUrl(Url::fromPath('user/list', array('backend' => $backend->getName())));
@@ -193,7 +193,7 @@ class UserController extends AuthBackendController
      */
     public function editAction()
     {
-        $this->assertPermission('config/authentication/users/edit');
+        $this->assertPermission('config/access-control/users');
         $userName = $this->params->getRequired('user');
         $backend = $this->getUserBackend($this->params->getRequired('backend'), 'Icinga\Data\Updatable');
 
@@ -215,7 +215,7 @@ class UserController extends AuthBackendController
      */
     public function removeAction()
     {
-        $this->assertPermission('config/authentication/users/remove');
+        $this->assertPermission('config/access-control/users');
         $userName = $this->params->getRequired('user');
         $backend = $this->getUserBackend($this->params->getRequired('backend'), 'Icinga\Data\Reducible');
 
@@ -237,7 +237,7 @@ class UserController extends AuthBackendController
      */
     public function createmembershipAction()
     {
-        $this->assertPermission('config/authentication/groups/edit');
+        $this->assertPermission('config/access-control/groups');
         $userName = $this->params->getRequired('user');
         $backend = $this->getUserBackend($this->params->getRequired('backend'));
 
@@ -325,18 +325,21 @@ class UserController extends AuthBackendController
     protected function createListTabs()
     {
         $tabs = $this->getTabs();
-        $tabs->add(
-            'role/list',
-            array(
-                'baseTarget'    => '_main',
-                'label'         => $this->translate('Roles'),
-                'title'         => $this->translate(
-                    'Configure roles to permit or restrict users and groups accessing Icinga Web 2'
-                ),
-                'url'           => 'role/list'
 
-            )
-        );
+        if ($this->hasPermission('config/access-control/roles')) {
+            $tabs->add(
+                'role/list',
+                array(
+                    'baseTarget'    => '_main',
+                    'label'         => $this->translate('Roles'),
+                    'title'         => $this->translate(
+                        'Configure roles to permit or restrict users and groups accessing Icinga Web 2'
+                    ),
+                    'url'           => 'role/list'
+                )
+            );
+        }
+
         $tabs->add(
             'user/list',
             array(
@@ -345,14 +348,18 @@ class UserController extends AuthBackendController
                 'url'       => 'user/list'
             )
         );
-        $tabs->add(
-            'group/list',
-            array(
-                'title'     => $this->translate('List groups of user group backends'),
-                'label'     => $this->translate('User Groups'),
-                'url'       => 'group/list'
-            )
-        );
+
+        if ($this->hasPermission('config/access-control/groups')) {
+            $tabs->add(
+                'group/list',
+                array(
+                    'title'     => $this->translate('List groups of user group backends'),
+                    'label'     => $this->translate('User Groups'),
+                    'url'       => 'group/list'
+                )
+            );
+        }
+
         return $tabs;
     }
 }

--- a/application/controllers/UsergroupbackendController.php
+++ b/application/controllers/UsergroupbackendController.php
@@ -21,7 +21,7 @@ class UsergroupbackendController extends Controller
      */
     public function init()
     {
-        $this->assertPermission('config/application/usergroupbackend');
+        $this->assertPermission('config/access-control/users');
     }
 
     /**

--- a/application/forms/Navigation/NavigationConfigForm.php
+++ b/application/forms/Navigation/NavigationConfigForm.php
@@ -299,7 +299,7 @@ class NavigationConfigForm extends ConfigForm
         $shared = false;
         $config = $this->getUserConfig($data['type']);
         if ((isset($data['users']) && $data['users']) || (isset($data['groups']) && $data['groups'])) {
-            if ($this->getUser()->can('application/share/navigation')) {
+            if ($this->getUser()->can('user/share/navigation')) {
                 $data['owner'] = $this->getUser()->getUsername();
                 $config = $this->getShareConfig($data['type']);
                 $shared = true;
@@ -370,7 +370,7 @@ class NavigationConfigForm extends ConfigForm
                 $config = $this->unshare($name, isset($data['parent']) ? $data['parent'] : null);
             }
         } elseif ((isset($data['users']) && $data['users']) || (isset($data['groups']) && $data['groups'])) {
-            if ($this->getUser()->can('application/share/navigation')) {
+            if ($this->getUser()->can('user/share/navigation')) {
                 // It is not shared yet but should be
                 $this->secondaryConfig = $config;
                 $config = $this->getShareConfig();
@@ -580,7 +580,7 @@ class NavigationConfigForm extends ConfigForm
         );
 
         if ((! $itemForm->requiresParentSelection() || ! isset($formData['parent']) || ! $formData['parent'])
-            && $this->getUser()->can('application/share/navigation')
+            && $this->getUser()->can('user/share/navigation')
         ) {
             $checked = isset($formData['shared']) ? null : (isset($formData['users']) || isset($formData['groups']));
 
@@ -783,7 +783,7 @@ class NavigationConfigForm extends ConfigForm
             return $this->getUserConfig();
         } elseif ($this->getShareConfig()->hasSection($name)) {
             if ($this->getShareConfig()->get($name, 'owner') === $this->getUser()->getUsername()
-                || $this->getUser()->can('config/application/navigation')
+                || $this->getUser()->can('user/share/navigation')
             ) {
                 return $this->getShareConfig();
             }

--- a/application/forms/PreferenceForm.php
+++ b/application/forms/PreferenceForm.php
@@ -255,7 +255,7 @@ class PreferenceForm extends Form
             )
         );
 
-        if (Auth::getInstance()->hasPermission('application/stacktraces')) {
+        if (Auth::getInstance()->hasPermission('user/application/stacktraces')) {
             $this->addElement(
                 'checkbox',
                 'show_stacktraces',

--- a/application/forms/Security/RoleForm.php
+++ b/application/forms/Security/RoleForm.php
@@ -195,8 +195,19 @@ class RoleForm extends RepositoryForm
                 'description'   => $this->translate('Everything is allowed')
             ]
         );
+        $this->addElement(
+            'checkbox',
+            'unrestricted',
+            [
+                'autosubmit'        => true,
+                'uncheckedValue'    => null,
+                'label'             => $this->translate('Unrestricted Access'),
+                'description'       => $this->translate('Access to any data is completely unrestricted')
+            ]
+        );
 
         $hasAdminPerm = isset($formData[self::WILDCARD_NAME]) && $formData[self::WILDCARD_NAME];
+        $isUnrestricted = isset($formData['unrestricted']) && $formData['unrestricted'];
         foreach ($this->providedPermissions as $moduleName => $permissionList) {
             $this->sortPermissions($permissionList);
 
@@ -301,7 +312,9 @@ class RoleForm extends RepositoryForm
                                 '/&#8203;',
                                 isset($spec['label']) ? $spec['label'] : $spec['name']
                             ),
-                            'description'   => $spec['description']
+                            'description'   => $spec['description'],
+                            'style'         => $isUnrestricted ? 'text-decoration:line-through;' : '',
+                            'readonly'      => $isUnrestricted ?: null
                         ]
                     )
                         ->getElement($name)
@@ -339,6 +352,7 @@ class RoleForm extends RepositoryForm
             'name'              => $role->name,
             'users'             => $role->users,
             'groups'            => $role->groups,
+            'unrestricted'      => $role->unrestricted,
             self::WILDCARD_NAME => (bool) preg_match('~(?<!/)\*~', $role->permissions)
         ];
 

--- a/application/views/scripts/announcements/index.phtml
+++ b/application/views/scripts/announcements/index.phtml
@@ -10,7 +10,7 @@
 </div>
 <?php endif ?>
 <div class="content">
-<?php if ($this->hasPermission('admin')) {
+<?php if ($this->hasPermission('application/announcements')) {
     echo $this->qlink(
         $this->translate('Create a New Announcement') ,
         'announcements/new',
@@ -41,7 +41,7 @@
     <?php foreach ($this->announcements as $announcement): /** @var object $announcement */ ?>
         <tr>
             <td><?= $this->escape($announcement->author) ?></td>
-        <?php if ($this->hasPermission('admin')): ?>
+        <?php if ($this->hasPermission('application/announcements')): ?>
             <td>
                 <a href="<?= $this->href('announcements/update', array('id' => $announcement->id)) ?>">
                     <?= $this->ellipsis($this->escape($announcement->message), 100) ?>
@@ -52,7 +52,7 @@
         <?php endif ?>
             <td><?= $this->formatDateTime($announcement->start) ?></td>
             <td><?= $this->formatDateTime($announcement->end) ?></td>
-        <?php if ($this->hasPermission('admin')): ?>
+        <?php if ($this->hasPermission('application/announcements')): ?>
             <td class="icon-col"><?= $this->qlink(
                 null,
                 'announcements/remove',

--- a/application/views/scripts/config/userbackend/reorder.phtml
+++ b/application/views/scripts/config/userbackend/reorder.phtml
@@ -2,6 +2,7 @@
     <?= $tabs ?>
 </div>
 <div class="content">
+  <?php if ($this->auth()->hasPermission('config/access-control/users')): ?>
     <h1><?= $this->translate('User Backends') ?></h1>
     <?= $this->qlink(
         $this->translate('Create a New User Backend') ,
@@ -15,7 +16,9 @@
         )
     ) ?>
     <?= $form ?>
+  <?php endif ?>
 
+  <?php if ($this->auth()->hasPermission('config/access-control/groups')): ?>
     <h1><?= $this->translate('User Group Backends') ?></h1>
     <?= $this->qlink(
         $this->translate('Create a New User Group Backend') ,
@@ -68,4 +71,5 @@
     <?php endforeach ?>
     </tbody>
     </table>
+  <?php endif ?>
 </div>

--- a/application/views/scripts/group/list.phtml
+++ b/application/views/scripts/group/list.phtml
@@ -22,8 +22,8 @@ if (! isset($backend)) {
     echo $this->translate('No backend found which is able to list user groups') . '</div>';
     return;
 } else {
-    $extensible = $this->hasPermission('config/authentication/groups/add') && $backend instanceof Extensible;
-    $reducible = $this->hasPermission('config/authentication/groups/remove') && $backend instanceof Reducible;
+    $extensible = $this->hasPermission('config/access-control/groups') && $backend instanceof Extensible;
+    $reducible = $this->hasPermission('config/access-control/groups') && $backend instanceof Reducible;
 }
 ?>
 

--- a/application/views/scripts/group/show.phtml
+++ b/application/views/scripts/group/show.phtml
@@ -3,10 +3,10 @@
 use Icinga\Data\Extensible;
 use Icinga\Data\Updatable;
 
-$extensible = $this->hasPermission('config/authentication/groups/add') && $backend instanceof Extensible;
+$extensible = $this->hasPermission('config/access-control/groups') && $backend instanceof Extensible;
 
 $editLink = null;
-if ($this->hasPermission('config/authentication/groups/edit') && $backend instanceof Updatable) {
+if ($this->hasPermission('config/access-control/groups') && $backend instanceof Updatable) {
     $editLink = $this->qlink(
         null,
         'group/edit',
@@ -83,7 +83,7 @@ if ($this->hasPermission('config/authentication/groups/edit') && $backend instan
             <tr>
                 <td>
                 <?php if (
-                    $this->hasPermission('config/authentication/users/show')
+                    $this->hasPermission('config/access-control/users')
                     && ($userBackend = $backend->getUserBackendName($member->user_name)) !== null
                 ): ?>
                     <?= $this->qlink($member->user_name, 'user/show', array(

--- a/application/views/scripts/role/list.phtml
+++ b/application/views/scripts/role/list.phtml
@@ -28,6 +28,7 @@
         <th><?= $this->translate('Name') ?></th>
         <th><?= $this->translate('Users') ?></th>
         <th><?= $this->translate('Groups') ?></th>
+        <th><?= $this->translate('Inherits From') ?></th>
         <th></th>
     </tr>
     </thead>
@@ -44,6 +45,7 @@
         </td>
         <td><?= $this->escape($role->users) ?></td>
         <td><?= $this->escape($role->groups) ?></td>
+        <td><?= $this->escape($role->parent) ?></td>
         <td class="icon-col text-right">
             <?= $this->qlink(
                 '',

--- a/application/views/scripts/user/list.phtml
+++ b/application/views/scripts/user/list.phtml
@@ -22,8 +22,8 @@ if (! isset($backend)) {
     echo $this->translate('No backend found which is able to list users') . '</div>';
     return;
 } else {
-    $extensible = $this->hasPermission('config/authentication/users/add') && $backend instanceof Extensible;
-    $reducible = $this->hasPermission('config/authentication/users/remove') && $backend instanceof Reducible;
+    $extensible = $this->hasPermission('config/access-control/users') && $backend instanceof Extensible;
+    $reducible = $this->hasPermission('config/access-control/users') && $backend instanceof Reducible;
 }
 ?>
 

--- a/application/views/scripts/user/show.phtml
+++ b/application/views/scripts/user/show.phtml
@@ -11,7 +11,7 @@ use Icinga\Data\Selectable;
 <?php endif ?>
     <h2><?= $this->escape($user->user_name) ?></h2>
     <?php
-    if ($this->hasPermission('config/authentication/users/edit') && $backend instanceof Updatable) {
+    if ($this->hasPermission('config/access-control/users') && $backend instanceof Updatable) {
         echo $this->qlink(
             $this->translate('Edit User'),
             'user/edit',
@@ -110,7 +110,7 @@ use Icinga\Data\Selectable;
         <?php foreach ($memberships as $membership): ?>
             <tr>
                 <td>
-                <?php if ($this->hasPermission('config/authentication/groups/show') && $membership->backend instanceof Selectable): ?>
+                <?php if ($this->hasPermission('config/access-control/groups') && $membership->backend instanceof Selectable): ?>
                     <?= $this->qlink($membership->group_name, 'group/show', array(
                         'backend' => $membership->backend->getName(),
                         'group'   => $membership->group_name

--- a/doc/06-Security.md
+++ b/doc/06-Security.md
@@ -80,7 +80,16 @@ users                     | Comma-separated list of **usernames** that should oc
 groups                    | Comma-separated list of **group names** whose users should occupy this role.
 permissions               | Comma-separated list of **permissions** granted by this role.
 refusals                  | Comma-separated list of **permissions** refused by this role.
+unrestricted              | If set to `1`, owners of this role are not restricted in any way (Default: `0`)
 monitoring/filter/objects | **Filter expression** that restricts the access to monitoring objects.
+
+### Administrative Roles
+
+Roles that have the wildcard `*` as permission, have full access and don't need any further permissions. However,
+they are still affected by refusals.
+
+Unrestricted roles are supposed to allow users to access data without being limited to a subset of it. Once a user
+occupies an unrestricted role, restrictions of the same and any other role are ignored.
 
 ### Inheritance
 

--- a/doc/06-Security.md
+++ b/doc/06-Security.md
@@ -110,12 +110,25 @@ a module permission in the format `module/<moduleName>` for each installed modul
 
 ### General Permissions
 
-Name                      | Permits
---------------------------|-----------------------------------------------
-\*                        | allow everything, including module-specific permissions
-config/\*                 | allow all configuration actions
-config/modules            | allow enabling or disabling modules
-module/`<moduleName>`     | allow access to module `<moduleName>` (e.g. `module/monitoring`)
+Name                         | Permits
+-----------------------------|-----------------------------------------------
+\*                           | allow everything, including module-specific permissions
+application/announcements    | allow to manage announcements
+application/log              | allow to view the application log
+config/\*                    | allow full config access
+config/access-control/\*     | allow to fully manage access control
+config/access-control/groups | allow to manage groups
+config/access-control/roles  | allow to manage roles
+config/access-control/users  | allow to manage user accounts
+config/general               | allow to adjust the general configuration
+config/modules               | allow to enable/disable and configure modules
+config/navigation            | allow to view and adjust shared navigation items
+config/resources             | allow to manage resources
+user/\*                      | allow all account related functionalities
+user/application/stacktraces | allow to adjust in the preferences whether to show stacktraces
+user/password-change         | allow password changes in the account preferences
+user/share/navigation        | allow to share navigation items
+module/`<moduleName>`        | allow access to module `<moduleName>` (e.g. `module/monitoring`)
 
 ### Monitoring Module Permissions
 

--- a/library/Icinga/Application/Web.php
+++ b/library/Icinga/Application/Web.php
@@ -336,7 +336,7 @@ class Web extends EmbeddedWeb
             $this->getRequest()->setUser($user);
             $this->user = $user;
 
-            if ($user->can('application/stacktraces')) {
+            if ($user->can('user/application/stacktraces')) {
                 $displayExceptions = $this->user->getPreferences()->getValue(
                     'icingaweb',
                     'show_stacktraces'

--- a/library/Icinga/Authentication/AdmissionLoader.php
+++ b/library/Icinga/Authentication/AdmissionLoader.php
@@ -71,6 +71,7 @@ class AdmissionLoader
         foreach ($roles as $roleName => $role) {
             if ($this->match($username, $userGroups, $role)) {
                 $permissionsFromRole = StringHelper::trimSplit($role->permissions);
+                $refusals = StringHelper::trimSplit($role->refusals);
                 $permissions = array_merge(
                     $permissions,
                     array_diff($permissionsFromRole, $permissions)
@@ -78,6 +79,7 @@ class AdmissionLoader
                 $restrictionsFromRole = $role->toArray();
                 unset($restrictionsFromRole['users']);
                 unset($restrictionsFromRole['groups']);
+                unset($restrictionsFromRole['refusals']);
                 unset($restrictionsFromRole['permissions']);
                 foreach ($restrictionsFromRole as $name => $restriction) {
                     if (! isset($restrictions[$name])) {
@@ -89,6 +91,7 @@ class AdmissionLoader
                 $roleObj = new Role();
                 $roleObjs[] = $roleObj
                     ->setName($roleName)
+                    ->setRefusals($refusals)
                     ->setPermissions($permissionsFromRole)
                     ->setRestrictions($restrictionsFromRole);
             }

--- a/library/Icinga/Authentication/AdmissionLoader.php
+++ b/library/Icinga/Authentication/AdmissionLoader.php
@@ -155,9 +155,13 @@ class AdmissionLoader
                         array_diff($role->getPermissions(), $permissions)
                     );
 
-                    foreach ($role->getRestrictions() as $name => $restriction) {
+                    $roleRestrictions = $role->getRestrictions();
+                    foreach ($roleRestrictions as $name => & $restriction) {
+                        $restriction = str_replace('$user:local_name$', $user->getLocalUsername(), $restriction);
                         $restrictions[$name][] = $restriction;
                     }
+
+                    $role->setRestrictions($roleRestrictions);
                 }
             }
         }

--- a/library/Icinga/Authentication/AdmissionLoader.php
+++ b/library/Icinga/Authentication/AdmissionLoader.php
@@ -93,7 +93,8 @@ class AdmissionLoader
                 ->setName($name)
                 ->setRefusals($refusals)
                 ->setPermissions($permissions)
-                ->setRestrictions($restrictions);
+                ->setRestrictions($restrictions)
+                ->setIsUnrestricted($section->get('unrestricted', false));
 
             if (isset($section->parent)) {
                 $parentName = $section->parent;
@@ -144,6 +145,7 @@ class AdmissionLoader
         $roles = [];
         $permissions = [];
         $restrictions = [];
+        $isUnrestricted = false;
         foreach ($this->roleConfig as $roleName => $roleConfig) {
             if (! isset($roles[$roleName]) && $this->match($username, $userGroups, $roleConfig)) {
                 foreach ($this->loadRole($roleName, $roleConfig) as $role) {
@@ -162,11 +164,15 @@ class AdmissionLoader
                     }
 
                     $role->setRestrictions($roleRestrictions);
+
+                    if (! $isUnrestricted) {
+                        $isUnrestricted = $role->isUnrestricted();
+                    }
                 }
             }
         }
 
-        $user->setRestrictions($restrictions);
+        $user->setRestrictions($isUnrestricted ? [] : $restrictions);
         $user->setPermissions($permissions);
         $user->setRoles(array_values($roles));
     }

--- a/library/Icinga/Authentication/Role.php
+++ b/library/Icinga/Authentication/Role.php
@@ -106,4 +106,41 @@ class Role
         $this->restrictions = $restrictions;
         return $this;
     }
+
+    /**
+     * Whether this role grants the given permission
+     *
+     * @param string $permission
+     *
+     * @return bool
+     */
+    public function grants($permission)
+    {
+        $requiredWildcard = strpos($permission, '*');
+        foreach ($this->permissions as $grantedPermission) {
+            if ($grantedPermission === '*' || $grantedPermission === $permission) {
+                return true;
+            }
+
+            if ($requiredWildcard !== false) {
+                if (($grantedWildcard = strpos($grantedPermission, '*')) !== false) {
+                    $wildcard = min($requiredWildcard, $grantedWildcard);
+                } else {
+                    $wildcard = $requiredWildcard;
+                }
+            } else {
+                $wildcard = strpos($grantedPermission, '*');
+            }
+
+            if ($wildcard !== false && $wildcard > 0) {
+                if (substr($permission, 0, $wildcard) === substr($grantedPermission, 0, $wildcard)) {
+                    return true;
+                }
+            } elseif ($permission === $grantedPermission) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/library/Icinga/Authentication/Role.php
+++ b/library/Icinga/Authentication/Role.php
@@ -27,6 +27,13 @@ class Role
     protected $children;
 
     /**
+     * Whether restrictions should not apply to owners of the role
+     *
+     * @var bool
+     */
+    protected $unrestricted = false;
+
+    /**
      * Permissions of the role
      *
      * @var string[]
@@ -129,6 +136,30 @@ class Role
     public function addChild(Role $role)
     {
         $this->children[] = $role;
+
+        return $this;
+    }
+
+    /**
+     * Get whether restrictions should not apply to owners of the role
+     *
+     * @return bool
+     */
+    public function isUnrestricted()
+    {
+        return $this->unrestricted;
+    }
+
+    /**
+     * Set whether restrictions should not apply to owners of the role
+     *
+     * @param bool $state
+     *
+     * @return $this
+     */
+    public function setIsUnrestricted($state)
+    {
+        $this->unrestricted = (bool) $state;
 
         return $this;
     }

--- a/library/Icinga/Authentication/Role.php
+++ b/library/Icinga/Authentication/Role.php
@@ -13,6 +13,20 @@ class Role
     protected $name;
 
     /**
+     * The role from which to inherit privileges
+     *
+     * @var Role
+     */
+    protected $parent;
+
+    /**
+     * The roles to which privileges are inherited
+     *
+     * @var Role[]
+     */
+    protected $children;
+
+    /**
      * Permissions of the role
      *
      * @var string[]
@@ -53,6 +67,68 @@ class Role
     public function setName($name)
     {
         $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * Get the role from which privileges are inherited
+     *
+     * @return Role
+     */
+    public function getParent()
+    {
+        return $this->parent;
+    }
+
+    /**
+     * Set the role from which to inherit privileges
+     *
+     * @param Role $parent
+     *
+     * @return $this
+     */
+    public function setParent(Role $parent)
+    {
+        $this->parent = $parent;
+
+        return $this;
+    }
+
+    /**
+     * Get the roles to which privileges are inherited
+     *
+     * @return Role[]
+     */
+    public function getChildren()
+    {
+        return $this->children;
+    }
+
+    /**
+     * Set the roles to which inherit privileges
+     *
+     * @param Role[] $children
+     *
+     * @return $this
+     */
+    public function setChildren(array $children)
+    {
+        $this->children = $children;
+
+        return $this;
+    }
+
+    /**
+     * Add a role to which inherit privileges
+     *
+     * @param Role $role
+     *
+     * @return $this
+     */
+    public function addChild(Role $role)
+    {
+        $this->children[] = $role;
 
         return $this;
     }
@@ -145,15 +221,20 @@ class Role
      * Whether this role grants the given permission
      *
      * @param string $permission
+     * @param bool $ignoreParent    Only evaluate the role's own permissions
      *
      * @return bool
      */
-    public function grants($permission)
+    public function grants($permission, $ignoreParent = false)
     {
         foreach ($this->permissions as $grantedPermission) {
             if ($this->match($grantedPermission, $permission)) {
                 return true;
             }
+        }
+
+        if (! $ignoreParent && $this->getParent() !== null) {
+            return $this->getParent()->grants($permission);
         }
 
         return false;
@@ -163,15 +244,20 @@ class Role
      * Whether this role denies the given permission
      *
      * @param string $permission
+     * @param bool $ignoreParent    Only evaluate the role's own refusals
      *
      * @return bool
      */
-    public function denies($permission)
+    public function denies($permission, $ignoreParent = false)
     {
         foreach ($this->refusals as $refusedPermission) {
             if ($this->match($refusedPermission, $permission, false)) {
                 return true;
             }
+        }
+
+        if (! $ignoreParent && $this->getParent() !== null) {
+            return $this->getParent()->denies($permission);
         }
 
         return false;

--- a/library/Icinga/Authentication/Role.php
+++ b/library/Icinga/Authentication/Role.php
@@ -17,14 +17,21 @@ class Role
      *
      * @var string[]
      */
-    protected $permissions = array();
+    protected $permissions = [];
+
+    /**
+     * Refusals of the role
+     *
+     * @var string[]
+     */
+    protected $refusals = [];
 
     /**
      * Restrictions of the role
      *
      * @var string[]
      */
-    protected $restrictions = array();
+    protected $restrictions = [];
 
     /**
      * Get the name of the role
@@ -46,6 +53,7 @@ class Role
     public function setName($name)
     {
         $this->name = $name;
+
         return $this;
     }
 
@@ -69,6 +77,31 @@ class Role
     public function setPermissions(array $permissions)
     {
         $this->permissions = $permissions;
+
+        return $this;
+    }
+
+    /**
+     * Get the refusals of the role
+     *
+     * @return string[]
+     */
+    public function getRefusals()
+    {
+        return $this->refusals;
+    }
+
+    /**
+     * Set the refusals of the role
+     *
+     * @param array $refusals
+     *
+     * @return $this
+     */
+    public function setRefusals(array $refusals)
+    {
+        $this->refusals = $refusals;
+
         return $this;
     }
 
@@ -104,6 +137,7 @@ class Role
     public function setRestrictions(array $restrictions)
     {
         $this->restrictions = $restrictions;
+
         return $this;
     }
 
@@ -116,29 +150,65 @@ class Role
      */
     public function grants($permission)
     {
-        $requiredWildcard = strpos($permission, '*');
         foreach ($this->permissions as $grantedPermission) {
-            if ($grantedPermission === '*' || $grantedPermission === $permission) {
+            if ($this->match($grantedPermission, $permission)) {
                 return true;
             }
+        }
 
-            if ($requiredWildcard !== false) {
-                if (($grantedWildcard = strpos($grantedPermission, '*')) !== false) {
-                    $wildcard = min($requiredWildcard, $grantedWildcard);
-                } else {
-                    $wildcard = $requiredWildcard;
-                }
+        return false;
+    }
+
+    /**
+     * Whether this role denies the given permission
+     *
+     * @param string $permission
+     *
+     * @return bool
+     */
+    public function denies($permission)
+    {
+        foreach ($this->refusals as $refusedPermission) {
+            if ($this->match($refusedPermission, $permission, false)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Get whether the role expression matches the required permission
+     *
+     * @param string $roleExpression
+     * @param string $requiredPermission
+     * @param bool $cascadeUpwards `false` if `foo/bar/*` and `foo/bar/raboof` should not match `foo/*`
+     *
+     * @return bool
+     */
+    protected function match($roleExpression, $requiredPermission, $cascadeUpwards = true)
+    {
+        if ($roleExpression === '*' || $roleExpression === $requiredPermission) {
+            return true;
+        }
+
+        $requiredWildcard = strpos($requiredPermission, '*');
+        if ($requiredWildcard !== false) {
+            if (($grantedWildcard = strpos($roleExpression, '*')) !== false) {
+                $wildcard = $cascadeUpwards ? min($requiredWildcard, $grantedWildcard) : $grantedWildcard;
             } else {
-                $wildcard = strpos($grantedPermission, '*');
+                $wildcard = $cascadeUpwards ? $requiredWildcard : false;
             }
+        } else {
+            $wildcard = strpos($roleExpression, '*');
+        }
 
-            if ($wildcard !== false && $wildcard > 0) {
-                if (substr($permission, 0, $wildcard) === substr($grantedPermission, 0, $wildcard)) {
-                    return true;
-                }
-            } elseif ($permission === $grantedPermission) {
+        if ($wildcard !== false && $wildcard > 0) {
+            if (substr($requiredPermission, 0, $wildcard) === substr($roleExpression, 0, $wildcard)) {
                 return true;
             }
+        } elseif ($requiredPermission === $roleExpression) {
+            return true;
         }
 
         return false;

--- a/library/Icinga/Authentication/RolesConfig.php
+++ b/library/Icinga/Authentication/RolesConfig.php
@@ -19,6 +19,7 @@ class RolesConfig extends IniRepository
     {
         $columns = [
             'roles' => [
+                'parent',
                 'name',
                 'users',
                 'groups',

--- a/library/Icinga/Authentication/RolesConfig.php
+++ b/library/Icinga/Authentication/RolesConfig.php
@@ -22,6 +22,7 @@ class RolesConfig extends IniRepository
                 'name',
                 'users',
                 'groups',
+                'refusals',
                 'permissions',
                 'application/share/users',
                 'application/share/groups'

--- a/library/Icinga/Authentication/RolesConfig.php
+++ b/library/Icinga/Authentication/RolesConfig.php
@@ -25,6 +25,7 @@ class RolesConfig extends IniRepository
                 'groups',
                 'refusals',
                 'permissions',
+                'unrestricted',
                 'application/share/users',
                 'application/share/groups'
             ]

--- a/library/Icinga/User.php
+++ b/library/Icinga/User.php
@@ -563,27 +563,8 @@ class User
      */
     public function can($requiredPermission)
     {
-        if (isset($this->permissions['*']) || isset($this->permissions[$requiredPermission])) {
-            return true;
-        }
-
-        $requiredWildcard = strpos($requiredPermission, '*');
-        foreach ($this->permissions as $grantedPermission) {
-            if ($requiredWildcard !== false) {
-                if (($grantedWildcard = strpos($grantedPermission, '*')) !== false) {
-                    $wildcard = min($requiredWildcard, $grantedWildcard);
-                } else {
-                    $wildcard = $requiredWildcard;
-                }
-            } else {
-                $wildcard = strpos($grantedPermission, '*');
-            }
-
-            if ($wildcard !== false && $wildcard > 0) {
-                if (substr($requiredPermission, 0, $wildcard) === substr($grantedPermission, 0, $wildcard)) {
-                    return true;
-                }
-            } elseif ($requiredPermission === $grantedPermission) {
+        foreach ($this->getRoles() as $role) {
+            if ($role->grants($requiredPermission)) {
                 return true;
             }
         }

--- a/library/Icinga/User.php
+++ b/library/Icinga/User.php
@@ -563,13 +563,18 @@ class User
      */
     public function can($requiredPermission)
     {
+        $granted = false;
         foreach ($this->getRoles() as $role) {
-            if ($role->grants($requiredPermission)) {
-                return true;
+            if ($role->denies($requiredPermission)) {
+                return false;
+            }
+
+            if (! $granted && $role->grants($requiredPermission)) {
+                $granted = true;
             }
         }
 
-        return false;
+        return $granted;
     }
 
     /**

--- a/library/Icinga/User.php
+++ b/library/Icinga/User.php
@@ -252,10 +252,6 @@ class User
      */
     public function setRestrictions(array $restrictions)
     {
-        foreach ($restrictions as $name => $restriction) {
-            $restrictions[$name] = str_replace('$user:local_name$', $this->getLocalUsername(), $restriction);
-        }
-
         $this->restrictions = $restrictions;
         return $this;
     }

--- a/library/Icinga/Web/Menu.php
+++ b/library/Icinga/Web/Menu.php
@@ -67,24 +67,23 @@ class Menu extends Navigation
                     'icon'        => 'wrench',
                     'description' => t('Open application configuration'),
                     'label'       => t('Application'),
-                    'url'         => 'config/general',
-                    'permission'  => 'config/application/*',
+                    'url'         => 'config',
                     'priority'    => 810
                 ],
                 'authentication' => [
                     'icon'        => 'users',
-                    'description' => t('Open authentication configuration'),
-                    'label'       => t('Authentication'),
-                    'permission'  => 'config/authentication/*',
+                    'description' => t('Open access control configuration'),
+                    'label'       => t('Access Control'),
+                    'permission'  => 'config/access-control/*',
                     'priority'    => 830,
-                    'url'         => 'role/list'
+                    'url'         => 'role'
                 ],
                 'navigation' => [
                     'icon'        => 'sitemap',
                     'description' => t('Open shared navigation configuration'),
                     'label'       => t('Shared Navigation'),
                     'url'         => 'navigation/shared',
-                    'permission'  => 'config/application/navigation',
+                    'permission'  => 'config/navigation',
                     'priority'    => 840,
                 ],
                 'modules' => [

--- a/modules/monitoring/application/controllers/ConfigController.php
+++ b/modules/monitoring/application/controllers/ConfigController.php
@@ -101,7 +101,7 @@ class ConfigController extends Controller
         try {
             $form->setResourceConfig(ResourceFactory::getResourceConfigs());
         } catch (ConfigurationError $e) {
-            if ($this->hasPermission('config/application/resources')) {
+            if ($this->hasPermission('config/resources')) {
                 Notification::error($e->getMessage());
                 $this->redirectNow('config/createresource');
             }

--- a/public/css/icinga/widgets.less
+++ b/public/css/icinga/widgets.less
@@ -242,7 +242,26 @@ form.role-form {
     }
 
     h4 {
+      display: inline-block;
+      width: 20em;
       margin-top: 1.5em;
+      padding-right: .5625em;
+      text-align: right;
+
+      & ~ i {
+        display: inline-block;
+        width: 2.625em;
+        margin-right: 1em;
+        text-align: center;
+
+        &.icon-ok {
+          color: @color-ok;
+        }
+
+        &.icon-cancel {
+          color: @color-critical;
+        }
+      }
     }
 
     .collapsible-control {

--- a/test/php/library/Icinga/UserTest.php
+++ b/test/php/library/Icinga/UserTest.php
@@ -3,6 +3,7 @@
 
 namespace Tests\Icinga;
 
+use Icinga\Authentication\Role;
 use Mockery;
 use DateTimeZone;
 use Icinga\User;
@@ -62,14 +63,18 @@ class UserTest extends BaseTestCase
 
     public function testPermissions()
     {
-        $user = new User('test');
-        $user->setPermissions(array(
+        $role = new Role();
+        $role->setPermissions([
             'test',
             'test/some/specific',
             'test/more/*',
             'test/wildcard-with-wildcard/*',
             'test/even-more/specific-with-wildcard/*'
-        ));
+        ]);
+
+        $user = new User('test');
+        $user->setRoles([$role]);
+
         $this->assertTrue($user->can('test'));
         $this->assertTrue($user->can('test/some/specific'));
         $this->assertTrue($user->can('test/more/everything'));

--- a/test/php/library/Icinga/Web/Widget/SearchDashboardTest.php
+++ b/test/php/library/Icinga/Web/Widget/SearchDashboardTest.php
@@ -3,6 +3,7 @@
 
 namespace Tests\Icinga\Web;
 
+use Icinga\Authentication\Role;
 use Mockery;
 use Icinga\Test\BaseTestCase;
 use Icinga\User;
@@ -47,8 +48,12 @@ class SearchDashboardTest extends BaseTestCase
 
     public function testWhetherSearchLoadsSearchDashletsFromModules()
     {
+        $role = new Role();
+        $role->setPermissions(['*']);
+
         $user = new User('test');
-        $user->setPermissions(array('*' => '*'));
+        $user->setRoles([$role]);
+
         $dashboard = new SearchDashboard();
         $dashboard->setUser($user);
         $dashboard = $dashboard->search('pending');
@@ -60,8 +65,12 @@ class SearchDashboardTest extends BaseTestCase
 
     public function testWhetherSearchProvidesHintWhenSearchStringIsEmpty()
     {
+        $role = new Role();
+        $role->setPermissions(['*']);
+
         $user = new User('test');
-        $user->setPermissions(array('*' => '*'));
+        $user->setRoles([$role]);
+
         $dashboard = new SearchDashboard();
         $dashboard->setUser($user);
         $dashboard = $dashboard->search();


### PR DESCRIPTION
Supplements https://github.com/Icinga/icingadb-web/pull/158 and adds the following features:

* **Role refusals**
  The picture below shows that all command permissions are granted. Though, not those to add or remove comments.
![Screenshot from 2021-02-01 15-25-59](https://user-images.githubusercontent.com/16668527/106471602-171a2100-64a2-11eb-922a-4b65ae4ff347.png)
* **Role inheritance**
  No picture. This has only an effect behind the scenes. Single inheritance only. No special behavior, memberships are just shared between roles this way.
* **Unrestricted Roles**
  A new option in addition to `Administrative Access`. If enabled, this causes the restrictions of the role and any other one to be ignored.
* **Password changes not allowed by default anymore**
  The fake refusal `no-user/password-change` has now been changed to a grant `user/password-change`. Any user that had `no-user/password-change` previously still cannot change passwords. Though any user that didn't have this *permission*, needs to be granted `user/password-change` now in order to change passwords.
* **Restructured general permissions**
  Most of the general permissions were re-structured so that they're less cluttered and relate better to their actual purpose. There's no migration required. Any previous role configuration is still valid. Once adjusted in the UI though, it's automatically migrated to the new format.
![Screenshot from 2021-02-18 09-35-41](https://user-images.githubusercontent.com/16668527/108328537-04eff080-71cd-11eb-9220-2719adb5f1e0.png)

resolves #3885 
resolves #4270 