### PR TITLE
PdfExport: Show decoded url in pdf footer

### DIFF
--- a/library/Icinga/Common/PdfExport.php
+++ b/library/Icinga/Common/PdfExport.php
@@ -61,7 +61,7 @@ trait PdfExport
                     ' / ',
                     Html::tag('span', ['class' => 'totalPages'])
                 ]),
-                Html::tag('p', null, Url::fromRequest()->setParams($this->params))
+                Html::tag('p', null, rawurldecode(Url::fromRequest()->setParams($this->params)))
             ]))
             ->addHtml($html);
 


### PR DESCRIPTION
<img width="812" alt="Screenshot 2022-05-25 at 13 52 20" src="https://user-images.githubusercontent.com/54990055/170258956-f47bcecb-bce2-4591-864c-b99179c8723b.png">
