### PR TITLE
Unveil hidden downtime in checkable detail view

### DIFF
--- a/modules/monitoring/application/views/scripts/show/components/downtime.phtml
+++ b/modules/monitoring/application/views/scripts/show/components/downtime.phtml
@@ -32,7 +32,7 @@ if ($this->hasPermission('monitoring/command/downtime/schedule')) {
         );
     }
 }
-if (empty($object->comments) && ! $addLink) {
+if (empty($object->downtimes) && ! $addLink) {
     return;
 }
 ?>


### PR DESCRIPTION
Case: there are no comments, one downtime and you may not schedule additional ones.

Before: downtime is not shown in checkable detail view.

After: downtime is shown in checkable detail view.

Found while working on ref/IP/42380 .