### PR TITLE
tabs.less: Fix tab dropdown being obscured by object-statistics-total

### DIFF
--- a/public/css/icinga/tabs.less
+++ b/public/css/icinga/tabs.less
@@ -70,7 +70,7 @@
   border-top: none;
   margin-left: -1px;
   min-width: 14em;
-  z-index: 1;
+  z-index: 10;
 }
 
 .tabs > .dropdown-nav-item > ul > li:hover > a {


### PR DESCRIPTION
In host group detail view the tab dropdown is obscured by the .object-statistics-total of the detail header. This changes fixes this.

![Screen Shot 2021-10-26 at 10 36 05](https://user-images.githubusercontent.com/6977434/138842603-c514fde3-19ec-465a-8ade-79d5c121a0ed.png)

