### PR TITLE
fix(csv): fix #5279 always force subject to be a string in str_replace

### DIFF
--- a/library/Icinga/File/Csv.php
+++ b/library/Icinga/File/Csv.php
@@ -37,7 +37,7 @@ class Csv
             }
             $out = array();
             foreach ($row as & $val) {
-                $out[] = '"' . str_replace('"', '""', $val) . '"';
+                $out[] = '"' . ($val ? str_replace('"', '""', $val) : '') . '"';
             }
             $csv .= implode(',', $out) . "\r\n";
         }


### PR DESCRIPTION
When performing a str_replace, subject should always be a string. If passing a non-existent column or empty column, subject may be null

This ensure str_replace is called when subject is actually a string (not NULL)