### PR TITLE
Fix module list sort in case of pagination

### DIFF
--- a/application/controllers/ConfigController.php
+++ b/application/controllers/ConfigController.php
@@ -5,6 +5,7 @@ namespace Icinga\Controllers;
 
 use Exception;
 use Icinga\Application\Version;
+use Icinga\Data\DataArray\ArrayDatasource;
 use InvalidArgumentException;
 use Icinga\Application\Config;
 use Icinga\Application\Icinga;
@@ -118,11 +119,16 @@ class ConfigController extends Controller
                 'url'   => 'config/modules'
             ))
             ->activate('modules');
-        $this->view->modules = Icinga::app()->getModuleManager()->select()
+        $queryArray = Icinga::app()->getModuleManager()->select()
             ->from('modules')
             ->order('enabled', 'desc')
             ->order('installed', 'asc')
-            ->order('name');
+            ->order('name')
+            ->fetchAll();
+
+        $query = new ArrayDatasource($queryArray);
+
+        $this->view->modules = $query->select();
         $this->setupLimitControl();
         $this->setupPaginationControl($this->view->modules);
         $this->view->title = $this->translate('Modules');


### PR DESCRIPTION
Earlier the module list was getting sorted incorrectly in case of pagination. This has been fixed here.

fixes #4329 