### PR TITLE
about.less: color “configure” links in about view

### DIFF
--- a/public/css/icinga/about.less
+++ b/public/css/icinga/about.less
@@ -27,6 +27,10 @@
     th,
     td {
       white-space: nowrap;
+
+      a {
+        color: @icinga-blue
+      }
     }
   }
 


### PR DESCRIPTION
Makes it more consistently obvious, that "configure" links are interactive.