### PR TITLE
Tests: Introduce base cli bootstrapping to be used for module unit tests

### DIFF
--- a/library/Icinga/Test/Bootstrap.php
+++ b/library/Icinga/Test/Bootstrap.php
@@ -1,0 +1,30 @@
+<?php
+
+/* Icinga Web 2 | (c) 2022 Icinga GmbH | GPLv2+ */
+
+namespace Icinga\Test;
+
+use Icinga\Application\Cli;
+
+class Bootstrap
+{
+    public static function bootstrap(string $module, string $basedir, string $testsDir = null)
+    {
+        error_reporting(E_ALL | E_STRICT);
+
+        $configDir = getenv('ICINGAWEB_CONFIGDIR');
+        if (isset($_SERVER['ICINGAWEB_CONFIGDIR'])) {
+            $configDir = $_SERVER['ICIGNAWEB_CONFIGDIR'];
+        }
+
+        if (! $testsDir) {
+            $testsDir = $basedir . '/tests';
+        }
+
+        require_once 'Icinga/Application/Cli.php';
+
+        Cli::start($testsDir, $configDir)
+            ->getModuleManager()
+            ->loadModule($module, $basedir);
+    }
+}


### PR DESCRIPTION
All our modules can then simply do the following to run custom unittests:

```php
$icingaweb2 = getenv('ICINGAWEB_BASEDIR') ?: '/usr/share/icingaweb2';

require_once $icingaweb2 . '/library/Icinga/Test/Bootstrap.php';
Bootstrap::bootstrap('x509', $basedir, $basedir . '/tests');
```