### PR TITLE
Fix unescaped error messages

### DIFF
--- a/application/views/scripts/config/module-configuration-error.phtml
+++ b/application/views/scripts/config/module-configuration-error.phtml
@@ -6,7 +6,7 @@
 <?= $this->tabs->render($this); ?>
 <br/>
 <div>
-  <h1>Could not <?= $action; ?> module "<?= $moduleName; ?>"</h1>
+  <h1>Could not <?= $action; ?> module "<?= $this->escape($moduleName); ?>"</h1>
   <p>
     While operation the following error occurred:
     <br />

--- a/modules/monitoring/application/forms/Config/BackendConfigForm.php
+++ b/modules/monitoring/application/forms/Config/BackendConfigForm.php
@@ -227,7 +227,7 @@ class BackendConfigForm extends ConfigForm
                 'autosubmit'    => true
             )
         );
-        $resourceName = isset($formData['resource']) ? $formData['resource'] : $this->getValue('resource');
+        $resourceName = $this->getView()->escape($formData['resource'] ?? $this->getValue('resource'));
         $this->addElement(
             'note',
             'resource_note',


### PR DESCRIPTION
In both cases the input, which wasn't escaped before, comes from a form element that doesn't allow any user to change its content. An ordinary user would need to access the DOM in order to do that.

Both forms are protected by CSRF, so this mitigates any potential exploit as well.