### PR TITLE
Handle non `.js` files in asset/js and non `.css` or `.less` in asset/css folder

### DIFF
--- a/library/Icinga/Application/Libraries/Library.php
+++ b/library/Icinga/Application/Libraries/Library.php
@@ -221,7 +221,7 @@ class Library
 
             $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator(
                 $dir,
-                RecursiveDirectoryIterator::CURRENT_AS_PATHNAME | RecursiveDirectoryIterator::SKIP_DOTS
+                RecursiveDirectoryIterator::CURRENT_AS_FILEINFO | RecursiveDirectoryIterator::SKIP_DOTS
             ));
             if ($type === 'static') {
                 return $iterator;
@@ -230,7 +230,15 @@ class Library
             return new CallbackFilterIterator(
                 $iterator,
                 function ($path) use ($type) {
-                    return substr($path, -5 - strlen($type)) !== ".min.$type";
+                    if ($type === 'js' && $path->getExtension() === 'js') {
+                        return substr($path->getPathname(), -5 - strlen($type)) !== ".min.$type";
+                    } elseif ($type === 'css'
+                        && ($path->getExtension() === 'css' || $path->getExtension() === 'less')
+                    ) {
+                        return substr($path->getPathname(), -5 - strlen($type)) !== ".min.$type";
+                    }
+
+                    return false;
                 }
             );
         };


### PR DESCRIPTION
Non javascript files in asset/js folder or non css or less files in asset/css folder causes minfier to throw error. This is handled here.

fix #4519 