### PR TITLE
Change FilterMatch to FilterEqual class for single object filter on object name.

### DIFF
--- a/library/Icinga/Data/Db/DbConnection.php
+++ b/library/Icinga/Data/Db/DbConnection.php
@@ -6,6 +6,8 @@ namespace Icinga\Data\Db;
 use DateTime;
 use DateTimeZone;
 use Exception;
+use Icinga\Data\Filter\FilterMatch;
+use Icinga\Data\Filter\FilterMatchNot;
 use Icinga\Data\Inspectable;
 use Icinga\Data\Inspection;
 use PDO;
@@ -552,13 +554,13 @@ class DbConnection implements Selectable, Extensible, Updatable, Reducible, Insp
             throw new ProgrammingError(
                 'Unable to render array expressions with operators other than equal or not equal'
             );
-        } elseif ($sign === '=' && strpos($value, '*') !== false) {
+        } elseif ($filter instanceof FilterMatch && strpos($value, '*') !== false) {
             if ($value === '*') {
                 return $column . ' IS NOT NULL';
             }
 
             return $column . ' LIKE ' . $this->dbAdapter->quote(preg_replace('~\*~', '%', $value));
-        } elseif ($sign === '!=' && strpos($value, '*') !== false) {
+        } elseif ($filter instanceof FilterMatchNot && strpos($value, '*') !== false) {
             if ($value === '*') {
                 return $column . ' IS NULL';
             }

--- a/modules/monitoring/application/controllers/ShowController.php
+++ b/modules/monitoring/application/controllers/ShowController.php
@@ -3,6 +3,7 @@
 
 namespace Icinga\Module\Monitoring\Controllers;
 
+use Icinga\Data\Filter\FilterEqual;
 use Icinga\Module\Monitoring\Backend;
 use Icinga\Module\Monitoring\Controller;
 use Icinga\Security\SecurityException;
@@ -63,7 +64,7 @@ class ShowController extends Controller
             'contact_notify_host_downtime',
         ));
         $this->applyRestriction('monitoring/filter/objects', $query);
-        $query->where('contact_name', $contactName);
+        $query->whereEx(new FilterEqual('contact_name', '=', $contactName));
         $contact = $query->getQuery()->fetchRow();
 
         if ($contact) {

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/CommentQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/CommentQuery.php
@@ -3,6 +3,7 @@
 
 namespace Icinga\Module\Monitoring\Backend\Ido\Query;
 
+use Icinga\Data\Filter\FilterExpression;
 use Zend_Db_Expr;
 use Zend_Db_Select;
 use Icinga\Data\Filter\Filter;
@@ -142,6 +143,16 @@ class CommentQuery extends IdoQuery
         foreach ($this->subQueries as $sub) {
             $sub->where($condition, $value);
         }
+        return $this;
+    }
+
+    public function whereEx(FilterExpression $ex)
+    {
+        $this->requireColumn($ex->getColumn());
+        foreach ($this->subQueries as $sub) {
+            $sub->whereEx($ex);
+        }
+
         return $this;
     }
 }

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/CommentdeletionhistoryQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/CommentdeletionhistoryQuery.php
@@ -3,6 +3,7 @@
 
 namespace Icinga\Module\Monitoring\Backend\Ido\Query;
 
+use Icinga\Data\Filter\FilterExpression;
 use Zend_Db_Expr;
 use Zend_Db_Select;
 use Icinga\Data\Filter\Filter;
@@ -163,6 +164,16 @@ class CommentdeletionhistoryQuery extends IdoQuery
         foreach ($this->subQueries as $sub) {
             $sub->applyFilter(clone $filter);
         }
+        return $this;
+    }
+
+    public function whereEx(FilterExpression $ex)
+    {
+        $this->requireColumn($ex->getColumn());
+        foreach ($this->subQueries as $sub) {
+            $sub->whereEx($ex);
+        }
+
         return $this;
     }
 }

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/CommenthistoryQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/CommenthistoryQuery.php
@@ -3,6 +3,7 @@
 
 namespace Icinga\Module\Monitoring\Backend\Ido\Query;
 
