### PR TITLE
Fix group views not showing all objects with mixed group filters

### DIFF
--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/HostgroupQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/HostgroupQuery.php
@@ -225,15 +225,15 @@ class HostgroupQuery extends IdoQuery
     protected function joinServicegroups()
     {
         $this->requireVirtualTable('services');
-        $this->select->join(
+        $this->select->joinLeft(
             array('sgm' => $this->prefix . 'servicegroup_members'),
             'sgm.service_object_id = s.service_object_id',
             array()
-        )->join(
+        )->joinLeft(
             array('sg' => $this->prefix . 'servicegroups'),
             'sgm.servicegroup_id = sg.servicegroup_id',
             array()
-        )->join(
+        )->joinLeft(
             array('sgo' => $this->prefix . 'objects'),
             'sgo.object_id = sg.servicegroup_object_id AND sgo.is_active = 1 AND sgo.objecttype_id = 4',
             array()
@@ -246,11 +246,11 @@ class HostgroupQuery extends IdoQuery
     protected function joinServices()
     {
         $this->requireVirtualTable('hosts');
-        $this->select->join(
+        $this->select->joinLeft(
             array('s' => $this->prefix . 'services'),
             's.host_object_id = h.host_object_id',
             array()
-        )->join(
+        )->joinLeft(
             array('so' => $this->prefix . 'objects'),
             'so.object_id = s.service_object_id AND so.is_active = 1 AND so.objecttype_id = 2',
             array()

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/ServicegroupQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/ServicegroupQuery.php
@@ -192,15 +192,15 @@ class ServicegroupQuery extends IdoQuery
     protected function joinHostgroups()
     {
         $this->requireVirtualTable('services');
-        $this->select->join(
+        $this->select->joinLeft(
             array('hgm' => $this->prefix . 'hostgroup_members'),
             'hgm.host_object_id = s.host_object_id',
             array()
-        )->join(
+        )->joinLeft(
             array('hg' => $this->prefix . 'hostgroups'),
             'hg.hostgroup_id = hgm.hostgroup_id',
             array()
-        )->join(
+        )->joinLeft(
             array('hgo' => $this->prefix . 'objects'),
             'hgo.object_id = hg.hostgroup_object_id AND hgo.objecttype_id = 3 AND hgo.is_active = 1',
             array()


### PR DESCRIPTION
## Before
![Screenshot from 2021-07-05 14-55-06](https://user-images.githubusercontent.com/16668527/124475233-c46ec900-dda1-11eb-8e66-bdc2bb3e2130.png)
![Screenshot from 2021-07-05 14-54-23](https://user-images.githubusercontent.com/16668527/124475234-c46ec900-dda1-11eb-96aa-0ec04061ae43.png)

## After
![Screenshot from 2021-07-05 14-55-34](https://user-images.githubusercontent.com/16668527/124475229-c33d9c00-dda1-11eb-8b5d-4aedcd430a97.png)
![Screenshot from 2021-07-05 14-53-53](https://user-images.githubusercontent.com/16668527/124475235-c46ec900-dda1-11eb-9119-7df95b8da951.png)

## Config
```
object Host "host_without_service" {
    display_name = "Host Without Service"
    check_command = "dummy"
    check_interval = 10m
    retry_interval = 10m

    vars.dummy_state = 2
    vars.issue_no = 4404
    vars.teams = [ "4404-test" ]
}

object Host "host_with_ungrouped_service" {
    display_name = "Host With Ungrouped Service"
    check_command = "dummy"
    check_interval = 10m
    retry_interval = 10m

    vars.dummy_state = 0
    vars.issue_no = 4404
    vars.teams = [ "4404-test" ]
}

object Host "host_with_grouped_service" {
    display_name = "Host With Grouped Service"
    check_command = "dummy"
    check_interval = 10m
    retry_interval = 10m

    vars.dummy_state = 0
    vars.issue_no = 4404
    vars.teams = [ "4404-test" ]
}

object HostGroup "4404-test" {
  display_name = "4404 Test"
  assign where "4404-test" in host.vars.teams
}

object Host "host_without_group" {
    display_name = "Host Without Group"
    check_command = "dummy"
    check_interval = 10m
    retry_interval = 10m

    vars.dummy_state = 0
    vars.issue_no = 4404
    vars.teams = []
}

object Service "first_service_without_group" {
    check_command = "dummy"
    check_interval = 10m
    retry_interval = 10m

    host_name = "host_with_ungrouped_service"
    display_name = "First Service Without Group"

    vars.issue_no = 4404
    vars.dummy_state = 0
}

object Service "second_service_without_group" {
    check_command = "dummy"
    check_interval = 10m
    retry_interval = 10m

    host_name = "host_with_ungrouped_service"
    display_name = "Second Service Without Group"

    vars.issue_no = 4404
    vars.dummy_state = 1
}

object Service "first_service_with_group" {
    check_command = "dummy"
    check_interval = 10m
    retry_interval = 10m

    host_name = "host_with_grouped_service"
    display_name = "First Service With Group"

    vars.issue_no = 4404
    vars.dummy_state = 2
    vars.teams = [ "4404-test" ]
}

object Service "second_service_with_group" {
    check_command = "dummy"
    check_interval = 10m
    retry_interval = 10m

    host_name = "host_with_grouped_service"
    display_name = "Second Service With Group"

    vars.issue_no = 4404
    vars.dummy_state = 3
    vars.teams = [ "4404-test" ]
}

object Service "third_service_with_group" {
    check_command = "dummy"
    check_interval = 10m
    retry_interval = 10m

    host_name = "host_without_group"
    display_name = "Third Service With Group"

    vars.issue_no = 4404
    vars.dummy_state = 0
    vars.teams = [ "4404-test" ]
}

object ServiceGroup "4404-test" {
  display_name = "4404 Test"
  assign where "4404-test" in service.vars.teams
}
```

fixes #4404