### PR TITLE
CSS: Set correct height input[type=“datetime-local”]

### DIFF
--- a/public/css/icinga/forms.less
+++ b/public/css/icinga/forms.less
@@ -228,7 +228,8 @@ form.icinga-form {
   }
 }
 
-form.icinga-form select:not([multiple]) {
+form.icinga-form select:not([multiple]),
+form.icinga-form input[type="datetime-local"] {
   // Compensate inconsistent select height calculations
   line-height: 1em;
   height: 2.25em;


### PR DESCRIPTION
The height for `input[type=“datetime-local”]` ist fixed.

![Screenshot 2023-03-23 at 16 07 20](https://user-images.githubusercontent.com/6977434/227247518-81d20eb4-ba62-43f7-a2ea-94d0dbda6c5b.png)

But I can’t reproduce the problem for `select`s

![Screenshot 2023-03-23 at 16 07 07](https://user-images.githubusercontent.com/6977434/227247782-59bd3624-d199-4f80-85d1-77f0824818e2.png)

