### PR TITLE
form.js: Ignore buttons again when being asked to render content

### DIFF
--- a/public/js/icinga/behavior/form.js
+++ b/public/js/icinga/behavior/form.js
@@ -83,7 +83,9 @@
         if ($container[0].contains(origFocus)
             && origFocus.form
             && ! origFocus.matches(
-                'input[type=submit], input[type=reset], input[type=button], .autofocus, .autosubmit:not(:hover)'
+                'input[type=submit], input[type=reset], input[type=button]'
+                + ', button[type=submit], button[type=reset], button[type=button]'
+                + ', .autofocus, .autosubmit:not(:hover)'
             )
         ) {
             this.icinga.logger.debug('Not changing content for ' + containerId + ' form has focus');


### PR DESCRIPTION
This slipped through, as I thought the CSS selector `:input`, which was used previously, is invalid. Although, it's a jQuery specific selector -.-, which was also previously used.

fixes #5293