### PR TITLE
Fix/collapsed active menu item indicator

### DIFF
--- a/public/css/icinga/menu.less
+++ b/public/css/icinga/menu.less
@@ -123,6 +123,7 @@
     height: 1.25em;
     width: 1.25em;
     top: ~"calc(50% - (1.25em / 2))";
+    z-index: 10;
   }
 }
 
@@ -130,6 +131,7 @@
   // Collapse menu by default
   display: none;
   line-height: 1.833em; // 22px
+  z-index: 12;
 
   > a {
     color: @menu-2ndlvl-color;
@@ -267,10 +269,12 @@
     padding-bottom: @vertical-padding;
     width: 14em;
     position: fixed;
-    z-index: 1;
+    z-index: 11;
     margin-top: -1px; // Align content with the menu item, not its border
 
     &::after {
+      --caretSide: 1.25em;
+
       .transform(rotate(45deg));
 
       background-color: @body-bg-color;
@@ -278,12 +282,11 @@
       border-left: 1px solid @gray-light;
       content: "";
       display: block;
-      height: 1.1em;
-      width: 1.1em;
+      height: var(--caretSide);
+      width: var(--caretSide);
       position: absolute;
-      top: ~"calc((@{nav-item-height} / 2) - (1.1em / 2))";
-      left: -.6em;
-      z-index: -1;
+      top: ~"calc(@{nav-item-height} / 2 - var(--caretSide) / 2)";
+      left: ~"calc(-1 * var(--caretSide) / 2 - 1px)";
     }
 
     &.bottom-up {
@@ -291,7 +294,7 @@
       margin-top: 1px;
 
       &::after {
-        top: ~"calc(var(--caretY) - (@{nav-item-height} / 2) - (1.1em / 2))";
+        top: ~"calc(var(--caretY) - (@{nav-item-height} / 2) - (var(--caretSide) / 2))";
       }
     }
 


### PR DESCRIPTION
## Before

Caret looks disconnected from viewport.

![Screenshot 2025-03-11 at 11 38 40](https://github.com/user-attachments/assets/28147015-f258-48f5-8e98-bc915f6e1643)

collapsed flyout is misaligned
![Screenshot 2025-03-11 at 11 41 34](https://github.com/user-attachments/assets/6dced6e7-ef7b-442a-abd3-37480206dad7)

## After

drop shadow does not cover caret
![Screenshot 2025-03-11 at 11 28 14](https://github.com/user-attachments/assets/8817b3d7-fdae-48b4-b717-043c4777495d)

collapsed flyout is aligned properly
![Screenshot 2025-03-11 at 11 28 06](https://github.com/user-attachments/assets/0551cf66-3df7-417d-a0bf-3dee84778924)
