### PR TITLE
TimeLine: Always parse `int` to validateTime()

### DIFF
--- a/modules/monitoring/library/Monitoring/Timeline/TimeLine.php
+++ b/modules/monitoring/library/Monitoring/Timeline/TimeLine.php
@@ -382,7 +382,7 @@ class TimeLine implements IteratorAggregate
         return array_filter(
             $this->resultset,
             function ($e) use ($range) {
-                return $range->validateTime($e->time);
+                return $range->validateTime((int) $e->time);
             }
         );
     }


### PR DESCRIPTION
Php < 8.1 converts fetched time(stamp) to string. This must always be an int.

fixes #5025 