### PR TITLE
Display announcements in fullscreen-layout

### DIFF
--- a/public/css/icinga/layout-structure.less
+++ b/public/css/icinga/layout-structure.less
@@ -98,7 +98,7 @@ body {
 
 /** Fullscreen layout **/
 #layout.fullscreen-layout {
-  #header, #sidebar {
+  #sidebar {
     display: none;
   }
 


### PR DESCRIPTION
As `#header` only contains announcements, It should not be hidden in the `fullscreen-layout`.

fixes #4596 