### PR TITLE
Reposition "X row(s) selected" message for downtimes and comments

### DIFF
--- a/modules/monitoring/application/views/scripts/list/comments.phtml
+++ b/modules/monitoring/application/views/scripts/list/comments.phtml
@@ -59,3 +59,8 @@
     </div>
 <?php endif ?>
 </div>
+<?php if (! $this->compact): ?>
+    <div class="monitoring-statusbar dont-print">
+        <?= $this->render('list/components/selectioninfo.phtml') ?>
+    </div>
+<?php endif ?>

--- a/modules/monitoring/application/views/scripts/list/downtimes.phtml
+++ b/modules/monitoring/application/views/scripts/list/downtimes.phtml
@@ -62,3 +62,8 @@ if (! $this->compact): ?>
     </div>
 <?php endif ?>
 </div>
+<?php if (! $this->compact): ?>
+    <div class="monitoring-statusbar dont-print">
+        <?= $this->render('list/components/selectioninfo.phtml') ?>
+    </div>
+<?php endif ?>


### PR DESCRIPTION
Like hosts or services this message should be displayed like a footer.

fix #5085 