### PR TITLE
Correct Auth#getUser() type spec

### DIFF
--- a/library/Icinga/Authentication/Auth.php
+++ b/library/Icinga/Authentication/Auth.php
@@ -45,7 +45,7 @@ class Auth
     /**
      * Authenticated user
      *
-     * @var User
+     * @var User|null
      */
     private $user;
 
@@ -189,7 +189,7 @@ class Auth
     /**
      * Returns the current user or null if no user is authenticated
      *
-     * @return User
+     * @return User|null
      */
     public function getUser()
     {


### PR DESCRIPTION
Doc says it may be null.