### PR TITLE
Fix unresponsive modal submit buttons in Safari

### DIFF
--- a/public/js/icinga/behavior/modal.js
+++ b/public/js/icinga/behavior/modal.js
@@ -96,7 +96,16 @@
         var $form = $(event.currentTarget).closest('form');
         var $modal = $form.closest('#modal');
 
-        var req = _this.icinga.loader.submitForm($form, $autoSubmittedBy);
+        var $button;
+        var $rememberedSubmittButton = $form.data('submitButton');
+        if (typeof $rememberedSubmittButton != 'undefined') {
+            if ($form.has($rememberedSubmittButton)) {
+                $button = $rememberedSubmittButton;
+            }
+            $form.removeData('submitButton');
+        }
+
+        var req = _this.icinga.loader.submitForm($form, $autoSubmittedBy, $button);
         req.addToHistory = false;
         req.$redirectTarget = $modal.data('redirectTarget');
         req.done(function (data, textStatus, req) {

--- a/public/js/icinga/events.js
+++ b/public/js/icinga/events.js
@@ -195,6 +195,10 @@
             // .closest is not required unless subelements to trigger this
             var $form = $(event.currentTarget).closest('form');
 
+            if ($form.closest('[data-no-icinga-ajax]').length > 0) {
+                return true;
+            }
+            
             var $button;
             var $rememberedSubmittButton = $form.data('submitButton');
             if (typeof $rememberedSubmittButton != 'undefined') {
@@ -202,10 +206,6 @@
                     $button = $rememberedSubmittButton;
                 }
                 $form.removeData('submitButton');
-            }
-
-            if ($form.closest('[data-no-icinga-ajax]').length > 0) {
-                return true;
             }
 
             if (typeof $button === 'undefined') {


### PR DESCRIPTION
In safari, the submit buttons in filter modal window of icingadb module were unresponsive, this is fixed here.