### PR TITLE
css: Hide details marker of collapsibles in Safari

### DIFF
--- a/public/css/icinga/main.less
+++ b/public/css/icinga/main.less
@@ -334,6 +334,13 @@ a:hover > .icon-cancel {
   }
 }
 
+details.collapsible > summary {
+  &::marker,
+  &::-webkit-details-marker {
+    display: none;
+  }
+}
+
 .collapsible[data-can-collapse]:not(.collapsed) + .collapsible-control button,
 .collapsible[data-can-collapse]:not(.collapsed) > .collapsible-control,
 details.collapsible[open] + .collapsible-control button,


### PR DESCRIPTION
In Chrome the marker was already invisible since normalize.css applies `display:block` to `summary`. Hence we should also disable the marker by default in Safari.

fixes https://github.com/Icinga/icingaweb2-module-businessprocess/issues/406