### PR TITLE
Pass event instead of object to the getHtmlForEvent method of EventDetailsExtensionHook

### DIFF
--- a/modules/monitoring/application/controllers/EventController.php
+++ b/modules/monitoring/application/controllers/EventController.php
@@ -83,7 +83,7 @@ class EventController extends Controller
         /** @var EventDetailsExtensionHook $hook */
         foreach (Hook::all('Monitoring\\EventDetailsExtension') as $hook) {
             try {
-                $html = $hook->getHtmlForEvent($object);
+                $html = $hook->getHtmlForEvent($event);
             } catch (\Exception $e) {
                 $html = $this->view->escape($e->getMessage());
             }

--- a/modules/monitoring/library/Monitoring/Hook/EventDetailsExtensionHook.php
+++ b/modules/monitoring/library/Monitoring/Hook/EventDetailsExtensionHook.php
@@ -41,7 +41,7 @@ abstract class EventDetailsExtensionHook
     /**
      * Shall return valid HTML to include in the detail view
      *
-     * @param   object $object     The object to generate HTML for
+     * @param   object $event     The object to generate HTML for
      *
      * @return  string
      */


### PR DESCRIPTION
Hello, this is our proposed bugfix for the bug https://github.com/Icinga/icingaweb2/issues/4370

fixes #4370