### PR TITLE
Release GHA: create only one Docker image at the same time

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,7 +10,19 @@ on:
   workflow_dispatch:
 
 jobs:
+  docker-release:
+    if: github.event_name == 'release'
+    concurrency: docker-release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Docker image
+        uses: Icinga/docker-icingaweb2@master
+        with:
+          dockerhub-token: '${{ secrets.DOCKER_HUB_PERSONAL_TOKEN }}'
+
   docker:
+    if: github.event_name != 'release'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Just like in all other repos making Docker images.

The following tasks finish our ARM support and depend on each other:

* [ ] Push only one Docker image at the same time (this PR)
* [ ] GHA repo: auto-create not just X.Y.Z tags, but also X.Y, X and latest
* [ ] GHA repo: build multi-platform images

Deriving X.Y from X.Y.Z is easy. Nobody releases a vX.Y.Z and a vX.Y.{Z+1} at the same time. But a vX.Y.Z and a vX.{Y+1}.0 is likely. Both check Docker Hub, both get green light and both push :latest. Who wins?