### PR TITLE
js: Fix regression for loading dependent modules for sub-containers

### DIFF
--- a/public/js/icinga.js
+++ b/public/js/icinga.js
@@ -169,25 +169,28 @@
          * @param {string} moduleName
          */
         ensureModule: function(moduleName) {
-            if (this.hasModule(moduleName) && !this.isLoadedModule(moduleName)) {
+            if (this.hasModule(moduleName) && ! this.isLoadedModule(moduleName)) {
                 this.loadModule(moduleName);
             }
         },
 
         /**
-         * If a container contains sub-containers for another modules,
+         * If a container contains sub-containers for other modules,
          * make sure the javascript code for each module is loaded.
          *
-         * Containers are identified by class "icinga-module" and the
-         * module name should be passed as "data-icinga-module".
+         * Containers are identified by "data-icinga-module" which
+         * holds the module name.
          *
          * @param container
          */
         ensureSubModules: function (container) {
             var icinga = this;
 
-            $(container).find('.icinga-module').each(function () {
-                icinga.ensureModule($(this).data('icingaModule'))
+            $(container).find('[data-icinga-module]').each(function () {
+                var moduleName = $(this).data('icingaModule');
+                if (moduleName) {
+                    icinga.ensureModule(moduleName);
+                }
             });
         },
 

--- a/public/js/icinga.js
+++ b/public/js/icinga.js
@@ -164,6 +164,34 @@
         },
 
         /**
+         * Ensure we have loaded the javascript code for a module
+         *
+         * @param {string} moduleName
+         */
+        ensureModule: function(moduleName) {
+            if (this.hasModule(moduleName) && !this.isLoadedModule(moduleName)) {
+                this.loadModule(moduleName);
+            }
+        },
+
+        /**
+         * If a container contains sub-containers for another modules,
+         * make sure the javascript code for each module is loaded.
+         *
+         * Containers are identified by class "icinga-module" and the
+         * module name should be passed as "data-icinga-module".
+         *
+         * @param container
+         */
+        ensureSubModules: function (container) {
+            var icinga = this;
+
+            $(container).find('.icinga-module').each(function () {
+                icinga.ensureModule($(this).data('icingaModule'))
+            });
+        },
+
+        /**
          * Get a module by name
          *
          * @param   {string}    name

--- a/public/js/icinga/events.js
+++ b/public/js/icinga/events.js
@@ -40,10 +40,10 @@
                 // Initialize module javascript (Applies only to module.js code)
                 var moduleName = $(this).data('icingaModule');
                 if (moduleName) {
-                    if (_this.icinga.hasModule(moduleName) && ! _this.icinga.isLoadedModule(moduleName)) {
-                        _this.icinga.loadModule(moduleName);
-                    }
+                    _this.icinga.ensureModule(moduleName);
                 }
+
+                _this.icinga.ensureSubModules(this);
             });
 
             // We catch resize events

--- a/public/js/icinga/events.js
+++ b/public/js/icinga/events.js
@@ -35,16 +35,8 @@
                 behavior.bind($(document));
             });
 
-            var _this = this;
-            $('.container').each(function () {
-                // Initialize module javascript (Applies only to module.js code)
-                var moduleName = $(this).data('icingaModule');
-                if (moduleName) {
-                    _this.icinga.ensureModule(moduleName);
-                }
-
-                _this.icinga.ensureSubModules(this);
-            });
+            // Initialize module javascript (Applies only to module.js code)
+            this.icinga.ensureSubModules(document);
 
             // We catch resize events
             $(window).on('resize', { self: this.icinga.ui }, this.icinga.ui.onWindowResize);

--- a/public/js/icinga/loader.js
+++ b/public/js/icinga/loader.js
@@ -734,9 +734,7 @@
                 });
                 if (moduleName) {
                     // Lazy load module javascript (Applies only to module.js code)
-                    if (_this.icinga.hasModule(moduleName) && ! _this.icinga.isLoadedModule(moduleName)) {
-                        _this.icinga.loadModule(moduleName);
-                    }
+                    _this.icinga.ensureModule(moduleName);
 
                     req.$target.data('icingaModule', moduleName);
                     classes.push('icinga-module');
@@ -1027,10 +1025,8 @@
 
             req.$target.find('.container').each(function () {
                 // Lazy load module javascript (Applies only to module.js code)
-                var moduleName = $(this).data('icingaModule');
-                if (_this.icinga.hasModule(moduleName) && ! _this.icinga.isLoadedModule(moduleName)) {
-                    _this.icinga.loadModule(moduleName);
-                }
+                _this.icinga.ensureModule($(this).data('icingaModule'));
+                _this.icinga.ensureSubModules(this);
 
                 $(this).trigger('rendered', [req.autorefresh, req.scripted, req.autosubmit]);
             });
@@ -1296,6 +1292,8 @@
             }
 
             this.icinga.ui.assignUniqueContainerIds();
+
+            _this.icinga.ensureSubModules($container);
 
             if (! discard && navigationAnchor) {
                 setTimeout(this.icinga.ui.focusElement.bind(this.icinga.ui), 0, navigationAnchor, $container);

--- a/public/js/icinga/loader.js
+++ b/public/js/icinga/loader.js
@@ -1023,11 +1023,10 @@
                 }
             }
 
-            req.$target.find('.container').each(function () {
-                // Lazy load module javascript (Applies only to module.js code)
-                _this.icinga.ensureModule($(this).data('icingaModule'));
-                _this.icinga.ensureSubModules(this);
+            // Lazy load module javascript (Applies only to module.js code)
+            this.icinga.ensureSubModules(req.$target);
 
+            req.$target.find('.container').each(function () {
                 $(this).trigger('rendered', [req.autorefresh, req.scripted, req.autosubmit]);
             });
             req.$target.trigger('rendered', [req.autorefresh, req.scripted, req.autosubmit]);
@@ -1292,8 +1291,6 @@
             }
 
             this.icinga.ui.assignUniqueContainerIds();
-
-            _this.icinga.ensureSubModules($container);
 
             if (! discard && navigationAnchor) {
                 setTimeout(this.icinga.ui.focusElement.bind(this.icinga.ui), 0, navigationAnchor, $container);


### PR DESCRIPTION
When any view includes a sub-container of this form, the required JS code might not be loaded:

    <div class="icinga-module module-dummy" data-icinga-module="dummy">...</div>

This can happen for most hooks, e.g. DetailView or Perfdata.

Introduced by 48098a2830e8dce86ae7f0e1449981c88008a7e0

I also slightly refactored the module loading calls.