### PR TITLE
X509\Sni: Clear backend instances before performing actual DB queries

### DIFF
--- a/modules/monitoring/library/Monitoring/ProvidedHook/X509/Sni.php
+++ b/modules/monitoring/library/Monitoring/ProvidedHook/X509/Sni.php
@@ -11,6 +11,8 @@ class Sni extends SniHook
 {
     public function getHosts(Filter $filter = null)
     {
+        MonitoringBackend::clearInstances();
+
         $hosts = MonitoringBackend::instance()
             ->select()
             ->from('hoststatus', [


### PR DESCRIPTION
To avoid such crashes:
```php
PHP Fatal error:  Uncaught PDOException: SQLSTATE[HY000]: General error: 2006 MySQL server has gone away in /usr/share/icinga-php/vendor/vendor/shardj/zf1-future/library/Zend/Db/Statement/Pdo.php:228
Stack trace:
#0 /usr/share/icinga-php/vendor/vendor/shardj/zf1-future/library/Zend/Db/Statement/Pdo.php(228): PDOStatement->execute(Array)
#1 /usr/share/icinga-php/vendor/vendor/shardj/zf1-future/library/Zend/Db/Statement.php(303): Zend_Db_Statement_Pdo->_execute(Array)
#2 /usr/share/icinga-php/vendor/vendor/shardj/zf1-future/library/Zend/Db/Adapter/Abstract.php(480): Zend_Db_Statement->execute(Array)
#3 /usr/share/icinga-php/vendor/vendor/shardj/zf1-future/library/Zend/Db/Adapter/Pdo/Abstract.php(265): Zend_Db_Adapter_Abstract->query('SELECT ho.name1...', Array)
#4 /usr/share/icinga-php/vendor/vendor/shardj/zf1-future/library/Zend/Db/Select.php(724): Zend_Db_Adapter_Pdo_Abstract->query(Object(Zend_Db_Select))
#5 /icingaweb2/library/Icinga/Data/Db/DbConnection.php(102): Zend_Db_Select->query()
#6 /icingaweb2/library/Icinga/Data/SimpleQuery.php(168): Icinga\Data\Db\DbConnection->query(Object(Icinga\Module\Monitoring\Backend\Ido\Query\HoststatusQuery))
#7 /icingaweb2/modules/monitoring/library/Monitoring/ProvidedHook/X509/Sni.php(27): Icinga\Data\SimpleQuery->rewind()
#8 /usr/share/icingaweb2-modules/x509/library/X509/Hook/SniHook.php(32): Icinga\Module\Monitoring\ProvidedHook\X509\Sni->getHosts()
#9 /usr/share/icingaweb2-modules/x509/application/clicommands/JobsCommand.php(145): Icinga\Module\X509\Hook\SniHook::getAll()
#10 /usr/share/icingaweb2-modules/x509/application/clicommands/JobsCommand.php(84): Icinga\Module\X509\Clicommands\JobsCommand->fetchSchedules('', '')
#11 /usr/share/icinga-php/vendor/vendor/react/event-loop/src/ExtEvLoop.php(144): Icinga\Module\X509\Clicommands\JobsCommand->Icinga\Module\X509\Clicommands\{closure}(Object(React\EventLoop\Timer\Timer))
#12 [internal function]: React\EventLoop\ExtEvLoop->React\EventLoop\{closure}()
#13 /usr/share/icinga-php/vendor/vendor/react/event-loop/src/ExtEvLoop.php(208): EvLoop->run(2)
#14 /usr/share/icinga-php/vendor/vendor/react/event-loop/src/Loop.php(55): React\EventLoop\ExtEvLoop->run()
#15 [internal function]: React\EventLoop\Loop::React\EventLoop\{closure}()
#16 {main}
```