### PR TITLE
tabs.less: Don't let icinga-loader element overlap the dropdown nav

### DIFF
--- a/public/css/icinga/tabs.less
+++ b/public/css/icinga/tabs.less
@@ -70,7 +70,7 @@
   border-top: none;
   margin-left: -1px;
   min-width: 14em;
-  z-index: 10;
+  z-index: 1001;
 }
 
 .tabs > .dropdown-nav-item > ul > li:hover > a {


### PR DESCRIPTION
resolves https://github.com/Icinga/icingaweb2/issues/5303