+use Icinga\Data\Filter\FilterExpression;
 use Zend_Db_Expr;
 use Zend_Db_Select;
 use Icinga\Data\Filter\Filter;
@@ -163,6 +164,16 @@ class CommenthistoryQuery extends IdoQuery
         foreach ($this->subQueries as $sub) {
             $sub->applyFilter(clone $filter);
         }
+        return $this;
+    }
+
+    public function whereEx(FilterExpression $ex)
+    {
+        $this->requireColumn($ex->getColumn());
+        foreach ($this->subQueries as $sub) {
+            $sub->whereEx($ex);
+        }
+
         return $this;
     }
 }

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/ContactQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/ContactQuery.php
@@ -3,6 +3,7 @@
 
 namespace Icinga\Module\Monitoring\Backend\Ido\Query;
 
+use Icinga\Data\Filter\FilterExpression;
 use Zend_Db_Select;
 use Icinga\Data\Filter\Filter;
 
@@ -101,6 +102,16 @@ class ContactQuery extends IdoQuery
         $this->requireColumn($condition);
         foreach ($this->subQueries as $sub) {
             $sub->where($condition, $value);
+        }
+
+        return $this;
+    }
+
+    public function whereEx(FilterExpression $ex)
+    {
+        $this->requireColumn($ex->getColumn());
+        foreach ($this->subQueries as $sub) {
+            $sub->whereEx($ex);
         }
 
         return $this;

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/CustomvarQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/CustomvarQuery.php
@@ -4,6 +4,7 @@
 namespace Icinga\Module\Monitoring\Backend\Ido\Query;
 
 use Icinga\Application\Config;
+use Icinga\Data\Filter\FilterExpression;
 
 class CustomvarQuery extends IdoQuery
 {
@@ -37,6 +38,20 @@ class CustomvarQuery extends IdoQuery
         } else {
             parent::where($expression, $parameters);
         }
+        return $this;
+    }
+
+    public function whereEx(FilterExpression $ex)
+    {
+        $types = ['host' => 1, 'service' => 2, 'contact' => 10];
+        if ($ex->getColumn() === 'object_type') {
+            $ex = clone $ex;
+            $ex->setColumn('object_type_id');
+            $ex->setExpression($types[$ex->getExpression()]);
+        }
+
+        parent::whereEx($ex);
+
         return $this;
     }
 

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/DowntimeQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/DowntimeQuery.php
@@ -3,6 +3,7 @@
 
 namespace Icinga\Module\Monitoring\Backend\Ido\Query;
 
+use Icinga\Data\Filter\FilterExpression;
 use Zend_Db_Expr;
 use Zend_Db_Select;
 use Icinga\Data\Filter\Filter;
@@ -147,6 +148,16 @@ class DowntimeQuery extends IdoQuery
         foreach ($this->subQueries as $sub) {
             $sub->where($condition, $value);
         }
+        return $this;
+    }
+
+    public function whereEx(FilterExpression $ex)
+    {
+        $this->requireColumn($ex->getColumn());
+        foreach ($this->subQueries as $sub) {
+            $sub->whereEx($ex);
+        }
+
         return $this;
     }
 }

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/DowntimeendhistoryQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/DowntimeendhistoryQuery.php
@@ -3,6 +3,7 @@
 
 namespace Icinga\Module\Monitoring\Backend\Ido\Query;
 
+use Icinga\Data\Filter\FilterExpression;
 use Zend_Db_Expr;
 use Zend_Db_Select;
 use Icinga\Data\Filter\Filter;
@@ -163,6 +164,16 @@ class DowntimeendhistoryQuery extends IdoQuery
         foreach ($this->subQueries as $sub) {
             $sub->applyFilter(clone $filter);
         }
