### PR TITLE
Icinga.Loader#onFailure(): on 401, reload the whole page

### DIFF
--- a/public/js/icinga/loader.js
+++ b/public/js/icinga/loader.js
@@ -1047,15 +1047,20 @@
                     errorThrown + ':',
                     $(req.responseText).text().replace(/\s+/g, ' ').slice(0, 100)
                 );
-                this.renderContentToContainer(
-                    req.responseText,
-                    req.$target,
-                    req.action,
-                    req.autorefresh,
-                    undefined,
-                    req.autosubmit,
-                    req.scripted
-                );
+
+                if (req.status === 401) {
+                    window.location.reload();
+                } else {
+                    this.renderContentToContainer(
+                        req.responseText,
+                        req.$target,
+                        req.action,
+                        req.autorefresh,
+                        undefined,
+                        req.autosubmit,
+                        req.scripted
+                    );
+                }
             } else {
                 if (errorThrown === 'abort') {
                     this.icinga.logger.debug(


### PR DESCRIPTION
instead of rendering 401 responses to all containers. Explicitly requested here:

fixes #5227

## Before

Everything's fine:

<img width="1024" alt="Bildschirmfoto 2025-04-25 um 14 18 12" src="https://github.com/user-attachments/assets/4e234041-fb49-4d84-ac8f-13d613667fbb" />

I add this:

```
RewriteEngine On
RewriteRule ^ - [R=401,L]
```

All containers panic:

![Bildschirmfoto 2025-04-25 um 14 18 34](https://github.com/user-attachments/assets/05ca6af7-67b8-4eef-8ef4-2f66fdb17707)

## After

Everything's fine:

<img width="1024" alt="Bildschirmfoto 2025-04-25 um 14 18 12" src="https://github.com/user-attachments/assets/4e234041-fb49-4d84-ac8f-13d613667fbb" />

I add this:

```
RewriteEngine On
RewriteRule ^ - [R=401,L]
```

Page reloads:

https://github.com/user-attachments/assets/db437fae-2598-4559-adc6-4daa4e788bd5