### PR TITLE
loader.js: Fix extra updates values inconsistency

### DIFF
--- a/public/js/icinga/loader.js
+++ b/public/js/icinga/loader.js
@@ -973,7 +973,7 @@
                     var $target;
                     var url;
                     if (parts.length === 2) {
-                        $target = $('#' + parts[0]);
+                        $target = $(parts[0].startsWith('#') ? parts[0] : '#' + parts[0]);
                         if (! $target.length) {
                             _this.icinga.logger.warn('Invalid target ID. Cannot load extra URL', el);
                             return;


### PR DESCRIPTION
When sending extra updates using the `X-Icinga-Extra-Updates` header, the values are processed differently given a single and multiple `key=>value` containers. When sending a single additional update, the container ID is expected to be specified like `#col1` or `.container`, but for `container=>url` pairs, the container ID is required to be provided without `#`: `['col2' => '__CLOSE__']`.
<img width="913" alt="Bildschirmfoto 2023-07-24 um 17 13 05" src="https://github.com/Icinga/icingaweb2/assets/57616252/242dd842-61b5-4fce-a129-3f102b653311">

With this PR both variants are supported.
