### PR TITLE
IcingaException: Only use `vsprintf()` if `$args` given

### DIFF
--- a/library/Icinga/Exception/IcingaException.php
+++ b/library/Icinga/Exception/IcingaException.php
@@ -25,7 +25,12 @@ class IcingaException extends Exception
                 $exc = $arg;
             }
         }
-        parent::__construct(vsprintf($message, $args), 0, $exc);
+
+        if (! empty($args)) {
+            $message = vsprintf($message, $args);
+        }
+
+        parent::__construct($message, 0, $exc);
     }
 
     /**


### PR DESCRIPTION
If the passed message contains a `%`, but no `$args`, `vsprintf()` throws an error.

fixes: #5004