### PR TITLE
Fix light mode variable references resolution issue

### DIFF
--- a/library/Icinga/Less/Call.php
+++ b/library/Icinga/Less/Call.php
@@ -34,7 +34,7 @@ class Call extends Less_Tree_Call
             }
 
             if ($name) {
-                foreach (array_reverse($env->frames) as $frame) {
+                foreach ($env->frames as $frame) {
                     if (($v = $frame->variable($name))) {
                         // Variables from the frame stack are always of type LESS Tree Rule
                         $vr = $v->value;

--- a/library/Icinga/Less/Call.php
+++ b/library/Icinga/Less/Call.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Icinga\Less;
+
+use Less_Tree_Call;
+use Less_Tree_Color;
+use Less_Tree_Value;
+use Less_Tree_Variable;
+
+class Call extends Less_Tree_Call
+{
+    public static function fromCall(Less_Tree_Call $call)
+    {
+        return new static($call->name, $call->args, $call->index, $call->currentFileInfo);
+    }
+
+    public function compile($env = null)
+    {
+        if (! $env) {
+            // Not sure how to trigger this, but if there is no $env, there is nothing we can do
+            return parent::compile($env);
+        }
+
+        foreach ($this->args as $arg) {
+            $name = null;
+            if ($arg->value[0] instanceof Less_Tree_Variable) {
+                // This is the case when defining a variable with a callable LESS rules such as fade, fadeout..
+                // Example: `@foo: #fff; @foo-bar: fade(@foo, 10);`
+                $name = $arg->value[0]->name;
+            } elseif ($arg->value[0] instanceof ColorPropOrVariable) {
+                // This is the case when defining a CSS rule using the LESS functions and passing
+                // a variable as an argument to them. Example: `... { color: fade(@foo, 10%); }`
+                $name = $arg->value[0]->getVariable()->name;
+            }
+
+            if ($name) {
+                foreach (array_reverse($env->frames) as $frame) {
+                    if (($v = $frame->variable($name))) {
+                        // Variables from the frame stack are always of type LESS Tree Rule
+                        $vr = $v->value;
+                        if ($vr instanceof Less_Tree_Value) {
+                            // Get the actual color prop, otherwise this may cause an invalid argument error
+                            $vr = $vr->compile($env);
+                        }
+
+                        if ($vr instanceof DeferredColorProp) {
+                            if (! $vr->hasReference()) {
+                                // Should never happen, though just for safety's sake
+                                $vr->compile($env);
+                            }
+
+                            // Get the uppermost variable of the variable references
+                            while (! $vr instanceof ColorProp) {
+                                $vr = $vr->getRef();
+                            }
+                        } elseif ($vr instanceof Less_Tree_Color) {
+                            $vr = ColorProp::fromColor($vr);
+                            $vr->setName($name);
+                        }
+
+                        $arg->value[0] = $vr;
+                        break;
+                    }
+                }
+            }
+        }
+
+        return parent::compile($env);
+    }
+}

--- a/library/Icinga/Less/Call.php
+++ b/library/Icinga/Less/Call.php
@@ -24,6 +24,10 @@ class Call extends Less_Tree_Call
         }
 
         foreach ($this->args as $arg) {
+            if (! is_array($arg->value)) {
+                continue;
+            }
+
             $name = null;
             if ($arg->value[0] instanceof Less_Tree_Variable) {
                 // This is the case when defining a variable with a callable LESS rules such as fade, fadeout..

--- a/library/Icinga/Less/Call.php
+++ b/library/Icinga/Less/Call.php
@@ -1,5 +1,7 @@
 <?php
 
+/* Icinga Web 2 | (c) 2022 Icinga GmbH | GPLv2+ */
+
 namespace Icinga\Less;
 
 use Less_Tree_Call;
@@ -59,6 +61,7 @@ class Call extends Less_Tree_Call
                         }
 
                         $arg->value[0] = $vr;
+
                         break;
                     }
                 }

--- a/library/Icinga/Less/ColorProp.php
+++ b/library/Icinga/Less/ColorProp.php
@@ -1,5 +1,5 @@
 <?php
-/* Icinga Web 2 | (c) 2022 Icinga Development Team | GPLv2+ */
+/* Icinga Web 2 | (c) 2022 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Less;
 

--- a/library/Icinga/Less/ColorProp.php
+++ b/library/Icinga/Less/ColorProp.php
@@ -38,7 +38,11 @@ class ColorProp extends Less_Tree_Color
         $self->color = $color;
 
         foreach ($color as $k => $v) {
-            $self->$k = $v;
+            if ($k === 'name') {
+                $self->setName($v); // Removes the @ char from the name
+            } else {
+                $self->$k = $v;
+            }
         }
 
         return $self;
@@ -79,6 +83,10 @@ class ColorProp extends Less_Tree_Color
      */
     public function setName($name)
     {
+        if ($name[0] === '@') {
+            $name = substr($name, 1);
+        }
+
         $this->name = $name;
 
         return $this;

--- a/library/Icinga/Less/ColorPropOrVariable.php
+++ b/library/Icinga/Less/ColorPropOrVariable.php
@@ -45,7 +45,12 @@ class ColorPropOrVariable extends Less_Tree
             // Evaluate variable variable as in Less_Tree_Variable:28.
             $vv = new Less_Tree_Variable(substr($v->name, 1), $v->index + 1, $v->currentFileInfo);
             // Overwrite the name so that the variable variable is not evaluated again.
-            $v->name = '@' . $vv->compile($env)->value;
+            $result = $vv->compile($env);
+            if ($result instanceof DeferredColorProp) {
+                $v->name = $result->name;
+            } else {
+                $v->name = '@' . $result->value;
+            }
         }
 
         $compiled = $v->compile($env);
@@ -58,7 +63,7 @@ class ColorPropOrVariable extends Less_Tree
         if ($compiled instanceof Less_Tree_Color) {
             return ColorProp::fromColor($compiled)
                 ->setIndex($v->index)
-                ->setName(substr($v->name, 1));
+                ->setName($v->name);
         }
 
         return $compiled;

--- a/library/Icinga/Less/ColorPropOrVariable.php
+++ b/library/Icinga/Less/ColorPropOrVariable.php
@@ -1,5 +1,5 @@
 <?php
-/* Icinga Web 2 | (c) 2022 Icinga Development Team | GPLv2+ */
+/* Icinga Web 2 | (c) 2022 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Less;
 

--- a/library/Icinga/Less/DeferredColorProp.php
+++ b/library/Icinga/Less/DeferredColorProp.php
@@ -5,6 +5,7 @@ namespace Icinga\Less;
 use Less_Exception_Compiler;
 use Less_Tree_Call;
 use Less_Tree_Color;
+use Less_Tree_Keyword;
 use Less_Tree_Value;
 use Less_Tree_Variable;
 
@@ -89,7 +90,7 @@ class DeferredColorProp extends Less_Tree_Variable
 
         $this->evaluating = true;
 
-        foreach (array_reverse($env->frames) as $frame) {
+        foreach ($env->frames as $frame) {
             if (($v = $frame->variable($this->getRef()->name))) {
                 $rv = $v->value;
                 if ($rv instanceof Less_Tree_Value) {
@@ -122,7 +123,7 @@ class DeferredColorProp extends Less_Tree_Variable
         $css = (new Less_Tree_Call(
             'var',
             [
-                new \Less_Tree_Keyword('--' . $this->getName()),
+                new Less_Tree_Keyword('--' . $this->getName()),
                 $this->getRef() // Each of the references will be generated recursively
             ],
             $this->index

--- a/library/Icinga/Less/DeferredColorProp.php
+++ b/library/Icinga/Less/DeferredColorProp.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Icinga\Less;
+
+use Less_Exception_Compiler;
+use Less_Tree_Call;
+use Less_Tree_Color;
+use Less_Tree_Value;
+use Less_Tree_Variable;
+
+class DeferredColorProp extends Less_Tree_Variable
+{
+    /** @var DeferredColorProp|ColorProp */
+    protected $reference;
+
+    protected $resolved = false;
+
+    public function __construct($name, $variable, $index = null, $currentFileInfo = null)
+    {
+        parent::__construct($name, $index, $currentFileInfo);
+
+        if ($variable instanceof Less_Tree_Variable) {
+            $this->reference = self::fromVariable($variable);
+        }
+    }
+
+    public function isResolved()
+    {
+        return $this->resolved;
+    }
+
+    public function getName()
+    {
+        $name = $this->name;
+        if ($this->name[0] === '@') {
+            $name = substr($this->name, 1);
+        }
+
+        return $name;
+    }
+
+    public function hasReference()
+    {
+        return $this->reference !== null;
+    }
+
+    public function getRef()
+    {
+        return $this->reference;
+    }
+
+    public function setReference($ref)
+    {
+        $this->reference = $ref;
+
+        return $this;
+    }
+
+    public static function fromVariable(Less_Tree_Variable $variable)
+    {
+        $static = new static($variable->name, $variable->index, $variable->currentFileInfo);
+        $static->evaluating = $variable->evaluating;
+        $static->type = $variable->type;
+
+        return $static;
+    }
+
+    public function compile($env)
+    {
+        if (! $this->hasReference()) {
+            // This is never supposed to happen, however, we might have a deferred color prop
+            // without a reference. In this case we can simply use the parent method.
+            return parent::compile($env);
+        }
+
+        if ($this->isResolved()) {
+            // The dependencies are already resolved, no need to traverse the frame stack over again!
+            return $this;
+        }
+
+        if ($this->evaluating) {
+            throw new Less_Exception_Compiler(
+                "Recursive variable definition for " . $this->name,
+                null,
+                $this->index,
+                $this->currentFileInfo
+            );
+        }
+
+        $this->evaluating = true;
+
+        foreach (array_reverse($env->frames) as $frame) {
+            if (($v = $frame->variable($this->getRef()->name))) {
+                $rv = $v->value;
+                if ($rv instanceof Less_Tree_Value) {
+                    $rv = $rv->compile($env);
+                }
+
+                // As we are at it anyway, let's cast the tree color to our color prop as well!
+                if ($rv instanceof Less_Tree_Color) {
+                    $rv = ColorProp::fromColor($rv);
+                    $rv->setName($this->getRef()->getName());
+                }
+
+                $this->evaluating = false;
+                $this->resolved = true;
+                $this->setReference($rv);
+
+                break;
+            }
+        }
+
+        return $this;
+    }
+
+    public function genCSS($output)
+    {
+        if (! $this->hasReference()) {
+            return; // Nothing to generate
+        }
+
+        $css = (new Less_Tree_Call(
+            'var',
+            [
+                new \Less_Tree_Keyword('--' . $this->getName()),
+                $this->getRef() // Each of the references will be generated recursively
+            ],
+            $this->index
+        ))->toCSS();
+
+        $output->add($css);
+    }
+}

--- a/library/Icinga/Less/DeferredColorProp.php
+++ b/library/Icinga/Less/DeferredColorProp.php
@@ -1,5 +1,7 @@
 <?php
 
+/* Icinga Web 2 | (c) 2022 Icinga GmbH | GPLv2+ */
+
 namespace Icinga\Less;
 
 use Less_Exception_Compiler;
@@ -79,7 +81,7 @@ class DeferredColorProp extends Less_Tree_Variable
             return $this;
         }
 
