### PR TITLE
Check if the column in the row is set for filters

### DIFF
--- a/library/Icinga/Data/Filter/FilterEqual.php
+++ b/library/Icinga/Data/Filter/FilterEqual.php
@@ -7,6 +7,10 @@ class FilterEqual extends FilterExpression
 {
     public function matches($row)
     {
+        if (! isset($row->{$this->column})) {
+            return false;
+        }
+
         return (string) $row->{$this->column} === (string) $this->expression;
     }
 }

--- a/library/Icinga/Data/Filter/FilterEqualOrGreaterThan.php
+++ b/library/Icinga/Data/Filter/FilterEqualOrGreaterThan.php
@@ -7,6 +7,10 @@ class FilterEqualOrGreaterThan extends FilterExpression
 {
     public function matches($row)
     {
+        if (! isset($row->{$this->column})) {
+            return false;
+        }
+
         return (string) $row->{$this->column} >= (string) $this->expression;
     }
 }

--- a/library/Icinga/Data/Filter/FilterEqualOrLessThan.php
+++ b/library/Icinga/Data/Filter/FilterEqualOrLessThan.php
@@ -17,6 +17,10 @@ class FilterEqualOrLessThan extends FilterExpression
 
     public function matches($row)
     {
+        if (! isset($row->{$this->column})) {
+            return false;
+        }
+
         return (string) $row->{$this->column} <= (string) $this->expression;
     }
 }

--- a/library/Icinga/Data/Filter/FilterLessThan.php
+++ b/library/Icinga/Data/Filter/FilterLessThan.php
@@ -17,6 +17,10 @@ class FilterLessThan extends FilterExpression
 
     public function matches($row)
     {
+        if (! isset($row->{$this->column})) {
+            return false;
+        }
+
         return (string) $row->{$this->column} < (string) $this->expression;
     }
 }


### PR DESCRIPTION
When the column is not set for the filters undefined property exception is thrown in icinga-director. This is a quick fix to solve the issue.

fixes icinga/icingaweb2-module-director#1795