### PR TITLE
Inconsistent comments in INI files

### DIFF
--- a/library/Icinga/File/Ini/IniParser.php
+++ b/library/Icinga/File/Ini/IniParser.php
@@ -153,7 +153,7 @@ class IniParser
                             $state = self::LINE_START;
                             $line ++;
                         } elseif ($s === ';') {
-                            $state = self::COMMENT;
+                            $state = self::COMMENT_END;
                         }
                     } else {
                         $token .= $s;


### PR DESCRIPTION
There is minor inconsistency with comment handling in INI file:
```ini
dir1 = "I have commentsPost( c1)" ; c1
dir2 = I have no comments ; c2
dir3 = I have commentsPre( c2) from previous line
```

BTW:
for quoted value, garbage is silently ignored, possibly leading to hard-to-spot problems. Is it worth fixing?
```ini
dir = "this is dir value"but this part is ignored"  ; and this is commentsPost
```
