### PR TITLE
Disable deprecation warnings unless ICINGAWEB_ENVIRONMENT is set to "dev"

### DIFF
--- a/library/Icinga/Application/ApplicationBootstrap.php
+++ b/library/Icinga/Application/ApplicationBootstrap.php
@@ -568,12 +568,7 @@ abstract class ApplicationBootstrap
      */
     protected function setupErrorHandling()
     {
-        error_reporting(
-            getenv('ICINGAWEB_ENVIRONMENT') === 'dev'
-                ? E_ALL | E_STRICT
-                : (E_ALL | E_STRICT) & ~E_DEPRECATED & ~E_USER_DEPRECATED
-        );
-
+        error_reporting(getenv('ICINGAWEB_ENVIRONMENT') === 'dev' ? E_ALL : E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED);
         ini_set('display_startup_errors', 1);
         ini_set('display_errors', 1);
         set_error_handler(function ($errno, $errstr, $errfile, $errline) {
@@ -584,7 +579,6 @@ abstract class ApplicationBootstrap
             switch ($errno) {
                 case E_NOTICE:
                 case E_WARNING:
-                case E_STRICT:
                 case E_RECOVERABLE_ERROR:
                     throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
             }

--- a/library/Icinga/Application/ApplicationBootstrap.php
+++ b/library/Icinga/Application/ApplicationBootstrap.php
@@ -568,7 +568,12 @@ abstract class ApplicationBootstrap
      */
     protected function setupErrorHandling()
     {
-        error_reporting(E_ALL | E_STRICT);
+        error_reporting(
+            getenv('ICINGAWEB_ENVIRONMENT') === 'dev'
+                ? E_ALL | E_STRICT
+                : (E_ALL | E_STRICT) & ~E_DEPRECATED & ~E_USER_DEPRECATED
+        );
+
         ini_set('display_startup_errors', 1);
         ini_set('display_errors', 1);
         set_error_handler(function ($errno, $errstr, $errfile, $errline) {

--- a/library/Icinga/Application/webrouter.php
+++ b/library/Icinga/Application/webrouter.php
@@ -8,7 +8,7 @@ use Icinga\Web\Controller\StaticController;
 use Icinga\Web\JavaScript;
 use Icinga\Web\StyleSheet;
 
-error_reporting(E_ALL | E_STRICT);
+error_reporting((E_ALL | E_STRICT) & ~E_DEPRECATED & ~E_USER_DEPRECATED);
 
 if (isset($_SERVER['REQUEST_URI'])) {
     $ruri = $_SERVER['REQUEST_URI'];

--- a/library/Icinga/Application/webrouter.php
+++ b/library/Icinga/Application/webrouter.php
@@ -8,7 +8,7 @@ use Icinga\Web\Controller\StaticController;
 use Icinga\Web\JavaScript;
 use Icinga\Web\StyleSheet;
 
-error_reporting((E_ALL | E_STRICT) & ~E_DEPRECATED & ~E_USER_DEPRECATED);
+error_reporting(E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED);
 
 if (isset($_SERVER['REQUEST_URI'])) {
     $ruri = $_SERVER['REQUEST_URI'];

--- a/test/php/library/Icinga/File/Storage/LocalFileStorageTest.php
+++ b/test/php/library/Icinga/File/Storage/LocalFileStorageTest.php
@@ -21,7 +21,7 @@ class LocalFileStorageTest extends BaseTestCase
         parent::__construct($name, $data, $dataName);
 
         $this->oldErrorReportingLevel = error_reporting();
-        error_reporting(E_ALL | E_STRICT);
+        error_reporting(E_ALL);
 
         set_error_handler(function ($errno, $errstr, $errfile, $errline) {
             if (error_reporting() === 0) {
@@ -32,7 +32,6 @@ class LocalFileStorageTest extends BaseTestCase
             switch ($errno) {
                 case E_NOTICE:
                 case E_WARNING:
-                case E_STRICT:
                 case E_RECOVERABLE_ERROR:
                     throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
             }


### PR DESCRIPTION
in ApplicationBootstrap#setupErrorHandling(). In webrouter.php disable them unconditionally (until ApplicationBootstrap#setupErrorHandling()) not to duplicate the check. ApplicationBootstrap#setupErrorHandling()) is called pretty early, so we won't miss much.

fixes #5117

* In addition, this provides #5269 and mitigates #5152 in production where ICINGAWEB_ENVIRONMENT isn't set.