### PR TITLE
LdapConnection#prepareNewConnection(): don't pass the port to ldap_connect()

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
         os: ['ubuntu-latest']
 
     steps:
@@ -62,7 +62,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
         os: ['ubuntu-latest']
         include:
           - php: '7.2'

--- a/library/Icinga/Protocol/Ldap/LdapConnection.php
+++ b/library/Icinga/Protocol/Ldap/LdapConnection.php
@@ -1198,7 +1198,7 @@ class LdapConnection implements Selectable, Inspectable
 
         $hostname = $this->normalizeHostname($this->hostname);
 
-        $ds = ldap_connect($hostname, $this->port);
+        $ds = ldap_connect($hostname);
 
         // Set a proper timeout for each connection
         ldap_set_option($ds, LDAP_OPT_NETWORK_TIMEOUT, $this->timeout);


### PR DESCRIPTION
This is deprecated since PHP 8.3.
But this is unnecessary anyway as the passed hostname is computed by #normalizeHostname() which takes the port into account.

fixes #5136

Now, in contrast to that issue, adding an LDAP resource doesn't print a PHP deprecation notice.