### PR TITLE
Fix missing global theme check refs #4723

### DIFF
--- a/application/forms/PreferenceForm.php
+++ b/application/forms/PreferenceForm.php
@@ -212,7 +212,7 @@ class PreferenceForm extends Form
         } else {
             $themeFile = StyleSheet::getThemeFile(Config::app()->get('themes', 'default'));
         }
-        
+
         if (isset($formData['theme']) && $formData['theme'] !== StyleSheet::DEFAULT_THEME) {
             $themeFile = StyleSheet::getThemeFile($formData['theme']);
         }

--- a/application/forms/PreferenceForm.php
+++ b/application/forms/PreferenceForm.php
@@ -186,7 +186,7 @@ class PreferenceForm extends Form
             );
         }
 
-        $themeFile = StyleSheet::getThemeFile(Config::app()->get('themes', 'default'));        
+        $themeFile = StyleSheet::getThemeFile(Config::app()->get('themes', 'default'));
         if (! (bool) Config::app()->get('themes', 'disabled', false)) {
             $themes = Icinga::app()->getThemes();
             if (count($themes) > 1) {

--- a/application/forms/PreferenceForm.php
+++ b/application/forms/PreferenceForm.php
@@ -186,7 +186,7 @@ class PreferenceForm extends Form
             );
         }
 
-        $themeFile = null;        
+        $themeFile = StyleSheet::getThemeFile(Config::app()->get('themes', 'default'));        
         if (! (bool) Config::app()->get('themes', 'disabled', false)) {
             $themes = Icinga::app()->getThemes();
             if (count($themes) > 1) {
@@ -209,8 +209,6 @@ class PreferenceForm extends Form
                     )
                 );
             }
-        } else {
-            $themeFile = StyleSheet::getThemeFile(Config::app()->get('themes', 'default'));
         }
 
         if (isset($formData['theme']) && $formData['theme'] !== StyleSheet::DEFAULT_THEME) {

--- a/application/forms/PreferenceForm.php
+++ b/application/forms/PreferenceForm.php
@@ -185,7 +185,8 @@ class PreferenceForm extends Form
                 false
             );
         }
-
+        $themeFile = null;
+        
         if (! (bool) Config::app()->get('themes', 'disabled', false)) {
             $themes = Icinga::app()->getThemes();
             if (count($themes) > 1) {
@@ -209,17 +210,15 @@ class PreferenceForm extends Form
                 );
             }
         } else {
-            $globalThemeFile = Config::app()->get('themes', 'default');
-            $themeFile = StyleSheet::getThemeFile($globalThemeFile);
-            $file = $themeFile !== null ? @file_get_contents($themeFile) : false;
-            if ($file && strpos($file, StyleSheet::LIGHT_MODE_IDENTIFIER) === false) {
-                $disabled = ['', 'light', 'system'];
-            }
+            $themeFile = StyleSheet::getThemeFile(Config::app()->get('themes', 'default'));
         }
         
         if (isset($formData['theme']) && $formData['theme'] !== StyleSheet::DEFAULT_THEME) {
             $themeFile = StyleSheet::getThemeFile($formData['theme']);
-            $file = $themeFile !== null ? @file_get_contents($themeFile) : false;
+        }
+
+        if ($themeFile !== null) {
+            $file = @file_get_contents($themeFile);
             if ($file && strpos($file, StyleSheet::LIGHT_MODE_IDENTIFIER) === false) {
                 $disabled = ['', 'light', 'system'];
             }

--- a/application/forms/PreferenceForm.php
+++ b/application/forms/PreferenceForm.php
@@ -185,8 +185,8 @@ class PreferenceForm extends Form
                 false
             );
         }
-        $themeFile = null;
-        
+
+        $themeFile = null;        
         if (! (bool) Config::app()->get('themes', 'disabled', false)) {
             $themes = Icinga::app()->getThemes();
             if (count($themes) > 1) {

--- a/application/forms/PreferenceForm.php
+++ b/application/forms/PreferenceForm.php
@@ -208,8 +208,15 @@ class PreferenceForm extends Form
                     )
                 );
             }
+        } else {
+            $globalThemeFile = Config::app()->get('themes', 'default');
+            $themeFile = StyleSheet::getThemeFile($globalThemeFile);
+            $file = $themeFile !== null ? @file_get_contents($themeFile) : false;
+            if ($file && strpos($file, StyleSheet::LIGHT_MODE_IDENTIFIER) === false) {
+                $disabled = ['', 'light', 'system'];
+            }
         }
-
+        
         if (isset($formData['theme']) && $formData['theme'] !== StyleSheet::DEFAULT_THEME) {
             $themeFile = StyleSheet::getThemeFile($formData['theme']);
             $file = $themeFile !== null ? @file_get_contents($themeFile) : false;


### PR DESCRIPTION
if  global theme is selected and theme chooser is disabled, ther should be a check on the system default theme which is the selected theme, if there is dark/lightmode support.
fixes #4723