### PR TITLE
Make `host` optional for `oci` database resources

### DIFF
--- a/application/forms/Config/Resource/DbResourceForm.php
+++ b/application/forms/Config/Resource/DbResourceForm.php
@@ -58,7 +58,7 @@ class DbResourceForm extends Form
             $offerMysql = true;
         }
 
-        if ($dbChoice === 'oracle') {
+        if ($dbChoice === 'oracle' || $dbChoice === 'oci') {
             $hostIsRequired = false;
         } else {
             $hostIsRequired = true;

--- a/library/Icinga/Application/Platform.php
+++ b/library/Icinga/Application/Platform.php
@@ -406,7 +406,7 @@ class Platform
      */
     public static function hasOracleSupport()
     {
-        return static::extensionLoaded('pdo_oci') && static::classExists('Zend_Db_Adapter_Pdo_Mysql');
+        return static::extensionLoaded('pdo_oci') && static::classExists('Zend_Db_Adapter_Pdo_Oci');
     }
 
     /**


### PR DESCRIPTION
`oci` uses Zend's `Oracle` adapter, which does not use this setting at all.

fixes #5062