### PR TITLE
Stylesheet: Don't parse library CSS as LESS

### DIFF
--- a/library/Icinga/Web/StyleSheet.php
+++ b/library/Icinga/Web/StyleSheet.php
@@ -90,6 +90,9 @@ class StyleSheet
      */
     protected $app;
 
+    /** @var string[] Pre-compiled CSS files */
+    protected $cssFiles = [];
+
     /**
      * Less compiler
      *
@@ -126,7 +129,11 @@ class StyleSheet
     {
         foreach ($this->app->getLibraries() as $library) {
             foreach ($library->getCssAssets() as $lessFile) {
-                $this->lessCompiler->addLessFile($lessFile);
+                if (substr($lessFile, -4) === '.css') {
+                    $this->cssFiles[] = $lessFile;
+                } else {
+                    $this->lessCompiler->addLessFile($lessFile);
+                }
             }
         }
 
@@ -190,6 +197,16 @@ class StyleSheet
     }
 
     /**
+     * Get all collected files
+     *
+     * @return string[]
+     */
+    protected function getFiles(): array
+    {
+        return array_merge($this->cssFiles, $this->lessCompiler->getLessFiles());
+    }
+
+    /**
      * Get the stylesheet for PDF export
      *
      * @return  $this
@@ -216,7 +233,13 @@ class StyleSheet
         if ($minified) {
             $this->lessCompiler->compress();
         }
-        return $this->lessCompiler->render();
+
+        $css = '';
+        foreach ($this->cssFiles as $cssFile) {
+            $css .= file_get_contents($cssFile);
+        }
+
+        return $css . $this->lessCompiler->render();
     }
 
     /**
@@ -238,14 +261,15 @@ class StyleSheet
 
         $noCache = $request->getHeader('Cache-Control') === 'no-cache' || $request->getHeader('Pragma') === 'no-cache';
 
-        if (! $noCache && FileCache::etagMatchesFiles($styleSheet->lessCompiler->getLessFiles())) {
+        $collectedFiles = $styleSheet->getFiles();
+        if (! $noCache && FileCache::etagMatchesFiles($collectedFiles)) {
             $response
                 ->setHttpResponseCode(304)
                 ->sendHeaders();
             return;
         }
 
-        $etag = FileCache::etagForFiles($styleSheet->lessCompiler->getLessFiles());
+        $etag = FileCache::etagForFiles($collectedFiles);
 
         $response->setHeader('ETag', $etag, true)
             ->setHeader('Content-Type', 'text/css', true);


### PR DESCRIPTION
must be backported to 2.9.7 and 2.10.2