### PR TITLE
history.js: Properly handle data attributes upon navigation

### DIFF
--- a/public/js/icinga/ui.js
+++ b/public/js/icinga/ui.js
@@ -212,6 +212,16 @@
             this.icinga.behaviors.navigation.trySetActiveAndSelectedByUrl($('#col1').data('icingaUrl'));
         },
 
+        moveToRight: function () {
+            let col1 = document.getElementById('col1'),
+                col2 = document.getElementById('col2'),
+                col1Backup = this.cutContainer($(col1));
+
+            this.cutContainer($(col2)); // Clear col2 states
+            this.pasteContainer($(col2), col1Backup);
+            this.layout2col();
+        },
+
         cutContainer: function ($col) {
             var props = {
               'elements': $('#' + $col.attr('id') + ' > *').detach(),
@@ -331,6 +341,8 @@
             $c.removeData('icingaRefresh');
             $c.removeData('lastUpdate');
             $c.removeData('icingaModule');
+            delete $c[0].dataset.icingaContainerId;
+            $c.removeAttr('class').attr('class', 'container');
             this.icinga.loader.stopPendingRequestsFor($c);
             $c.trigger('close-column');
             $c.html('');


### PR DESCRIPTION
This is required so that attributes like `data-icinga-container-id` are properly managed if the user navigates using the history buttons. Previously these were not managed at all as `applyLocationBar` didn't made use of ui.js' capabilities to paste/cut/move contents.

I've rewritten `applyLocationBar` basically. It now also just moves a column if only the location has changed, not the url.

I will add a comment with test-cases the next days.