### PR TITLE
Implement client cert auth for the API client and verify the certificates

### DIFF
--- a/doc/20-Advanced-Topics.md
+++ b/doc/20-Advanced-Topics.md
@@ -296,6 +296,9 @@ host = "localhost"
 port = "5665"
 username = "api"
 password = "api"
+# Optional, disables username/password auth
+clientKey = "/etc/icingaweb2/client.key"
+clientCert = "/etc/icingaweb2/client.crt"
 ```
 
 ### Icinga Web 2 Manual Setup Login <a id="web-setup-manual-from-source-login"></a>

--- a/doc/20-Advanced-Topics.md
+++ b/doc/20-Advanced-Topics.md
@@ -299,6 +299,9 @@ password = "api"
 # Optional, disables username/password auth
 clientKey = "/etc/icingaweb2/client.key"
 clientCert = "/etc/icingaweb2/client.crt"
+# Optional, default is not to verify anything
+caFile = "/etc/icingaweb2/api-ca.crt"
+verifyHostname = 0
 ```
 
 ### Icinga Web 2 Manual Setup Login <a id="web-setup-manual-from-source-login"></a>

--- a/modules/monitoring/application/forms/Config/Transport/ApiTransportForm.php
+++ b/modules/monitoring/application/forms/Config/Transport/ApiTransportForm.php
@@ -70,6 +70,24 @@ class ApiTransportForm extends Form
             ),
             array(
                 'text',
+                'caFile',
+                array(
+                    'required'      => false,
+                    'label'         => $this->translate('CA Certificate'),
+                    'description'   => $this->translate('Path to a CA certificate to verify the API host with. Leave unset to disable verification')
+                )
+            ),
+            array(
+                'checkbox',
+                'verifyHostname',
+                array(
+                    'required'      => false,
+                    'label'         => $this->translate('Verify hostname'),
+                    'description'   => $this->translate('Whether to verify the hostname in the certificate when CA verification is enabled')
+                )
+            ),
+            array(
+                'text',
                 'clientKey',
                 array(
                     'required'      => false,

--- a/modules/monitoring/application/forms/Config/Transport/ApiTransportForm.php
+++ b/modules/monitoring/application/forms/Config/Transport/ApiTransportForm.php
@@ -47,7 +47,7 @@ class ApiTransportForm extends Form
                 'text',
                 'username',
                 array(
-                    'required'      => true,
+                    'required'      => false,
                     'label'         => $this->translate('API Username'),
                     'description'   => $this->translate(
                         'User to log in as on the remote Icinga instance. Please note that key-based SSH login must be'
@@ -59,13 +59,31 @@ class ApiTransportForm extends Form
                 'password',
                 'password',
                 array(
-                    'required'      => true,
+                    'required'      => false,
                     'label'         => $this->translate('API Password'),
                     'description'   => $this->translate(
                         'User to log in as on the remote Icinga instance. Please note that key-based SSH login must be'
                         . ' possible for this user'
                     ),
                     'renderPassword'    => true
+                )
+            ),
+            array(
+                'text',
+                'clientKey',
+                array(
+                    'required'      => false,
+                    'label'         => $this->translate('Client Key'),
+                    'description'   => $this->translate('Path to a private key for client authentication')
+                )
+            ),
+            array(
+                'text',
+                'clientCert',
+                array(
+                    'required'      => false,
+                    'label'         => $this->translate('Client Certificate'),
+                    'description'   => $this->translate('Path to a public certificate for client authentication')
                 )
             )
         ));

--- a/modules/monitoring/library/Monitoring/Command/Transport/ApiCommandTransport.php
+++ b/modules/monitoring/library/Monitoring/Command/Transport/ApiCommandTransport.php
@@ -60,6 +60,20 @@ class ApiCommandTransport implements CommandTransportInterface
     protected $username;
 
     /**
+     * API client key
+     *
+     * @var string
+     */
+    protected $clientKey;
+
+    /**
+     * API client certificate
+     *
+     * @var string
+     */
+    protected $clientCert;
+
+    /**
      * Create a new API command transport
      */
     public function __construct()
@@ -178,6 +192,54 @@ class ApiCommandTransport implements CommandTransportInterface
     }
 
     /**
+     * Get the auth key path
+     *
+     * @return string
+     */
+    public function getClientKey()
+    {
+        return $this->clientKey;
+    }
+
+    /**
+     * Set the auth key path
+     *
+     * @param   string  $clientKey
+     *
+     * @return  $this
+     */
+    public function setClientKey($clientKey)
+    {
+        $this->clientKey = $clientKey;
+
+        return $this;
+    }
+
+    /**
+     * Get the auth certificate path
+     *
+     * @return string
+     */
+    public function getClientCert()
+    {
+        return $this->clientCert;
+    }
+
+    /**
+     * Set the auth certificate path
+     *
+     * @param   string  $clientCert
+     *
+     * @return  $this
+     */
+    public function setClientCert($clientCert)
+    {
+        $this->clientCert = $clientCert;
+
+        return $this;
+    }
+
+    /**
      * Get URI for endpoint
      *
      * @param   string  $endpoint
@@ -207,12 +269,17 @@ class ApiCommandTransport implements CommandTransportInterface
         );
 
         try {
-            $response = RestRequest::post($this->getUriFor($command->getEndpoint()))
-                ->authenticateWith($this->getUsername(), $this->getPassword())
+            $request = RestRequest::post($this->getUriFor($command->getEndpoint()))
                 ->sendJson()
                 ->noStrictSsl()
-                ->setPayload($command->getData())
-                ->send();
+                ->setPayload($command->getData());
+
+            if ($this->getClientKey() && $this->getClientCert()) {
+                $request->authenticateCert($this->getClientKey(), $this->getClientCert());
+            } else {
+                $request->authenticateWith($this->getUsername(), $this->getPassword());
+            }
+            $response = $request->send();
         } catch (JsonDecodeException $e) {
             throw new CommandTransportException(
                 'Got invalid JSON response from the Icinga 2 API: %s',
@@ -263,8 +330,13 @@ class ApiCommandTransport implements CommandTransportInterface
     public function probe()
     {
         $request = RestRequest::get($this->getUriFor(null))
-            ->authenticateWith($this->getUsername(), $this->getPassword())
             ->noStrictSsl();
+
+        if ($this->getClientKey() && $this->getClientCert()) {
+            $response = $request->authenticateCert($this->getClientKey(), $this->getClientCert());
+        } else {
+            $response = $request->authenticateWith($this->getUsername(), $this->getPassword());
+        }
 
         try {
             $response = $request->send();

--- a/modules/monitoring/library/Monitoring/Web/Rest/RestRequest.php
+++ b/modules/monitoring/library/Monitoring/Web/Rest/RestRequest.php
@@ -84,6 +84,22 @@ class RestRequest
     protected $payload;
 
     /**
+     * Path to a CA certificate file, can be
+     * set to null to not explicitly set one.
+     *
+     * @var string
+     */
+    protected $caFile = null;
+
+    /**
+     * Whether to verify the hostname when CA
+     * verification is enabled.
+     *
+     * @var bool
+     */
+    protected $verifyHostname = true;
+
+    /**
      * Whether strict SSL is enabled
      *
      * @var bool
@@ -190,6 +206,30 @@ class RestRequest
     }
 
     /**
+     * Set a CA file
+     *
+     * @return $this
+     */
+    public function setCaFile($caFile)
+    {
+        $this->caFile = $caFile;
+
+        return $this;
+    }
+
+    /**
+     * Enable or disable hostname verification
+     *
+     * @return $this
+     */
+    public function setVerifyHostname($verifyHostname)
+    {
+        $this->verifyHostname = $verifyHostname;
+
+        return $this;
+    }
+
+    /**
      * Disable strict SSL
      *
      * @return $this
@@ -266,11 +306,16 @@ class RestRequest
 
         if ($this->strictSsl) {
             $options[CURLOPT_SSL_VERIFYHOST] = 2;
-            $options[CURLOPT_SSL_VERIFYPEER] = true;
+            $options[CURLOPT_SSL_VERIFYPEER] = $this->verifyHostname;
         } else {
             $options[CURLOPT_SSL_VERIFYHOST] = false;
             $options[CURLOPT_SSL_VERIFYPEER] = false;
             $curlCmd[] = '-k';
+        }
+
+        if ($this->caFile != null) {
+            $options[CURLOPT_CAINFO] = $this->caFile;
+            $curlCmd += [ '--cacert', escapeshellarg($this->caFile) ];
         }
 
         if ($this->hasBasicAuth) {


### PR DESCRIPTION
This is probably only half-done because it lacks docs and the UI is not perfect (you can currently enter no username or certificate and the config is saved).
The code works and I'm currently running it in production. The second commit fixes a [CWE-295](https://cwe.mitre.org/data/definitions/295.html).