### PR TITLE
Update selection-info-count immediately on selection

### DIFF
--- a/public/js/icinga/behavior/actiontable.js
+++ b/public/js/icinga/behavior/actiontable.js
@@ -425,7 +425,7 @@
         });
 
         // update selection info
-        $('.selection-info-count').text(table.selections().length);
+        $('.selection-info-count').text(count);
         return false;
     };
 


### PR DESCRIPTION
The selection-info-count at the left bottom of host or service info needs to be updated immediately after selection.
Hence use the already defined ´count´ to update the selection info on click. 
fix #4516