### PR TITLE
icingacli setup config webserver apache: add trailing / to Alias dir

### DIFF
--- a/modules/setup/library/Setup/Webserver.php
+++ b/modules/setup/library/Setup/Webserver.php
@@ -76,12 +76,14 @@ abstract class Webserver
         $searchTokens = array(
             '{urlPath}',
             '{documentRoot}',
+            '{aliasDocumentRoot}',
             '{configDir}',
             '{fpmUri}'
         );
         $replaceTokens = array(
             $this->getUrlPath(),
             $this->getDocumentRoot(),
+            preg_match('~/$~', $this->getUrlPath()) ? $this->getDocumentRoot() . '/' : $this->getDocumentRoot(),
             $this->getConfigDir(),
             $this->getFpmUri()
         );

--- a/modules/setup/library/Setup/Webserver/Apache.php
+++ b/modules/setup/library/Setup/Webserver/Apache.php
@@ -16,7 +16,7 @@ class Apache extends Webserver
     {
         if (! $this->enableFpm) {
             return  <<<'EOD'
-Alias {urlPath} "{documentRoot}"
+Alias {urlPath} "{aliasDocumentRoot}"
 
 # Remove comments if you want to use PHP FPM and your Apache version is older than 2.4
 #<IfVersion < 2.4>
@@ -79,7 +79,7 @@ Alias {urlPath} "{documentRoot}"
 EOD;
         } else {
             return <<<'EOD'
-Alias {urlPath} "{documentRoot}"
+Alias {urlPath} "{aliasDocumentRoot}"
 
 <IfVersion < 2.4>
     # Forward PHP requests to FPM


### PR DESCRIPTION
if the Alias URI (e.g. /) has a trailing /. Otherwise Apache says 403.

* `RUN ["icingacli", "setup", "config", "webserver", "apache", "--path=/icingaweb2", "--file=/etc/apache2/conf-enabled/icingaweb2.conf"]` still works es expected
* `RUN ["icingacli", "setup", "config", "webserver", "apache", "--path=/", "--file=/etc/apache2/conf-enabled/icingaweb2.conf"]` now works es expected

This would allow me to remove the `--root=/usr/share/icingaweb2/public/` workaround from Icinga/docker-icingaweb2#105.