### PR TITLE
form.js: Don't ignore autosubmit elements

### DIFF
--- a/public/js/icinga/behavior/form.js
+++ b/public/js/icinga/behavior/form.js
@@ -81,7 +81,6 @@
         if ($container.has(origFocus).length
             && $(origFocus).length
             && ! $(origFocus).hasClass('autofocus')
-            && ! $(origFocus).hasClass('autosubmit')
             && $(origFocus).closest('form').length
             && $(origFocus).not(':input[type=button], :input[type=submit], :input[type=reset]').length
         ) {


### PR DESCRIPTION
A while ago this already has changed so that autosubmit responses are guaranteed to be applied. Thus this
exception is now obsolete.

fixes #4942