-        if ($this->evaluating) {
+        if ($this->evaluating) { // Just like the parent method
             throw new Less_Exception_Compiler(
                 "Recursive variable definition for " . $this->name,
                 null,

--- a/library/Icinga/Less/LightMode.php
+++ b/library/Icinga/Less/LightMode.php
@@ -1,5 +1,5 @@
 <?php
-/* Icinga Web 2 | (c) 2022 Icinga Development Team | GPLv2+ */
+/* Icinga Web 2 | (c) 2022 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Less;
 

--- a/library/Icinga/Less/LightModeCall.php
+++ b/library/Icinga/Less/LightModeCall.php
@@ -1,5 +1,5 @@
 <?php
-/* Icinga Web 2 | (c) 2022 Icinga Development Team | GPLv2+ */
+/* Icinga Web 2 | (c) 2022 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Less;
 

--- a/library/Icinga/Less/LightModeDefinition.php
+++ b/library/Icinga/Less/LightModeDefinition.php
@@ -1,5 +1,5 @@
 <?php
-/* Icinga Web 2 | (c) 2022 Icinga Development Team | GPLv2+ */
+/* Icinga Web 2 | (c) 2022 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Less;
 

--- a/library/Icinga/Less/LightModeTrait.php
+++ b/library/Icinga/Less/LightModeTrait.php
@@ -1,5 +1,5 @@
 <?php
-/* Icinga Web 2 | (c) 2022 Icinga Development Team | GPLv2+ */
+/* Icinga Web 2 | (c) 2022 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Less;
 

--- a/library/Icinga/Less/LightModeVisitor.php
+++ b/library/Icinga/Less/LightModeVisitor.php
@@ -1,5 +1,5 @@
 <?php
-/* Icinga Web 2 | (c) 2022 Icinga Development Team | GPLv2+ */
+/* Icinga Web 2 | (c) 2022 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Less;
 

--- a/library/Icinga/Less/Visitor.php
+++ b/library/Icinga/Less/Visitor.php
@@ -1,5 +1,5 @@
 <?php
-/* Icinga Web 2 | (c) 2022 Icinga Development Team | GPLv2+ */
+/* Icinga Web 2 | (c) 2022 Icinga GmbH | GPLv2+ */
 
 namespace Icinga\Less;
 
@@ -65,26 +65,13 @@ CSS;
 
     public function visitCall($c)
     {
-        if ($c->name === 'var') {
-            if ($this->callingVar !== false) {
-                throw new LogicException('Already calling var');
-            }
-
-            $this->callingVar = spl_object_hash($c);
-        } else {
+        if ($c->name !== 'var') {
             // We need to use our own tree call class , so that we can precompile the arguments before making
             // the actual LESS function calls. Otherwise, it will produce lots of invalid argument exceptions!
             $c = Call::fromCall($c);
         }
 
         return $c;
-    }
-
-    public function visitCallOut($c)
-    {
-        if ($this->callingVar !== false && $this->callingVar === spl_object_hash($c)) {
-            $this->callingVar = false;
-        }
     }
 
     public function visitDetachedRuleset($drs)
@@ -194,7 +181,7 @@ CSS;
 
     public function visitVariable($v)
     {
-        if ($this->callingVar !== false || $this->definingVariable !== false) {
+        if ($this->definingVariable !== false) {
             return $v;
         }
 
@@ -205,6 +192,7 @@ CSS;
     public function visitColor($c)
     {
         if ($this->definingVariable !== false) {
+            // Make sure that all less tree colors do have a proper name
             $c->name = $this->variableOrigin->name;
         }
 

--- a/test/php/library/Icinga/Util/LessParserTest.php
+++ b/test/php/library/Icinga/Util/LessParserTest.php
@@ -90,6 +90,40 @@ LESS
         );
     }
 
+    public function testNestedVariablesInMixinCalls()
+    {
+        $this->assertEquals(
+            <<<CSS
+.button1 {
+  background-color: var(--my-color, var(--black, #000000));
+}
+.button2 {
+  background-color: var(--my-black-color, var(--my-color, var(--black, #000000)));
+}
+
+CSS
+            ,
+            $this->compileLess(<<<LESS
+@black: black;
+@my-color: @black;
+@my-black-color: @my-color;
+
+.button(@bg-color: @my-color) {
+  background-color: @bg-color;
+}
+
+.button1 {
+  .button();
+}
+
+.button2 {
+  .button(@my-black-color)
+}
+LESS
+            )
+        );
+    }
+
     public function testDefiningVariablesWithLessCallables()
     {
         $this->assertEquals(

--- a/test/php/library/Icinga/Util/LessParserTest.php
+++ b/test/php/library/Icinga/Util/LessParserTest.php
@@ -60,6 +60,59 @@ LESS
         );
     }
 
+    public function testNestedVariables()
+    {
+        $this->assertEquals(
+            <<<CSS
+.black {
+  color: var(--my-color, var(--black, #000000));
+}
+.notBlack {
+  color: var(--my-black-color, var(--my-color, var(--black, #000000)));
+}
+
+CSS
+            ,
+            $this->compileLess(<<<LESS
+@black: black;
+@my-color: @black;
+@my-black-color: @my-color;
+
+.black {
+  color: @my-color;
+}
+
+.notBlack {
+  color: @my-black-color;
+}
+LESS
+            )
+        );
+    }
+
+    public function testDefiningVariablesWithLessCallables()
+    {
+        $this->assertEquals(
+            <<<CSS
+.my-rule {
+  color: var(--fade-color, rgba(221, 221, 221, 0.5));
+}
+
+CSS
+            ,
+            $this->compileLess(<<<LESS
+@color: #ddd;
+@my-color: @color;
+@fade-color: fade(@my-color, 50%);
+
+.my-rule {
+    color: @fade-color;
+}
+LESS
+            )
+        );
+    }
+
     public function testVariablesUsedInFunctions()
     {
         $this->assertEquals(


### PR DESCRIPTION
Currently, if a variable is pointing to another variable, which in turn is pointing to another variable, e.g. `@foo: green; @foo-bar: @foo; @foo-bar-foo: @foo-bar;` and when the variable `@foo-bar-foo` is used somewhere, the resolution of the variable hierarchy is not performed as defined. The resolved version of this variable would look like `var(--foo-bar-foo, green)`, which is actually wrong. This is because all variables in between will simply omitted and results in the following behavior. Suppose that the variable `@foo: green` is a base variable of Icinga Web 2 and has an appropriate light mode rule defined for it and changes the value to `--foo: white;`. But since the variable hierarchy is not taken into account, the parser will never notice that the value of the base variable has been changed meanwhile and will always render the same value in light and dark mode.

One can solve this by defining a separate light mode rule for the used variable `@foo-bar-foo`, but this would be cumbersome and one would have to look everywhere in which module the base variables from Icinga Web 2 are overwritten. Alternatively, the variable override hierarchy could be resolved exactly as it is defined in the respective less files, and you will always get the desired values in dark and light mode. This PR implements the second solution and the variables are rendered as follows, for example.

```
@color: #ddd;
@mycolor: @color;
@foo-color: @mycolor; 
@foo-bar-color: @foo-color;
@foo-bar-foo-color: @foo-bar-color;
@fade-color: fade(@mycolor, 50);
@fade-color-out: fadeout(@mycolor, 50%);
@fade-color-in: fadein(@fade-color-out, 50%);

.container { 
    color: @foo-bar-foo-color;
    background: @fade-color;
    background: @fade-color-out;
    background: @fade-color-in;
    background-color: fade(@foo-bar-color, 50%);
}
```

### Before

```
.container {
  color: var(--foo-bar-foo-color, #dddddd);
  background: var(--fade-color, rgba(221, 221, 221, 0.5));
  background: var(--fade-color-out, rgba(221, 221, 221, 0.5));
  background: var(--fade-color-in, #dddddd);
  background-color: rgba(221, 221, 221, 0.5);
}
```

### After

```
.container {
  color: var(--foo-bar-foo-color, var(--foo-bar-color, var(--foo-color, var(--mycolor, var(--color, #dddddd)))));
  background: var(--fade-color, rgba(221, 221, 221, 0.5));
  background: var(--fade-color-out, rgba(221, 221, 221, 0.5));
  background: var(--fade-color-in, #dddddd);
  background-color: rgba(221, 221, 221, 0.5);
}
```

fixes https://github.com/Icinga/icingaweb2-module-vspheredb/issues/355