+        return $this;
+    }
+
+    public function whereEx(FilterExpression $ex)
+    {
+        $this->requireColumn($ex->getColumn());
+        foreach ($this->subQueries as $sub) {
+            $sub->whereEx($ex);
+        }
+
         return $this;
     }
 }

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/DowntimestarthistoryQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/DowntimestarthistoryQuery.php
@@ -3,6 +3,7 @@
 
 namespace Icinga\Module\Monitoring\Backend\Ido\Query;
 
+use Icinga\Data\Filter\FilterExpression;
 use Zend_Db_Expr;
 use Zend_Db_Select;
 use Icinga\Data\Filter\Filter;
@@ -163,6 +164,16 @@ class DowntimestarthistoryQuery extends IdoQuery
         foreach ($this->subQueries as $sub) {
             $sub->applyFilter(clone $filter);
         }
+        return $this;
+    }
+
+    public function whereEx(FilterExpression $ex)
+    {
+        $this->requireColumn($ex->getColumn());
+        foreach ($this->subQueries as $sub) {
+            $sub->whereEx($ex);
+        }
+
         return $this;
     }
 }

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/EventhistoryQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/EventhistoryQuery.php
@@ -3,6 +3,7 @@
 
 namespace Icinga\Module\Monitoring\Backend\Ido\Query;
 
+use Icinga\Data\Filter\FilterExpression;
 use Zend_Db_Select;
 use Icinga\Data\Filter\Filter;
 
@@ -118,6 +119,16 @@ class EventhistoryQuery extends IdoQuery
         foreach ($this->subQueries as $sub) {
             $sub->applyFilter(clone $filter);
         }
+        return $this;
+    }
+
+    public function whereEx(FilterExpression $ex)
+    {
+        $this->requireColumn($ex->getColumn());
+        foreach ($this->subQueries as $sub) {
+            $sub->whereEx($ex);
+        }
+
         return $this;
     }
 }

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/FlappingstarthistoryQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/FlappingstarthistoryQuery.php
@@ -3,6 +3,7 @@
 
 namespace Icinga\Module\Monitoring\Backend\Ido\Query;
 
+use Icinga\Data\Filter\FilterExpression;
 use Zend_Db_Expr;
 use Zend_Db_Select;
 use Icinga\Data\Filter\Filter;
@@ -163,6 +164,16 @@ class FlappingstarthistoryQuery extends IdoQuery
         foreach ($this->subQueries as $sub) {
             $sub->applyFilter(clone $filter);
         }
+        return $this;
+    }
+
+    public function whereEx(FilterExpression $ex)
+    {
+        $this->requireColumn($ex->getColumn());
+        foreach ($this->subQueries as $sub) {
+            $sub->whereEx($ex);
+        }
+
         return $this;
     }
 }

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/HoststatussummaryQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/HoststatussummaryQuery.php
@@ -4,6 +4,7 @@
 namespace Icinga\Module\Monitoring\Backend\Ido\Query;
 
 use Icinga\Data\Filter\Filter;
