### PR TITLE
IdoQuery: Don't try to add a `HAVING` without group by rules

### DIFF
--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/IdoQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/IdoQuery.php
@@ -616,16 +616,18 @@ abstract class IdoQuery extends DbQuery
             }
         }
 
-        if ($and || $negate && ! $and) {
+        if ($and || $negate) {
             // Having is only required for AND and != filters,
             // e.g. hostgroup_name=(ping&linux), hostgroup_name!=ping, hostgroup_name!=(ping|linux)
             $groups = $subQuery->getGroup();
-            $group = $groups[0];
-            $group = preg_replace('/(?<=^|\s)\w+(?=\.)/', 'sub_$0', $group);
+            if (! empty($groups)) {
+                $group = $groups[0];
+                $group = preg_replace('/(?<=^|\s)\w+(?=\.)/', 'sub_$0', $group);
 
-            $cnt = count($expr);
+                $cnt = count($expr);
 
-            $subQuery->select()->having("COUNT(DISTINCT $group) >= $cnt");
+                $subQuery->select()->having("COUNT(DISTINCT $group) >= $cnt");
+            }
         }
 
         $subQueryFilter->setColumn(preg_replace(


### PR DESCRIPTION
Not easy to explain what this fixes. Check out https://github.com/Icinga/icingaweb2-module-cube/commit/14fda58ef2c3431a1ce017a91d9123b260c670e2, have a restriction or filter for `service_description` on the hosts view and this appears:

```
Undefined array key 0

#0 /icingaweb2/modules/monitoring/library/Monitoring/Backend/Ido/Query/IdoQuery.php(623): Icinga\Application\ApplicationBootstrap->Icinga\Application\{closure}(Integer, String, String, Integer)
#1 /icingaweb2/modules/monitoring/library/Monitoring/Backend/Ido/Query/IdoQuery.php(673): Icinga\Module\Monitoring\Backend\Ido\Query\IdoQuery->createSubQueryFilter(Object(Icinga\Data\Filter\FilterExpression), String)
#2 /icingaweb2/modules/monitoring/library/Monitoring/Backend/Ido/Query/IdoQuery.php(753): Icinga\Module\Monitoring\Backend\Ido\Query\IdoQuery->requireFilterColumns(Object(Icinga\Data\Filter\FilterExpression))
#3 /icingaweb2/modules/monitoring/library/Monitoring/Backend/Ido/Query/IdoQuery.php(768): Icinga\Module\Monitoring\Backend\Ido\Query\IdoQuery->requireFilterColumns(Object(Icinga\Data\Filter\FilterOr))
#4 /icingaweb2/modules/monitoring/library/Monitoring/DataView/DataView.php(493): Icinga\Module\Monitoring\Backend\Ido\Query\IdoQuery->addFilter(Object(Icinga\Data\Filter\FilterOr))
#5 /icingaweb2/modules/monitoring/library/Monitoring/DataView/DataView.php(432): Icinga\Module\Monitoring\DataView\DataView->addFilter(Object(Icinga\Data\Filter\FilterOr))
#6 /usr/share/icingaweb2-modules/cube/library/Cube/Ido/IdoHostStatusCube.php(92): Icinga\Module\Monitoring\DataView\DataView->applyFilter(Object(Icinga\Data\Filter\FilterOr))
#7 /usr/share/icingaweb2-modules/cube/library/Cube/DbCube.php(136): Icinga\Module\Cube\Ido\IdoHostStatusCube->prepareInnerQuery()
#8 /usr/share/icingaweb2-modules/cube/library/Cube/DbCube.php(153): Icinga\Module\Cube\DbCube->innerQuery()
#9 /usr/share/icingaweb2-modules/cube/library/Cube/DbCube.php(273): Icinga\Module\Cube\DbCube->finalizeInnerQuery()
#10 /usr/share/icingaweb2-modules/cube/library/Cube/DbCube.php(198): Icinga\Module\Cube\DbCube->prepareRollupQuery()
#11 /usr/share/icingaweb2-modules/cube/library/Cube/DbCube.php(224): Icinga\Module\Cube\DbCube->rollupQuery()
#12 /usr/share/icingaweb2-modules/cube/library/Cube/DbCube.php(184): Icinga\Module\Cube\DbCube->prepareFullQuery()
#13 /usr/share/icingaweb2-modules/cube/library/Cube/DbCube.php(66): Icinga\Module\Cube\DbCube->fullQuery()
#14 /usr/share/icingaweb2-modules/cube/library/Cube/CubeRenderer.php(183): Icinga\Module\Cube\DbCube->fetchAll()
#15 /usr/share/icingaweb2-modules/cube/library/Cube/Cube.php(291): Icinga\Module\Cube\CubeRenderer->render(Object(Icinga\Web\View))
#16 /usr/share/icingaweb2-modules/cube/application/views/scripts/cube-index.phtml(18): Icinga\Module\Cube\Cube->render(Object(Icinga\Web\View))
#17 /icingaweb2/library/Icinga/Web/View.php(235): include(String)
#18 /icingaweb2/library/vendor/Zend/View/Abstract.php(877): Icinga\Web\View->_run(String)
#19 /icingaweb2/library/vendor/Zend/Controller/Action/Helper/ViewRenderer.php(904): Zend_View_Abstract->render(NULL)
#20 /icingaweb2/library/vendor/Zend/Controller/Action/Helper/ViewRenderer.php(925): Zend_Controller_Action_Helper_ViewRenderer->renderScript(String, NULL)
#21 /icingaweb2/library/vendor/Zend/Controller/Action.php(206): Zend_Controller_Action_Helper_ViewRenderer->render(String, NULL, Boolean)
#22 /usr/share/icingaweb2-modules/cube/library/Cube/Web/Controller.php(112): Zend_Controller_Action->render(String, NULL, Boolean)
#23 /usr/share/icingaweb2-modules/cube/application/controllers/HostsController.php(15): Icinga\Module\Cube\Web\Controller->renderCube()
#24 /icingaweb2/library/vendor/Zend/Controller/Action.php(507): Icinga\Module\Cube\Controllers\HostsController->indexAction()
#25 /icingaweb2/library/Icinga/Web/Controller/Dispatcher.php(76): Zend_Controller_Action->dispatch(String)
#26 /icingaweb2/library/vendor/Zend/Controller/Front.php(937): Icinga\Web\Controller\Dispatcher->dispatch(Object(Icinga\Web\Request), Object(Icinga\Web\Response))
#27 /icingaweb2/library/Icinga/Application/Web.php(304): Zend_Controller_Front->dispatch(Object(Icinga\Web\Request), Object(Icinga\Web\Response))
#28 /icingaweb2/library/Icinga/Application/webrouter.php(109): Icinga\Application\Web->dispatch()
#29 /icingaweb2/public/index.php(4): require_once(String)
#30 {main}
```