### PR TITLE
MonitoringBadgeNavigationItemRenderer: do not fail

### DIFF
--- a/modules/monitoring/library/Monitoring/Web/Navigation/Renderer/MonitoringBadgeNavigationItemRenderer.php
+++ b/modules/monitoring/library/Monitoring/Web/Navigation/Renderer/MonitoringBadgeNavigationItemRenderer.php
@@ -114,6 +114,10 @@ class MonitoringBadgeNavigationItemRenderer extends BadgeNavigationItemRenderer
     {
         $restrictions = Filter::matchAny();
         foreach (Auth::getInstance()->getRestrictions($restriction) as $filter) {
+            if ($filter === '*') {
+                $filterable->addFilter(Filter::matchAll());
+                return $filterable;
+            }
             $restrictions->addFilter(Filter::fromQueryString($filter));
         }
         $filterable->applyFilter($restrictions);


### PR DESCRIPTION
Summary badges are failing in case one of your roles has a wildcard filter:

![Bildschirmfoto vom 2023-02-24 08-39-29](https://user-images.githubusercontent.com/553008/221123123-b0609cab-3d1e-4124-8bcc-da00fe816b9f.png)

![Bildschirmfoto vom 2023-02-24 08-39-51](https://user-images.githubusercontent.com/553008/221123130-e3c50548-f7a4-42bd-84a1-d6a39ef196df.png)
