### PR TITLE
Update docs

### DIFF
--- a/doc/02-Installation.md
+++ b/doc/02-Installation.md
@@ -282,9 +282,16 @@ yum install icingaweb2 icingacli
 
 ## Install the Web Server <a id="install-the-web-server"></a>
 
-Make sure you have a web server with PHP up and running before moving on.
-Please refer to the [installation requirements](#installation-requirements) for details about supported versions.
-Depending on your OS you might have to install, and configure the web server separately.
+Ensure that you have a web server with PHP installed before proceeding,
+such as Apache or Nginx with PHP version ≥ 7.2. Depending on your operating system,
+you may need to install and configure the web server separately.
+An Apache configuration file to serve Icinga Web is already installed.
+If you want to use Nginx, you must manually create a configuration file using the following command.
+Save the output as a new file in the web server configuration directory:
+
+```bash
+icingacli setup config webserver nginx --document-root /usr/share/icingaweb2/public
+```
 
 ## Prepare Web Setup <a id="prepare-web-setup-from-package"></a>
 

--- a/doc/02-Installation.md
+++ b/doc/02-Installation.md
@@ -32,9 +32,10 @@ thoroughly.
 
 ## Installation Requirements <a id="installation-requirements"></a>
 
-* [Icinga 2](https://icinga.com/products/icinga-2/) with the IDO database backend (MySQL or PostgreSQL)
+* [Icinga 2](https://icinga.com/docs/icinga-2) and [Icinga DB](https://icinga.com/docs/icinga-db) to
+  monitor your infrastructure
 * A web server, e.g. Apache or Nginx
-* PHP version >= 7.2
+* PHP version ≥ 7.2
 
 ### Optional Requirements
 * For exports to PDF also the following PHP modules are required: mbstring, GD, Imagick
@@ -381,11 +382,12 @@ mv icingaweb2-2.9.5 icingaweb2
 
 You will need to install certain dependencies depending on your setup:
 
-* [Icinga 2](https://icinga.com/products/icinga-2/) with the IDO database backend (MySQL or PostgreSQL)
+* [Icinga 2](https://github.com/Icinga/icinga2) and [Icinga DB](https://github.com/Icinga/icingadb) to
+  monitor your infrastructure
 * A web server, e.g. Apache or Nginx
-* PHP version >= 7.2
-* [Icinga PHP Library (ipl)](https://github.com/Icinga/icinga-php-library) (>= 0.9)
-* [Icinga PHP Thirdparty](https://github.com/Icinga/icinga-php-thirdparty) (>= 0.11)
+* PHP version ≥ 7.2
+* [Icinga PHP Library (ipl)](https://github.com/Icinga/icinga-php-library) (≥ 0.9)
+* [Icinga PHP Thirdparty](https://github.com/Icinga/icinga-php-thirdparty) (≥ 0.11)
 * The following PHP modules must be installed: cURL, json, gettext, fileinfo, intl, dom, OpenSSL and xml
 * For exports to PDF also the following PHP modules are required: mbstring, GD, Imagick
 * LDAP PHP library when using Active Directory or LDAP for authentication

--- a/doc/02-Installation.md
+++ b/doc/02-Installation.md
@@ -38,7 +38,9 @@ thoroughly.
 * PHP version ≥ 7.2
 
 ### Optional Requirements
-* For exports to PDF also the following PHP modules are required: mbstring, GD, Imagick
+
+* The [pdfexport](https://github.com/Icinga/icingaweb2-module-pdfexport) module (≥0.10) is required for the
+  export to PDF
 * LDAP PHP library when using Active Directory or LDAP for authentication
 
 ## Add Icinga Package Repository <a id="add-icinga-package-repository"></a>
@@ -396,7 +398,8 @@ You will need to install certain dependencies depending on your setup:
 * [Icinga PHP Library (ipl)](https://github.com/Icinga/icinga-php-library) (≥ 0.9)
 * [Icinga PHP Thirdparty](https://github.com/Icinga/icinga-php-thirdparty) (≥ 0.11)
 * The following PHP modules must be installed: cURL, json, gettext, fileinfo, intl, dom, OpenSSL and xml
-* For exports to PDF also the following PHP modules are required: mbstring, GD, Imagick
+* The [pdfexport](https://github.com/Icinga/icingaweb2-module-pdfexport) module (≥0.10) is required for the
+  export to PDF
 * LDAP PHP library when using Active Directory or LDAP for authentication
 * MySQL or PostgreSQL PHP libraries
 


### PR DESCRIPTION
This PR introduces the following documentation changes:

- Require Icinga DB instead of IDO
- Recommend the pdfexport module instead of dompdf
- Added a little more text to the install web server section as we are linking to it from the Icinga DB Web documentation