### PR TITLE
added feature required expire time

### DIFF
--- a/modules/monitoring/application/forms/Command/Object/AcknowledgeProblemCommandForm.php
+++ b/modules/monitoring/application/forms/Command/Object/AcknowledgeProblemCommandForm.php
@@ -76,6 +76,7 @@ class AcknowledgeProblemCommandForm extends ObjectsCommandForm
                 'checkbox',
                 'expire',
                 array(
+                    'required'      => (bool) $config->get('settings', 'acknowledge_expire_required', false),
                     'label'         => $this->translate('Use Expire Time'),
                     'value'         => $acknowledgeExpire,
                     'description'   => $this->translate(


### PR DESCRIPTION
added config parameter "acknowledge_expire_required" for setting "Use expire Time", so clients have to set an expire time at acknowleding the problem