### PR TITLE
modal.js: Fix modal hide error

### DIFF
--- a/public/js/icinga/behavior/modal.js
+++ b/public/js/icinga/behavior/modal.js
@@ -171,7 +171,10 @@
         var _this = event.data.self;
 
         if (! event.isDefaultPrevented() && event.key === 'Escape') {
-            _this.hide(_this.$layout.children('#modal'));
+            let $modal = _this.$layout.children('#modal');
+            if ($modal.length) {
+                _this.hide($modal);
+            }
         }
     };
 


### PR DESCRIPTION
Fixes a bug that when e.g. closing a color picker by clicking the escape key,
also the `modal.hide()` action is performed, even though there was no real modal
opened before, but it seems to react automatically on the escape key click.