### PR TITLE
Support setting a default comment for acknowledgements

### DIFF
--- a/modules/monitoring/application/forms/Command/Object/AcknowledgeProblemCommandForm.php
+++ b/modules/monitoring/application/forms/Command/Object/AcknowledgeProblemCommandForm.php
@@ -57,7 +57,8 @@ class AcknowledgeProblemCommandForm extends ObjectsCommandForm
                         . ' the host or service that is having problems. Make sure you enter a brief description of'
                         . ' what you are doing.'
                     ),
-                    'attribs'       => array('class' => 'autofocus')
+                    'attribs'       => array('class' => 'autofocus'),
+                    'value'         => $config->get('settings', 'acknowledge_comment_text')
                 )
             ),
             array(

--- a/modules/monitoring/doc/03-Configuration.md
+++ b/modules/monitoring/doc/03-Configuration.md
@@ -21,6 +21,7 @@ by this module.
 
 Option                            | Description
 ----------------------------------|-----------------------------------------------
+acknowledge_comment_text          | **Optional.** Set default text for "Comment" in Acknowledgement dialog by default.
 acknowledge_expire                | **Optional.** Check "Use Expire Time" in Acknowledgement dialog by default. Defaults to **0 (false)**.
 acknowledge_expire_time           | **Optional.** Set default value for "Expire Time" in Acknowledgement dialog, its calculated as now + this setting. Format is a [PHP Dateinterval](http://www.php.net/manual/en/dateinterval.construct.php). Defaults to **1 hour (PT1H)**.
 acknowledge_notify                | **Optional.** Check "Send Notification" in Acknowledgement dialog by default. Defaults to **1 (true)**.


### PR DESCRIPTION
I propose to add a new option for setting a default comment for acknowledging problems (`acknowledge_comment_text`), similar to the existing `hostdowntime_comment_text` and `servicedowntime_comment_text` options.