### PR TITLE
Fix: Scheme and hostname prepended to col2 url in the address bar

### DIFF
--- a/public/js/icinga/loader.js
+++ b/public/js/icinga/loader.js
@@ -828,9 +828,7 @@
             if (!! contentSeparator) {
                 var locationQuery = req.getResponseHeader('X-Icinga-Location-Query');
                 if (locationQuery !== null) {
-                    var a = this.icinga.utils.getUrlHelper().cloneNode(true);
-                    a.search = locationQuery ? '?' + locationQuery : '';
-
+                    let url = currentUrl.path + (locationQuery ? '?' + locationQuery : '');
                     if (req.autosubmit || autoSubmit) {
                         // Also update a form's action if it doesn't differ from the container's url
                         var $form = $(referrer.forceFocus).closest('form');
@@ -840,12 +838,12 @@
                             if (formAction.path === currentUrl.path
                                 && this.icinga.utils.arraysEqual(formAction.params, currentUrl.params)
                             ) {
-                                $form.attr('action', a.href);
+                                $form.attr('action', url);
                             }
                         }
                     }
 
-                    req.$target.data('icingaUrl', a.href);
+                    req.$target.data('icingaUrl', url);
                     this.icinga.history.replaceCurrentState();
                 }
 

--- a/public/js/icinga/loader.js
+++ b/public/js/icinga/loader.js
@@ -806,9 +806,9 @@
             }
 
             var autoSubmit = false;
+            var currentUrl = this.icinga.utils.parseUrl(req.$target.data('icingaUrl'));
             if (referrer.method === 'POST') {
                 var newUrl = this.icinga.utils.parseUrl(req.url);
-                var currentUrl = this.icinga.utils.parseUrl(req.$target.data('icingaUrl'));
                 if (newUrl.path === currentUrl.path && this.icinga.utils.arraysEqual(newUrl.params, currentUrl.params)) {
                     autoSubmit = true;
                 }


### PR DESCRIPTION
Direct access (a.href) automatically prepends the scheme and hostname.

fixes #4754