### PR TITLE
If appropriate, set the API parameter all_services for schedule-downtime

### DIFF
--- a/modules/monitoring/library/Monitoring/Command/Object/ApiScheduleHostDowntimeCommand.php
+++ b/modules/monitoring/library/Monitoring/Command/Object/ApiScheduleHostDowntimeCommand.php
@@ -1,0 +1,40 @@
+<?php
+/* Icinga Web 2 | (c) 2021 Icinga GmbH | GPLv2+ */
+
+namespace Icinga\Module\Monitoring\Command\Object;
+
+/**
+ * Schedule host downtime command for API command transport and Icinga >= 2.11.0 that
+ * sends all_services and child_options in a single request
+ */
+class ApiScheduleHostDowntimeCommand extends ScheduleHostDowntimeCommand
+{
+    /** @var int Whether no, triggered, or non-triggered child downtimes should be scheduled */
+    protected $childOptions;
+
+    protected $forAllServicesNative = true;
+
+    /**
+     * Get child options, i.e. whether no, triggered, or non-triggered child downtimes should be scheduled
+     *
+     * @return int
+     */
+    public function getChildOptions()
+    {
+        return $this->childOptions;
+    }
+
+    /**
+     * Set child options, i.e. whether no, triggered, or non-triggered child downtimes should be scheduled
+     *
+     * @param int $childOptions
+     *
+     * @return $this
+     */
+    public function setChildOptions($childOptions)
+    {
+        $this->childOptions = $childOptions;
+
+        return $this;
+    }
+}

--- a/modules/monitoring/library/Monitoring/Command/Object/ScheduleHostDowntimeCommand.php
+++ b/modules/monitoring/library/Monitoring/Command/Object/ScheduleHostDowntimeCommand.php
@@ -23,6 +23,9 @@ class ScheduleHostDowntimeCommand extends ScheduleServiceDowntimeCommand
      */
     protected $forAllServices = false;
 
+    /** @var bool Whether to send the all_services API parameter */
+    protected $forAllServicesNative;
+
     /**
      * Set whether to schedule a downtime for all services associated with a particular host
      *
@@ -44,5 +47,29 @@ class ScheduleHostDowntimeCommand extends ScheduleServiceDowntimeCommand
     public function getForAllServices()
     {
         return $this->forAllServices;
+    }
+
+    /**
+     * Get whether to send the all_services API parameter
+     *
+     * @return bool
+     */
+    public function isForAllServicesNative()
+    {
+        return $this->forAllServicesNative;
+    }
+
+    /**
+     * Get whether to send the all_services API parameter
+     *
+     * @param bool $forAllServicesNative
+     *
+     * @return $this
+     */
+    public function setForAllServicesNative($forAllServicesNative = true)
+    {
+        $this->forAllServicesNative = (bool) $forAllServicesNative;
+
+        return $this;
     }
 }


### PR DESCRIPTION
Since Icinga 2.11.0 the schedule-downtime API supports the
all_services parameter. So far we've always sent a separate
request for scheduling service downtimes. As of Icinga 2.13.0,
these service downtimes are automatically removed when the host
downtimes are removed. Of course, this doesn't work if we don't
use the all_services parameter but send a separate request.
With this commit we set this parameter if the transport is API
and Icinga is equal to or greater than 2.11.0.

In addition, if child_options and all_services were previously set,
a request was sent per host and service. This is now also only a
single request if an API command transport is requested or only
API command transports are configured.