### PR TITLE
js: Don't trigger beforerender or rendered for discarded content

### DIFF
--- a/doc/80-Upgrading.md
+++ b/doc/80-Upgrading.md
@@ -15,6 +15,10 @@ v2.6 to v2.8 requires to follow the instructions for v2.7 too.
   developers should not encounter breaking changes in their Less files. The `wikimedia/less.php`
   [changelog](https://github.com/wikimedia/less.php/blob/master/CHANGES.md) covers all changes introduced between
   these versions.
+* Our JavaScript framework does not trigger the events `beforerender` and `rendered` on containers anymore,
+  in case the response has been discarded by a behavior with a `renderHook` implementation. Other postprocessing
+  such as updates according to the request header `X-Icinga-Extra-Updates` or fulfilling redirects is also skipped
+  in this case.
 
 ## Upgrading to Icinga Web 2.13
 

--- a/public/js/icinga/loader.js
+++ b/public/js/icinga/loader.js
@@ -875,7 +875,7 @@
                     }
                 })
             } else {
-                this.renderContentToContainer(
+                const rendered = this.renderContentToContainer(
                     req.responseText,
                     req.$target,
                     req.action,
@@ -884,6 +884,10 @@
                     req.autosubmit || autoSubmit,
                     req.scripted
                 );
+
+                if (! rendered) {
+                    req.discarded = true;
+                }
             }
 
             if (oldNotifications) {
@@ -907,14 +911,28 @@
                 req = reqOrError;
             }
 
+            req.$target.data('lastUpdate', (new Date()).getTime());
+            delete this.requests[req.$target.attr('id')];
+            this.icinga.ui.fadeNotificationsAway();
+
+            // Remove 'impact' class if there was such
+            if (req.$target.hasClass('impact')) {
+                req.$target.removeClass('impact');
+            } else {
+                const $impact = req.$target.find(':scope > .content.impact').first();
+                if ($impact.length) {
+                    $impact.removeClass('impact');
+                }
+            }
+
+            if (req.discarded) {
+                return;
+            }
+
             if (req.getResponseHeader('X-Icinga-Reload-Window') === 'yes') {
                 window.location.reload();
                 return;
             }
-
-            req.$target.data('lastUpdate', (new Date()).getTime());
-            delete this.requests[req.$target.attr('id')];
-            this.icinga.ui.fadeNotificationsAway();
 
             var extraUpdates = req.getResponseHeader('X-Icinga-Extra-Updates');
             if (!! extraUpdates && req.getResponseHeader('X-Icinga-Redirect-Http') !== 'yes') {
@@ -965,16 +983,6 @@
 
             if ((textStatus === 'abort' && typeof req.referrer !== 'undefined') || this.processRedirectHeader(req)) {
                 return;
-            }
-
-            // Remove 'impact' class if there was such
-            if (req.$target.hasClass('impact')) {
-                req.$target.removeClass('impact');
-            } else {
-                const $impact = req.$target.find(':scope > .content.impact').first();
-                if ($impact.length) {
-                    $impact.removeClass('impact');
-                }
             }
 
             if (! req.autorefresh && ! req.autosubmit) {
@@ -1276,8 +1284,6 @@
                 }
             }
 
-            $container.trigger('beforerender', [content, action, autorefresh, scripted, autoSubmit]);
-
             let discard = false;
             for (const hook of _this.icinga.renderHooks) {
                 const changed = hook.renderHook(content, $container, action, autorefresh, autoSubmit);
@@ -1294,6 +1300,8 @@
             });
 
             if (! discard) {
+                $container.trigger('beforerender', [content, action, autorefresh, scripted, autoSubmit]);
+
                 if ($container.closest('.dashboard').length) {
                     var title = $('h1', $container).first().detach();
                     $container.html(title).append(content);
@@ -1359,6 +1367,8 @@
 
             // Re-enable all click events (disabled as of performance reasons)
             // $('*').off('click');
+
+            return ! discard;
         },
 
         /**


### PR DESCRIPTION
A listener for `rendered` should not need to check if the content really changed. Though, if such a listener is not triggered anymore, `beforerender` listeners also must not be triggered, as they might assume that the content is really being updated and their accompanied `rendered` listener is triggered. (e.g. input-enrichment.js)

This might be breaking change and any `Behavior.renderHook` implementation needs to be checked against it. Potentially also in third party modules. As if such an implementation updates the container on its own, `beforerender` listeners only have access to the updated container after this change, while they had access to the original beforehand.

`rendered` listeners should not be that much affected, as for them the change results in the same behavior as if no update has ever been scheduled for the container.

fixes #5056