### PR TITLE
Fix CSS duplicate definitions

### DIFF
--- a/library/Icinga/Less/Visitor.php
+++ b/library/Icinga/Less/Visitor.php
@@ -65,11 +65,9 @@ CSS;
 
     public function visitCall($c)
     {
-        if ($c->name !== 'var') {
-            // We need to use our own tree call class , so that we can precompile the arguments before making
-            // the actual LESS function calls. Otherwise, it will produce lots of invalid argument exceptions!
-            $c = Call::fromCall($c);
-        }
+        // We need to use our own tree call class , so that we can precompile the arguments before making
+        // the actual LESS function calls. Otherwise, it will produce lots of invalid argument exceptions!
+        $c = Call::fromCall($c);
 
         return $c;
     }

--- a/test/php/library/Icinga/Util/LessParserTest.php
+++ b/test/php/library/Icinga/Util/LessParserTest.php
@@ -90,6 +90,66 @@ LESS
         );
     }
 
+    public function testNestedCssDefinitions()
+    {
+        $this->assertEquals(
+            <<<CSS
+.black {
+  color: var(--my-color, var(--black, #000000));
+}
+.notBlack {
+  color: var(--my-black-color, var(--my-color, var(--black, #000000)));
+}
+
+CSS
+            ,
+            $this->compileLess(<<<LESS
+@black: black;
+@my-color: @black;
+@my-black-color: @my-color;
+
+.black {
+  color: var(--my-color, @black);
+}
+
+.notBlack {
+  color: var(--my-black-color, @my-color);
+}
+LESS
+            )
+        );
+    }
+
+    public function testNestedDuplcateCssDefinitions()
+    {
+        $this->assertEquals(
+            <<<CSS
+.black {
+  color: var(--my-color, var(--black, #000000));
+}
+.notBlack {
+  color: var(--my-black-color, var(--my-color, var(--black, #000000)));
+}
+
+CSS
+            ,
+            $this->compileLess(<<<LESS
+@black: black;
+@my-color: @black;
+@my-black-color: @my-color;
+
+.black {
+  color: var(--my-color, @my-color);
+}
+
+.notBlack {
+  color: var(--my-black-color, @my-black-color);
+}
+LESS
+            )
+        );
+    }
+
     public function testNestedVariablesInMixinCalls()
     {
         $this->assertEquals(


### PR DESCRIPTION
Use `Call::fromCall()` in `Visitor::visitCall()` irrespective of CSS calling function name (var, fade etc.).

And in `Call::compile()` in case we have CSS `var()` function calls and the keyword value of the function call prefixed by 
`--` and color property name prefixed by `@` are same, then avoid generation of duplicate CSS definitions.

fixes #4847 