### PR TITLE
DbMigrationHook: Pad matching groups to the desired length before using them

### DIFF
--- a/library/Icinga/Application/Hook/DbMigrationHook.php
+++ b/library/Icinga/Application/Hook/DbMigrationHook.php
@@ -305,7 +305,8 @@ abstract class DbMigrationHook implements Countable
         /** @var SplFileInfo $file */
         foreach (new DirectoryIterator($path . DIRECTORY_SEPARATOR . $upgradeDir) as $file) {
             if (preg_match('/^(v)?([^_]+)(?:_(\w+))?\.sql$/', $file->getFilename(), $m, PREG_UNMATCHED_AS_NULL)) {
-                [$_, $_, $migrateVersion, $description] = $m;
+                [$_, $_, $migrateVersion, $description] = array_pad($m, 4, null);
+                /** @var string $migrateVersion */
                 if ($migrateVersion && version_compare($migrateVersion, $version, '>')) {
                     $migration = new DbMigrationStep($migrateVersion, $file->getRealPath());
                     if (isset($descriptions[$migrateVersion])) {


### PR DESCRIPTION
Testing the migration hook with PHP 7.2, 7.3 renders the following stack trace.
```php
Undefined offset: 3
#0 /icingaweb2/library/Icinga/Application/Hook/DbMigrationHook.php(308): Icinga\Application\ApplicationBootstrap->Icinga\Application\{closure}(Integer, String, String, Integer, Array)
#1 /icingaweb2/library/Icinga/Application/Hook/DbMigrationHook.php(172): Icinga\Application\Hook\DbMigrationHook->load()
...
```