### PR TITLE
Fix doc module markdown table rows in light mode

### DIFF
--- a/modules/doc/public/css/module.less
+++ b/modules/doc/public/css/module.less
@@ -1,17 +1,5 @@
 /*! Icinga Web 2 | (c) 2014 Icinga Development Team | GPLv2+ */
 
-// Mixins
-
-.gradient(@a: @gray-lighter; @b: @gray-lightest) {
-  background: @a;
-  background: -webkit-gradient(linear, left top, left bottom, from(@a), to(@b));
-  background: -webkit-linear-gradient(top, @a, @b);
-  background: -moz-linear-gradient(top, @a, @b);
-  background: -ms-linear-gradient(top, @a, @b);
-  background: -o-linear-gradient(top, @a, @b);
-  background: linear-gradient(to bottom, @a, @b);
-}
-
 // General styles
 
 code {
@@ -84,7 +72,7 @@ table {
 }
 
 tbody > tr:nth-child(odd) {
-  .gradient()
+  background: @gray-light;
 }
 
 tbody > tr:nth-child(even) {


### PR DESCRIPTION
- Replaced the gradient mixin with a simple color for odd rows. This fixes and markdown table rows in light mode and - since there are very gradients in general - it makes the overall look more uniform.

Fixes https://github.com/Icinga/icingaweb2/issues/5320

![screenshot_2025-03-05-152405](https://github.com/user-attachments/assets/7450e166-9870-48e7-abf5-367046bf4f10)
![screenshot_2025-03-05-152410](https://github.com/user-attachments/assets/9a5714c4-b8fb-4da1-bc97-8233c4006c01)
