### PR TITLE
Form submission: Identify pressed submit button associated through form attribute

### DIFF
--- a/public/js/icinga/behavior/modal.js
+++ b/public/js/icinga/behavior/modal.js
@@ -92,31 +92,39 @@
      * @returns {boolean}
      */
     Modal.prototype.onFormSubmit = function(event) {
-        var _this = event.data.self;
-        var $form = $(event.currentTarget).closest('form');
-        var $modal = $form.closest('#modal');
+        const _this = event.data.self;
+        const $form = $(event.currentTarget).closest('form');
+        const $modal = $form.closest('#modal');
 
-        var $button;
-        var $rememberedSubmittButton = $form.data('submitButton');
-        if (typeof $rememberedSubmittButton != 'undefined') {
-            if ($form.has($rememberedSubmittButton)) {
-                $button = $rememberedSubmittButton;
+        let $button;
+        if (typeof event.originalEvent !== 'undefined'
+            && typeof event.originalEvent.submitter !== 'undefined'
+            && event.originalEvent.submitter !== null) {
+            $button = $(event.originalEvent.submitter);
+        }
+
+        // Safari fallback only
+        const $rememberedSubmitButton = $form.data('submitButton');
+        if (typeof $rememberedSubmitButton !== 'undefined') {
+            if (typeof $button === 'undefined' && $form.has($rememberedSubmitButton)) {
+                $button = $rememberedSubmitButton;
             }
+
             $form.removeData('submitButton');
         }
 
         let $autoSubmittedBy;
-        if (! $autoSubmittedBy && event.detail && event.detail.submittedBy) {
+        if (typeof event.detail !== 'undefined' && "submittedBy" in event.detail) {
             $autoSubmittedBy = $(event.detail.submittedBy);
         }
 
         // Prevent our other JS from running
         $modal[0].dataset.noIcingaAjax = '';
 
-        var req = _this.icinga.loader.submitForm($form, $autoSubmittedBy, $button);
+        const req = _this.icinga.loader.submitForm($form, $autoSubmittedBy, $button);
         req.addToHistory = false;
         req.done(function (data, textStatus, req) {
-            var title = req.getResponseHeader('X-Icinga-Title');
+            const title = req.getResponseHeader('X-Icinga-Title');
             if (!! title) {
                 _this.setTitle($modal, decodeURIComponent(title).replace(/\s::\s.*/, ''));
             }

--- a/public/js/icinga/events.js
+++ b/public/js/icinga/events.js
@@ -200,26 +200,34 @@
          *
          */
         submitForm: function (event, $autoSubmittedBy) {
-            var _this   = event.data.self;
+            const _this   = event.data.self;
 
             // .closest is not required unless subelements to trigger this
-            var $form = $(event.currentTarget).closest('form');
+            const $form = $(event.currentTarget).closest('form');
 
             if ($form.closest('[data-no-icinga-ajax]').length > 0) {
                 return true;
             }
-            
-            var $button;
-            var $rememberedSubmittButton = $form.data('submitButton');
-            if (typeof $rememberedSubmittButton != 'undefined') {
-                if ($form.has($rememberedSubmittButton)) {
-                    $button = $rememberedSubmittButton;
+
+            let $button;
+            if (typeof event.originalEvent !== 'undefined'
+                && typeof event.originalEvent.submitter !== 'undefined'
+                && event.originalEvent.submitter !== null) {
+                $button = $(event.originalEvent.submitter);
+            }
+
+            // Safari fallback only
+            const $rememberedSubmitButton = $form.data('submitButton');
+            if (typeof $rememberedSubmitButton !== 'undefined') {
+                if (typeof $button === 'undefined' && $form.has($rememberedSubmitButton)) {
+                    $button = $rememberedSubmitButton;
                 }
+
                 $form.removeData('submitButton');
             }
 
             if (typeof $button === 'undefined') {
-                var $el;
+                let $el;
 
                 if (typeof event.originalEvent !== 'undefined'
                     && typeof event.originalEvent.explicitOriginalTarget === 'object') { // Firefox
@@ -239,7 +247,7 @@
                 }
             }
 
-            if (! $autoSubmittedBy && event.detail && event.detail.submittedBy) {
+            if (! $autoSubmittedBy && typeof event.detail !== 'undefined' && "submittedBy" in event.detail) {
                 $autoSubmittedBy = $(event.detail.submittedBy);
             }
 


### PR DESCRIPTION
### Issue

When there are multiple submit buttons outside the form which are associated with it as shown below, the form fails to correctly identify the pressed submit button.


```
<html>
  <form id="test-form">
    <input type="text" name="name"/>
    <input value="Save" name="save" type="submit">
  </form>
  
  <div>
    <button type="submit" form="test-form" name="button-1">Button 1</button>
    <button type="submit" form="test-form" name="button-2">Button 2</button>
  </div>
</html>
```
### Solution

In case the button is undefined upon submit event, get the pressed submit button using the [submitter](https://developer.mozilla.org/en-US/docs/Web/API/SubmitEvent/submitter) property found on the `SubmitEvent` interface. 