### PR TITLE
Displaying items in a menu with many items

### DIFF
--- a/public/css/icinga/layout.less
+++ b/public/css/icinga/layout.less
@@ -125,7 +125,6 @@
         // Remove gutter for tabs
         margin-left: -1 * @gutter;
         margin-right: -1 * @gutter;
-        height: 2.5em;
       }
 
       .tabs:first-child:not(:last-child) {


### PR DESCRIPTION
When creating many elements in the menu, they do not appear. After verifying the code, it was detected that it was caused because the menu has a fixed height. By eliminating this style, all the menu elements can now be displayed.

![Selection_59360](https://github.com/Icinga/icingaweb2/assets/3307586/241726d5-2009-4bc5-a453-6443e5365b1f)
