### PR TITLE
css: Optimize performance

### DIFF
--- a/public/css/icinga/forms.less
+++ b/public/css/icinga/forms.less
@@ -560,7 +560,8 @@ form.icinga-form .form-info {
     box-shadow: 0 0 .25em 0 rgba(0,0,0,.4);
   }
 
-  &[disabled] ~ * {
+  &[disabled] ~ img,
+  &[disabled] ~ span {
     opacity: .25;
   }
 


### PR DESCRIPTION
I don't quite understand why exactly this rule exposes such an issue. We have several other rules that are similar. But they don't reference form elements on the left. I suspect a different issue somewhere else, this only exaggerated it.

fixes #4929