### PR TITLE
ApplicationConfigForm: fix typo

### DIFF
--- a/application/forms/Config/General/ApplicationConfigForm.php
+++ b/application/forms/Config/General/ApplicationConfigForm.php
@@ -61,7 +61,7 @@ class ApplicationConfigForm extends Form
             [
                 'label'         => $this->translate('Enable strict content security policy'),
                 'description'   => $this->translate(
-                    'Set whether to to use strict content security policy (CSP).'
+                    'Set whether to use strict content security policy (CSP).'
                     . ' This setting helps to protect from cross-site scripting (XSS).'
                 )
             ]


### PR DESCRIPTION
Fix a consecutive "to" in a form element description.