### PR TITLE
Allow token refresh for external auth

### DIFF
--- a/public/js/icinga/loader.js
+++ b/public/js/icinga/loader.js
@@ -1015,7 +1015,12 @@
                 this.icinga.timer.unregister(req.progressTimer);
             }
 
-            if (req.status > 0 && req.status < 501) {
+            if (req.status == 401) {
+                this.icinga.logger.debug(
+                    'Request to ' + url + ' return 401. Will refresh page to trigger new login.'
+                );
+                window.refresh();
+            } else if (req.status > 0 && req.status < 501) {
                 this.icinga.logger.error(
                     req.status,
                     errorThrown + ':',

--- a/public/js/icinga/loader.js
+++ b/public/js/icinga/loader.js
@@ -1019,7 +1019,7 @@
                 this.icinga.logger.debug(
                     'Request to ' + url + ' return 401. Will refresh page to trigger new login.'
                 );
-                window.refresh();
+                window.location.reload();
             } else if (req.status > 0 && req.status < 501) {
                 this.icinga.logger.error(
                     req.status,


### PR DESCRIPTION
Issue:
When using Icingaweb2 with external auth (such as OIDC) your token will eventually expire and the user has to relogin via the external provider. However, this does not work on ajax requests (as they cannot redirect the user). Most external auth plugins (such as mod_auth_openid) will return 401 instead of a redirect when they detect ajax requests. Icingaweb2 will show a 401 in a few places (example here: https://community.icinga.com/t/401-unauthorized-in-icingaweb2-with-external-auth/9563).

Change:
With this change icingaweb2 will reload the window instead which in turn will trigger a redirect to the IDP. In most cases the user should get redirected back and should not even notice that his OIDC token got renewed.

Alternative solution:

1. We could also use another code such as 407 Proxy Authentication Required. In mod_auth_openid this is configurable but it might not work for other solutions.
2. I saw that loader.js also supports an header `X-Icinga-Reload-Window` which would trigger a reload as well. Unfortunately, mod_auth_openid does not support setting an additional header when auth fails.