### PR TITLE
base.less: Optmize contrast for `pre` elements

### DIFF
--- a/public/css/icinga/base.less
+++ b/public/css/icinga/base.less
@@ -219,7 +219,8 @@ h6 {
 }
 
 pre {
-  .var(background-color, gray-lightest);
+  .rounded-corners(.25em);
+  .var(background-color, gray-lighter);
   font-family: @font-family-fixed;
   font-size: @font-size-small;
   padding: @vertical-padding @horizontal-padding;


### PR DESCRIPTION
Smaller fix for `pre` elements