### PR TITLE
Only use Flatpickr for non-native inputs

### DIFF
--- a/public/js/icinga/behavior/datetime-picker.js
+++ b/public/js/icinga/behavior/datetime-picker.js
@@ -66,6 +66,13 @@
         _this.cleanupPickers(containerId);
 
         $.each(inputs, function () {
+            if (this.type !== 'text') {
+                // Ignore native inputs. Browser widgets are (mostly) superior.
+                // TODO: This makes the type distinction below useless.
+                //       Refactor this once we decided how we continue here in the future.
+                return;
+            }
+
             var server_format = _this.server_full_format;
             if (this.type === 'date') {
                 server_format = _this.server_date_format;


### PR DESCRIPTION
### Chrome

* has a native `datetime-local` input. Uses 24h format for e.g. German, otherwise 12h format. But the date format is always mm/dd/yyyy.
* has a native `date` input. Uses always mm/dd/yyyy format.
* has a native `time` input. Uses 24h format for e.g. German, otherwise 12h format.

### Firefox

* falls back to `text` for `datetime-local` inputs.
* has a native `date` input. Uses a locale aware format.
* has a native `time` input. Uses 24h format for e.g. German, otherwise 12h format.

### Safari

* has a native `datetime-local` input. But there's only a date picker, time needs to be entered by keyboard.
* ?
* ?

### Final result

We show the Flatpickr only in Firefox for `datetime-local` inputs. Otherwise we'll leave the browser's native input alone.

We should really consider to switch from `datetime-local` to a combination of `date` and `time` in the future.

fixes #4442