### PR TITLE
Don't rpm --import https://packages.icinga.com/icinga.key

### DIFF
--- a/doc/02-Installation.md
+++ b/doc/02-Installation.md
@@ -90,7 +90,6 @@ apt-get update
 ### CentOS Repository <a id="centos-repository"></a>
 
 ```bash
-rpm --import https://packages.icinga.com/icinga.key
 wget https://packages.icinga.com/centos/ICINGA-release.repo -O /etc/yum.repos.d/ICINGA-release.repo
 ```
 
@@ -123,7 +122,6 @@ yum install centos-release-scl
     Don't forget to fill in the username and password section with your credentials in the local .repo file.
 
 ```bash
-rpm --import https://packages.icinga.com/icinga.key
 wget https://packages.icinga.com/subscription/rhel/ICINGA-release.repo -O /etc/yum.repos.d/ICINGA-release.repo
 ```
 
@@ -165,8 +163,6 @@ yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.r
     Don't forget to fill in the username and password section with your credentials in the local .repo file.
 
 ```bash
-rpm --import https://packages.icinga.com/icinga.key
-
 zypper ar https://packages.icinga.com/subscription/sles/ICINGA-release.repo
 zypper ref
 ```
@@ -194,7 +190,6 @@ SUSEConnect -p PackageHub/$VERSION_ID/x86_64
     Don't forget to fill in the username and password section with your credentials in the local .repo file.
 
 ```bash
-rpm --import https://packages.icinga.com/icinga.key
 wget https://packages.icinga.com/subscription/amazon/ICINGA-release.repo -O /etc/yum.repos.d/ICINGA-release.repo
 ```
 


### PR DESCRIPTION
for the same security reasons we don't use apt-key add anymore for: https://blog.cloudflare.com/dont-use-apt-key

Our repos already reference https://packages.icinga.com/icinga.key and both RPM distro families properly handle that.

* CC https://github.com/Icinga/packages.icinga.com/pull/42