### PR TITLE
Always reload window when redirecting to the login

### DIFF
--- a/library/Icinga/Web/Controller/ActionController.php
+++ b/library/Icinga/Web/Controller/ActionController.php
@@ -399,7 +399,8 @@ class ActionController extends Zend_Controller_Action
             }
         }
 
-        $this->rerenderLayout()->redirectNow($login);
+        $this->getResponse()->setReloadWindow(true);
+        $this->redirectNow($login);
     }
 
     protected function rerenderLayout()


### PR DESCRIPTION
This ensures that, if CSP is enabled, the newly created token on the login is accepted by the browser. A small, but IMHO desired, side effect is that the login now always appears in the default theme.

fixes #5126