### PR TITLE
CommentParser: Wrap outputs after `120` chars and not `72`

### DIFF
--- a/library/Icinga/Cli/Documentation/CommentParser.php
+++ b/library/Icinga/Cli/Documentation/CommentParser.php
@@ -3,6 +3,8 @@
 
 namespace Icinga\Cli\Documentation;
 
+use Icinga\Cli\Screen;
+
 class CommentParser
 {
     protected $raw;
@@ -75,7 +77,7 @@ class CommentParser
         }
 
         foreach ($this->paragraphs as $p) {
-            $res .= wordwrap($p, 72) . "\n\n";
+            $res .= wordwrap($p, Screen::instance()->getColumns()) . "\n\n";
         }
 
         return $res;


### PR DESCRIPTION
Well, what should I say, the PHP code sniffer allows us up to `120` characters line length and when you code/format based on these rules, e.g the description of a cli command, it will mess everything up when you run `icingacli module --help`. So if we are allowed to have up to 120 characters on a line in the code, why not in the output.