### PR TITLE
js: Only disable submit buttons on form submit

### DIFF
--- a/public/js/icinga/behavior/modal.js
+++ b/public/js/icinga/behavior/modal.js
@@ -120,7 +120,7 @@
         });
 
         // otherwise the form is submitted several times by clicking the "Submit" button several times
-        $form.find('input:not(:disabled)').prop('disabled', true);
+        $form.find('input[type=submit],button[type=submit],button:not([type])').prop('disabled', true);
 
         event.stopPropagation();
         event.preventDefault();

--- a/public/js/icinga/behavior/modal.js
+++ b/public/js/icinga/behavior/modal.js
@@ -119,8 +119,10 @@
             }
         });
 
-        // otherwise the form is submitted several times by clicking the "Submit" button several times
-        $form.find('input[type=submit],button[type=submit],button:not([type])').prop('disabled', true);
+        if (typeof $autoSubmittedBy === 'undefined') {
+            // otherwise the form is submitted several times by clicking the "Submit" button several times
+            $form.find('input[type=submit],button[type=submit],button:not([type])').prop('disabled', true);
+        }
 
         event.stopPropagation();
         event.preventDefault();

--- a/public/js/icinga/loader.js
+++ b/public/js/icinga/loader.js
@@ -130,7 +130,7 @@
             // Disable all form controls to prevent resubmission except for our search input
             // Note that disabled form inputs will not be enabled via JavaScript again
             if (! $form.is('[role="search"]') && $target.attr('id') === $form.closest('.container').attr('id')) {
-                $form.find('input:not(:disabled)').prop('disabled', true);
+                $form.find('input[type=submit],button[type=submit],button:not([type])').prop('disabled', true);
             }
 
             // Show a spinner depending on how the form is being submitted

--- a/public/js/icinga/loader.js
+++ b/public/js/icinga/loader.js
@@ -129,7 +129,10 @@
 
             // Disable all form controls to prevent resubmission except for our search input
             // Note that disabled form inputs will not be enabled via JavaScript again
-            if (! $form.is('[role="search"]') && $target.attr('id') === $form.closest('.container').attr('id')) {
+            if (! $autoSubmittedBy
+                && ! $form.is('[role="search"]')
+                && $target.attr('id') === $form.closest('.container').attr('id')
+            ) {
                 $form.find('input[type=submit],button[type=submit],button:not([type])').prop('disabled', true);
             }
 


### PR DESCRIPTION
Previously all `input` elements (text, date, number, ...) got also disabled. This is unecessary.