### PR TITLE
Prevent use of empty filters in FilterChain::toQueryString()

### DIFF
--- a/library/Icinga/Data/Filter/FilterChain.php
+++ b/library/Icinga/Data/Filter/FilterChain.php
@@ -171,7 +171,9 @@ abstract class FilterChain extends Filter
             return '';
         }
         foreach ($this->filters() as $filter) {
-            $parts[] = $filter->toQueryString();
+            if (! $filter->isEmpty()) {
+                $parts[] = $filter->toQueryString();
+            }
         }
 
         // TODO: getLevel??


### PR DESCRIPTION
Due to instantiation of filters using Filter::matchAll() in ObjectList::getFilter(), we get an empty FilterAnd instance when
$this->filter is null. This prepends unnecessary separator '&' to the query string during conversion of filter to querystring.
This breaks the state badge links for host and service lists int host/service detail view when multiple hosts or services are selected.

fix #4751 