### PR TITLE
Improve cache handling

### DIFF
--- a/application/controllers/ConfigController.php
+++ b/application/controllers/ConfigController.php
@@ -176,11 +176,22 @@ class ConfigController extends Controller
 
         $form = new ActionForm();
         $form->setOnSuccess(function (ActionForm $form) {
-            $module = $form->getValue('identifier');
-            Icinga::app()->getModuleManager()->enableModule($module);
-            Notification::success(sprintf($this->translate('Module "%s" enabled'), $module));
+            $moduleName = $form->getValue('identifier');
+            $module = Icinga::app()->getModuleManager()
+                ->enableModule($moduleName)
+                ->getModule($moduleName);
+            Notification::success(sprintf($this->translate('Module "%s" enabled'), $moduleName));
             $form->onSuccess();
-            $this->redirectHttp('config/modules');
+
+            if ($module->hasJs()) {
+                $this->redirectHttp('config/modules');
+            } else {
+                if ($module->hasCss()) {
+                    $this->reloadCss();
+                }
+
+                $this->rerenderLayout()->redirectNow('config/modules');
+            }
         });
 
         try {
@@ -202,11 +213,22 @@ class ConfigController extends Controller
 
         $form = new ActionForm();
         $form->setOnSuccess(function (ActionForm $form) {
-            $module = $form->getValue('identifier');
-            Icinga::app()->getModuleManager()->disableModule($module);
-            Notification::success(sprintf($this->translate('Module "%s" disabled'), $module));
+            $mm = Icinga::app()->getModuleManager();
+            $moduleName = $form->getValue('identifier');
+            $module = $mm->getModule($moduleName);
+            $mm->disableModule($moduleName);
+            Notification::success(sprintf($this->translate('Module "%s" disabled'), $moduleName));
             $form->onSuccess();
-            $this->redirectHttp('config/modules');
+
+            if ($module->hasJs()) {
+                $this->redirectHttp('config/modules');
+            } else {
+                if ($module->hasCss()) {
+                    $this->reloadCss();
+                }
+
+                $this->rerenderLayout()->redirectNow('config/modules');
+            }
         });
 
         try {

--- a/library/Icinga/Web/JavaScript.php
+++ b/library/Icinga/Web/JavaScript.php
@@ -129,7 +129,7 @@ class JavaScript
         $request = Icinga::app()->getRequest();
         $noCache = $request->getHeader('Cache-Control') === 'no-cache' || $request->getHeader('Pragma') === 'no-cache';
 
-        header('Cache-Control: public');
+        header('Cache-Control: public,no-cache,must-revalidate');
 
         if (! $noCache && FileCache::etagMatchesFiles($files)) {
             header("HTTP/1.1 304 Not Modified");

--- a/library/Icinga/Web/StyleSheet.php
+++ b/library/Icinga/Web/StyleSheet.php
@@ -192,7 +192,7 @@ class StyleSheet
 
         $request = $styleSheet->app->getRequest();
         $response = $styleSheet->app->getResponse();
-        $response->setHeader('Cache-Control', 'public', true);
+        $response->setHeader('Cache-Control', 'private,no-cache,must-revalidate', true);
 
         $noCache = $request->getHeader('Cache-Control') === 'no-cache' || $request->getHeader('Pragma') === 'no-cache';
 

--- a/public/js/icinga/ui.js
+++ b/public/js/icinga/ui.js
@@ -111,10 +111,7 @@
                 var $oldLink = $(this);
                 if ($oldLink.hasAttr('type') && $oldLink.attr('type').indexOf('css') > -1) {
                     var base = location.protocol + '//' + location.host;
-                    var url = icinga.utils.addUrlParams(
-                        $(this).attr('href'),
-                        { id: new Date().getTime() }
-                    );
+                    var url = $(this).attr('href');
 
                     var $newLink = $oldLink.clone().attr(
                         'href',


### PR DESCRIPTION
We reload JS (HTTP redirect) and CSS on several occasions now:

* Upon login
  * CSS is reloaded if the theme changes
  * An HTTP redirect is made, if the locale changes
* Upon saving preferences
  * CSS is reloaded if the theme changes
  * An HTTP redirect is made, if the locale changes
* Upon en-/disabling a module
  * An HTTP redirect is made

If CSS is reloaded only, it also results in a bypass of our own caching implementation.

This PR changes the following:

* Upon login
  * Nothing
* Upon saving preferences
  * Nothing
* Upon en-/disabling a module
  * CSS is reloaded, if the module has CSS but no JS
  * An HTTP redirect is made, if the module has JS

If CSS is reloaded only, it won't bypass our own caching implementation. It's mature enough now that we can safely assume new CSS/JS is delivered if necessary.

This assumption is supported by the following changes:

* For CSS we transmit the following `Cache-Control` options: `private,no-cache,must-revalidate`
  * Previously it was only `public`
  * `private` because themes and soon the mode preference are user-specific
* For JS we transmit the following `Cache-Control` options: `public,no-cache,must-revalidate`
  * Previously it was only `public`

The `no-cache,must-revalidate` options force a browser to check for an update first before its own cache is utilized. This ensures we have the chance to deliver the user updated CSS/JS upon HTTP redirects without such hacks as the timestamp parameter.