### PR TITLE
load dashboard based on rolename(s)

### DIFF
--- a/library/Icinga/Legacy/DashboardConfig.php
+++ b/library/Icinga/Legacy/DashboardConfig.php
@@ -56,23 +56,54 @@ class DashboardConfig extends Config
      *
      * @return  string[]
      */
-    public static function listConfigFilesForUser(User $user)
-    {
-        $files = array();
-        $dashboards = static::resolvePath('dashboards');
-        if ($handle = @opendir($dashboards)) {
-            while (false !== ($entry = readdir($handle))) {
-                if ($entry[0] === '.' || ! is_dir($dashboards . '/' . $entry)) {
-                    continue;
-                }
-                if (strtolower($entry) === strtolower($user->getUsername())) {
-                    $files[] = $dashboards . '/' . $entry . '/dashboard.ini';
-                }
+     public static function listConfigFilesForUser(User $user)
+     {
+         $files = array();
+         $dashboards = static::resolvePath('dashboards');
+         if ($handle = @opendir($dashboards)) {
+             while (false !== ($entry = readdir($handle))) {
+                 if ($entry[0] === '.' || ! is_dir($dashboards . '/' . $entry)) {
+                     continue;
+                 }
+                 if (strtolower($entry) === strtolower($user->getUsername())) {
+                     $files[] = $dashboards . '/' . $entry . '/dashboard.ini';
+                 }
+             }
+             closedir($handle);
+         }
+         if (empty($files)) {
+            $roles = $user->getRoles();
+            if (! empty($roles)) {
+               foreach($roles as $role) {
+                 if ($handle = @opendir($dashboards)) {
+                     while (false !== ($entry = readdir($handle))) {
+                         if ($entry[0] === '.' || ! is_dir($dashboards . '/' . $entry)) {
+                             continue;
+                         }
+                         if (strtolower($entry) === strtolower($role->getName())) {
+                             $files[] = $dashboards . '/' . $entry . '/dashboard.ini';
+                         }
+                     }
+                     closedir($handle);
+                 }
+               }
             }
-            closedir($handle);
-        }
-        return $files;
-    }
+         }
+         if (empty($files)) {
+           if ($handle = @opendir($dashboards)) {
+               while (false !== ($entry = readdir($handle))) {
+                   if ($entry[0] === '.' || ! is_dir($dashboards . '/' . $entry)) {
+                       continue;
+                   }
+                   if (strtolower($entry) === 'default') {
+                       $files[] = $dashboards . '/default/dashboard.ini';
+                   }
+               }
+               closedir($handle);
+           }
+         }
+         return $files;
+     }
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
We link the icingaweb (icingadb) to a Microsoft AD and there will be more than 500 possible users. In order not to have to create a dashboard for every user, I propose these modifications.

If the user does not have his own dashboard, and the user is linked to a role(s) that has a dashboard folder based on the role name, he will load it.

If there is no user or role dashboard and a default folder with a dashboard exists, it will use it.