### PR TITLE
Remove redundant gravatar in contact detail

### DIFF
--- a/application/controllers/StaticController.php
+++ b/application/controllers/StaticController.php
@@ -28,42 +28,6 @@ class StaticController extends Controller
         $this->_helper->layout()->disableLayout();
     }
 
-    public function gravatarAction()
-    {
-        $response = $this->getResponse();
-        $response->setHeader('Cache-Control', 'public, max-age=1814400, stale-while-revalidate=604800', true);
-        $response->setHeader('Content-Type', 'image/png', true);
-
-        $noCache = $this->getRequest()->getHeader('Cache-Control') === 'no-cache'
-            || $this->getRequest()->getHeader('Pragma') === 'no-cache';
-
-        $cache = FileCache::instance();
-        $filename = md5(strtolower(trim($this->getParam('email'))));
-        $cacheFile = 'gravatar-' . $filename;
-
-        if (! $noCache && $cache->has($cacheFile, time() - 1814400)) {
-            if ($cache->etagMatchesCachedFile($cacheFile)) {
-                $response->setHttpResponseCode(304);
-                return;
-            }
-
-            $response->setHeader('Content-Type', 'image/jpg', true);
-            $response->setHeader('ETag', sprintf('"%s"', $cache->etagForCachedFile($cacheFile)));
-            $cache->send($cacheFile);
-            return;
-        }
-
-        $img = @file_get_contents('http://www.gravatar.com/avatar/' . $filename . '?s=120&d=mm');
-        if ($img === false) {
-            $this->httpNotFound('Unable to connect to gravatar.com');
-        }
-
-        $cache->store($cacheFile, $img);
-        $response->setHeader('ETag', sprintf('"%s"', $cache->etagForCachedFile($cacheFile)));
-
-        echo $img;
-    }
-
     /**
      * Return an image from a module's public folder
      */

--- a/modules/monitoring/application/views/scripts/show/contact.phtml
+++ b/modules/monitoring/application/views/scripts/show/contact.phtml
@@ -4,9 +4,6 @@
   <?= $this->tabs; ?>
  <?php endif ?>
   <h1><?= $this->translate('Contact details') ?></h1>
-  <div class="circular" style="background-image: url('<?=
-      $this->href('static/gravatar', array('email' => $contact->contact_email))
-  ?>';width:120px;height:120px;)"></div>
 
 <?php if (! $contact): ?>
   <?= $this->translate('No such contact') ?>: <?= $contactName ?>

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1031,11 +1031,6 @@ parameters:
 			path: application/controllers/StaticController.php
 
 		-
-			message: "#^Method Icinga\\\\Controllers\\\\StaticController\\:\\:gravatarAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: application/controllers/StaticController.php
-
-		-
 			message: "#^Method Icinga\\\\Controllers\\\\StaticController\\:\\:imgAction\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: application/controllers/StaticController.php
@@ -1052,16 +1047,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$name of method Icinga\\\\Application\\\\Modules\\\\Manager\\:\\:getModule\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: application/controllers/StaticController.php
-
-		-
-			message: "#^Parameter \\#1 \\$string of function trim expects string, mixed given\\.$#"
-			count: 1
-			path: application/controllers/StaticController.php
-
-		-
-			message: "#^Parameter \\#2 \\$content of method Icinga\\\\Web\\\\FileCache\\:\\:store\\(\\) expects string, string\\|false given\\.$#"
 			count: 1
 			path: application/controllers/StaticController.php
 


### PR DESCRIPTION
The gravatar for contacts was never correctly rendered in the detailed page. Hence it will be completely removed.

ref #5089 