### PR TITLE
overrides `customvarsWithOriginalNames` only if the given object is of type `host`

### DIFF
--- a/modules/monitoring/library/Monitoring/Object/MonitoredObject.php
+++ b/modules/monitoring/library/Monitoring/Object/MonitoredObject.php
@@ -538,7 +538,11 @@ abstract class MonitoredObject implements Filterable
             ->where('host_name', $this->host_name);
 
         $this->hostVariables = [];
-        $this->customvarsWithOriginalNames = [];
+
+        if ($this->type === static::TYPE_HOST) {
+            $this->customvarsWithOriginalNames = [];
+        }
+
         foreach ($query as $row) {
             if ($row->is_json) {
                 $this->hostVariables[strtolower($row->varname)] = json_decode($row->varvalue);


### PR DESCRIPTION
A call to `__get()` reset the `customvarsWithOriginalNames` array if the given `$name` is a customvar.
If `service` has a `host` customvar filter, the `fetchHostVariables()`
method was executed and overwrote the `customvarsWithOriginalNames` array.

fixes #4757