### PR TITLE
MonitoredObject notes: don't pass null to trim()

### DIFF
--- a/modules/monitoring/application/views/scripts/show/components/notes.phtml
+++ b/modules/monitoring/application/views/scripts/show/components/notes.phtml
@@ -5,7 +5,7 @@ use Icinga\Web\Navigation\Navigation;
 /** @var \Icinga\Module\Monitoring\Object\MonitoredObject $object */
 
 $navigation = new Navigation();
-$notes = trim($object->notes);
+$notes = trim($object->notes ?? '');
 
 $links = $object->getNotesUrls();
 if (! empty($links)) {


### PR DESCRIPTION
as this is deprecated and generates warnings in the detail view if the notes are null. In this case fall back to "" which is already handled by the following code.

fixes #5221