### PR TITLE
Don't double encode query param values when using the quick search

### DIFF
--- a/library/Icinga/Web/Widget/FilterEditor.php
+++ b/library/Icinga/Web/Widget/FilterEditor.php
@@ -288,7 +288,10 @@ class FilterEditor extends AbstractWidget
             $url = Url::fromRequest()->onlyWith($this->preserveParams);
             $urlParams = $url->getParams();
             $url->setQueryString($filter->toQueryString());
-            $url->getParams()->mergeValues($urlParams->toArray(false));
+            foreach ($urlParams->toArray(false) as $key => $value) {
+                $url->getParams()->addEncoded($key, $value);
+            }
+
             $this->redirectNow($url);
         }
 


### PR DESCRIPTION
fixes #4321

ref/IP/32759