### PR TITLE
Css: Do not allow `:hover` to affect the `.active` list elements

### DIFF
--- a/modules/monitoring/public/css/tables.less
+++ b/modules/monitoring/public/css/tables.less
@@ -248,13 +248,13 @@
     -moz-transform: none; /* Firefox collapses border spacing due to the above */
   }
 
-  tr[href].active {
-    background-color: @tr-active-color;
-  }
-
   tr[href]:hover {
     background-color: @tr-hover-color;
     cursor: pointer;
+  }
+
+  tr[href].active {
+    background-color: @tr-active-color;
   }
 
   tr[href].state-outdated:not(:hover):not(.active) td:not(.state-col) {

--- a/public/css/icinga/main.less
+++ b/public/css/icinga/main.less
@@ -217,14 +217,14 @@ a:hover > .icon-cancel {
     }
   }
 
-  tr[href].active {
-    background-color: @tr-active-color;
-    border-left-color: @icinga-blue;
-  }
-
   tr[href]:hover {
     background-color: @tr-hover-color;
     cursor: pointer;
+  }
+
+  tr[href].active {
+    background-color: @tr-active-color;
+    border-left-color: @icinga-blue;
   }
 }
 


### PR DESCRIPTION
The `.active` state should not be overwritten by `:hover`.