### PR TITLE
StyleSheet: Use an absolute path to load responsive login orbs

### DIFF
--- a/library/Icinga/Web/StyleSheet.php
+++ b/library/Icinga/Web/StyleSheet.php
@@ -176,7 +176,7 @@ class StyleSheet
         }
 
         if (! $themePath || in_array($theme, self::THEME_WHITELIST, true)) {
-            $this->lessCompiler->addLessFile('css/icinga/login-orbs.less');
+            $this->lessCompiler->addLessFile($this->pubPath . '/css/icinga/login-orbs.less');
         }
 
         $mode = 'none';


### PR DESCRIPTION
fixes #4635
closes https://github.com/Icinga/icingaweb2-module-reporting/issues/106