+use Icinga\Data\Filter\FilterExpression;
 
 /**
  * Query for host group summaries
@@ -78,6 +79,13 @@ class HoststatussummaryQuery extends IdoQuery
     public function where($condition, $value = null)
     {
         $this->subSelect->where($condition, $value);
+        return $this;
+    }
+
+    public function whereEx(FilterExpression $ex)
+    {
+        $this->subSelect->whereEx($ex);
+
         return $this;
     }
 }

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/IdoQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/IdoQuery.php
@@ -784,6 +784,30 @@ abstract class IdoQuery extends DbQuery
     }
 
     /**
+     * Add a filter expression, with as less validation as possible
+     *
+     * @param FilterExpression $ex
+     *
+     * @internal If you use this outside the monitoring module, it's your fault if something breaks
+     * @return $this
+     */
+    public function whereEx(FilterExpression $ex)
+    {
+        $this->requireColumn($ex->getColumn());
+        $col = $this->getMappedField($ex->getColumn());
+        if ($col === null) {
+            throw new IcingaException(
+                'No such field: %s',
+                $ex->getColumn()
+            );
+        }
+
+        parent::addFilter((clone $ex)->setColumn($col));
+
+        return $this;
+    }
+
+    /**
      * Return true if an field contains an explicit timestamp
      *
      * @param   string  $field      The field to test for containing an timestamp

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/NotificationQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/NotificationQuery.php
@@ -3,6 +3,7 @@
 
 namespace Icinga\Module\Monitoring\Backend\Ido\Query;
 
+use Icinga\Data\Filter\FilterExpression;
 use Zend_Db_Expr;
 use Zend_Db_Select;
 use Icinga\Data\Filter\Filter;
@@ -128,6 +129,16 @@ class NotificationQuery extends IdoQuery
         foreach ($this->subQueries as $sub) {
             $sub->where($condition, $value);
         }
+        return $this;
+    }
+
+    public function whereEx(FilterExpression $ex)
+    {
+        $this->requireColumn($ex->getColumn());
+        foreach ($this->subQueries as $sub) {
+            $sub->whereEx($ex);
+        }
+
         return $this;
     }
 }

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/NotificationhistoryQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/NotificationhistoryQuery.php
@@ -3,6 +3,7 @@
 
 namespace Icinga\Module\Monitoring\Backend\Ido\Query;
 
+use Icinga\Data\Filter\FilterExpression;
 use Zend_Db_Expr;
 use Zend_Db_Select;
 use Icinga\Data\Filter\Filter;
@@ -126,6 +127,16 @@ class NotificationhistoryQuery extends IdoQuery
         foreach ($this->subQueries as $sub) {
             $sub->where($condition, $value);
         }
+        return $this;
+    }
+
+    public function whereEx(FilterExpression $ex)
+    {
+        $this->requireColumn($ex->getColumn());
+        foreach ($this->subQueries as $sub) {
+            $sub->whereEx($ex);
+        }
+
         return $this;
     }
 }

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/ServicestatussummaryQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/ServicestatussummaryQuery.php
@@ -4,6 +4,7 @@
 namespace Icinga\Module\Monitoring\Backend\Ido\Query;
 
 use Icinga\Data\Filter\Filter;
+use Icinga\Data\Filter\FilterExpression;
 
 /**
  * Query for service status summary
@@ -91,6 +92,13 @@ class ServicestatussummaryQuery extends IdoQuery
     public function where($condition, $value = null)
     {
         $this->subSelect->where($condition, $value);
+        return $this;
+    }
+
+    public function whereEx(FilterExpression $ex)
+    {
+        $this->subSelect->whereEx($ex);
+
         return $this;
     }
 }

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/StatehistoryQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/StatehistoryQuery.php
@@ -3,6 +3,7 @@
 
 namespace Icinga\Module\Monitoring\Backend\Ido\Query;
 
+use Icinga\Data\Filter\FilterExpression;
 use Zend_Db_Expr;
 use Zend_Db_Select;
 use Icinga\Data\Filter\Filter;
@@ -163,6 +164,16 @@ class StatehistoryQuery extends IdoQuery
         foreach ($this->subQueries as $sub) {
             $sub->applyFilter(clone $filter);
         }
+        return $this;
+    }
+
+    public function whereEx(FilterExpression $ex)
+    {
+        $this->requireColumn($ex->getColumn());
+        foreach ($this->subQueries as $sub) {
+            $sub->whereEx($ex);
+        }
+
         return $this;
     }
 }

--- a/modules/monitoring/library/Monitoring/Backend/Ido/Query/StatussummaryQuery.php
+++ b/modules/monitoring/library/Monitoring/Backend/Ido/Query/StatussummaryQuery.php
@@ -3,6 +3,7 @@
 
 namespace Icinga\Module\Monitoring\Backend\Ido\Query;
 
+use Icinga\Data\Filter\FilterExpression;
 use Zend_Db_Expr;
 use Zend_Db_Select;
 use Icinga\Data\Filter\Filter;
@@ -227,6 +228,16 @@ We have to find a better solution here.
         foreach ($this->subQueries as $sub) {
             $sub->where($condition, $value);
         }
+        return $this;
+    }
+
+    public function whereEx(FilterExpression $ex)
+    {
+        $this->requireColumn($ex->getColumn());
+        foreach ($this->subQueries as $sub) {
+            $sub->whereEx($ex);
+        }
+
         return $this;
     }
 }

--- a/modules/monitoring/library/Monitoring/DataView/DataView.php
+++ b/modules/monitoring/library/Monitoring/DataView/DataView.php
@@ -3,11 +3,11 @@
 
 namespace Icinga\Module\Monitoring\DataView;
 
+use Icinga\Data\Filter\FilterExpression;
 use IteratorAggregate;
 use Icinga\Application\Hook;
 use Icinga\Data\ConnectionInterface;
 use Icinga\Data\Filter\Filter;
-use Icinga\Data\Filter\FilterMatch;
 use Icinga\Data\FilterColumns;
 use Icinga\Data\PivotTable;
 use Icinga\Data\QueryInterface;
@@ -456,7 +456,7 @@ abstract class DataView implements QueryInterface, SortRules, FilterColumns, Ite
      */
     public function validateFilterColumns(Filter $filter)
     {
-        if ($filter instanceof FilterMatch) {
+        if ($filter instanceof FilterExpression) {
             if (! $this->isValidFilterTarget($filter->getColumn())) {
                 throw new QueryException(
                     mt('monitoring', 'The filter column "%s" is not allowed here.'),

--- a/modules/monitoring/library/Monitoring/DataView/DataView.php
+++ b/modules/monitoring/library/Monitoring/DataView/DataView.php
@@ -94,6 +94,20 @@ abstract class DataView implements QueryInterface, SortRules, FilterColumns, Ite
         return $this;
     }
 
+    /**
+     * Add a filter expression, with as less validation as possible
+     *
+     * @param FilterExpression $ex
+     *
+     * @internal If you use this outside the monitoring module, it's your fault if something breaks
+     * @return $this
+     */
+    public function whereEx(FilterExpression $ex)
+    {
+        $this->query->whereEx($ex);
+        return $this;
+    }
+
     public function dump()
     {
         if (! $this->isSorted) {

--- a/modules/monitoring/library/Monitoring/Object/Host.php
+++ b/modules/monitoring/library/Monitoring/Object/Host.php
@@ -3,6 +3,7 @@
 
 namespace Icinga\Module\Monitoring\Object;
 
+use Icinga\Data\Filter\FilterEqual;
 use InvalidArgumentException;
 use Icinga\Module\Monitoring\Backend\MonitoringBackend;
 
@@ -142,7 +143,7 @@ class Host extends MonitoredObject
             'instance_name'
         );
         return $this->backend->select()->from('hoststatus', $columns)
-            ->where('host_name', $this->host);
+            ->whereEx(new FilterEqual('host_name', '=', $this->host));
     }
 
     /**

--- a/modules/monitoring/library/Monitoring/Object/Service.php
+++ b/modules/monitoring/library/Monitoring/Object/Service.php
@@ -3,6 +3,7 @@
 
 namespace Icinga\Module\Monitoring\Object;
 
+use Icinga\Data\Filter\FilterEqual;
 use InvalidArgumentException;
 use Icinga\Module\Monitoring\Backend\MonitoringBackend;
 
@@ -171,8 +172,8 @@ class Service extends MonitoredObject
             'service_state',
             'service_state_type'
         ))
-            ->where('host_name', $this->host->getName())
-            ->where('service_description', $this->service);
+            ->whereEx(new FilterEqual('host_name', '=', $this->host->getName()))
+            ->whereEx(new FilterEqual('service_description', '=', $this->service));
     }
 
     /**


### PR DESCRIPTION
Correspondingly the rendering of the filter for the db query is also modified to identify the instances of FilterEqual and to render accordingly.

This correctly selects the host, service or contact for the detailed view in case the object name contains wild card characters like "\\*".

depends on #4758
fix #4682 