### PR TITLE
Fix PluginOutputHookImplementation gets called twice #5271

### DIFF
--- a/doc/80-Upgrading.md
+++ b/doc/80-Upgrading.md
@@ -2,11 +2,13 @@
 
 Specific version upgrades are described below. Please note that upgrades are incremental. An upgrade from
 v2.6 to v2.8 requires to follow the instructions for v2.7 too.
+
 ## Upgrading to Icinga Web 2.12.2
 
 **Framework changes affecting third-party code**
 
 * `Icinga\Module\Monitoring\Hook\PluginOutputHook` When rendering the Icinga check output, the output and long_output fields are now concatenated with a newline (\n) before any post-processing occurs, such as through a PluginOutputHook
+
 ## Upgrading to Icinga Web 2.12.0
 
 **Database Schema**

--- a/doc/80-Upgrading.md
+++ b/doc/80-Upgrading.md
@@ -2,7 +2,11 @@
 
 Specific version upgrades are described below. Please note that upgrades are incremental. An upgrade from
 v2.6 to v2.8 requires to follow the instructions for v2.7 too.
+## Upgrading to Icinga Web 2.12.2
 
+**Framework changes affecting third-party code**
+
+* `Icinga\Module\Monitoring\Hook\PluginOutputHook` When rendering the Icinga check output, the output and long_output fields are now concatenated with a newline (\n) before any post-processing occurs, such as through a PluginOutputHook
 ## Upgrading to Icinga Web 2.12.0
 
 **Database Schema**

--- a/modules/monitoring/application/views/scripts/show/components/output.phtml
+++ b/modules/monitoring/application/views/scripts/show/components/output.phtml
@@ -1,5 +1,4 @@
 <h2><?= $this->translate('Plugin Output') ?></h2>
 <div id="check-output-<?= $this->escape(str_replace(' ', '-', $object->check_command)) ?>" class="collapsible" data-visible-height="100">
-    <?= $this->pluginOutput($object->output, false, $object->check_command) ?>
-    <?= $this->pluginOutput($object->long_output, false, $object->check_command) ?>
+    <?= $this->pluginOutput($object->output. "\n" . $object->long_output, false, $object->check_command) ?>
 </div>

--- a/modules/monitoring/application/views/scripts/show/components/output.phtml
+++ b/modules/monitoring/application/views/scripts/show/components/output.phtml
@@ -1,4 +1,4 @@
 <h2><?= $this->translate('Plugin Output') ?></h2>
 <div id="check-output-<?= $this->escape(str_replace(' ', '-', $object->check_command)) ?>" class="collapsible" data-visible-height="100">
-    <?= $this->pluginOutput($object->output. "\n" . $object->long_output, false, $object->check_command) ?>
+    <?= $this->pluginOutput($object->output . "\n" . $object->long_output, false, $object->check_command) ?>
 </div>


### PR DESCRIPTION
Concatenate Output.

This might break workarounds used implemented in a PluginOutputHookImplementation but I haven't found any out in the wild.

This removes the annoying space between the first line and the other lines in the monitoring module plugin output

Alternatives :
Introduce a monitoring setting that disables this fix for a fast switch back in case this breaks something

Best Regards
Nicolas