### PR TITLE
Keep h1 titles on favorite dashboard

### DIFF
--- a/public/js/icinga/loader.js
+++ b/public/js/icinga/loader.js
@@ -1284,7 +1284,7 @@
             });
 
             if (! discard) {
-                if ($container.closest('.dashboard').length) {
+                if ($container.closest('.dashboard').length || $container.closest('.favorite-dashboard').length) {
                     var title = $('h1', $container).first().detach();
                     $container.html(title).append(content);
                 } else if (action === 'replace') {


### PR DESCRIPTION
Add JavaScript to keep h1 titles, when the content is rendered to the containers on the favorite dashboard of Icinga for Kubernetes.

Refs [Favorite feature of Icinga for Kubernetes](https://github.com/Icinga/icinga-kubernetes-web/pull/125)