### PR TITLE
menu.less: Apply same `bg-color` to the caret in the `.nav-item-header`

### DIFF
--- a/public/css/icinga/menu.less
+++ b/public/css/icinga/menu.less
@@ -534,25 +534,31 @@ html.no-js  #toggle-sidebar {
   margin-right: 0;
 }
 
-#layout.sidebar-collapsed #menu .nav-level-1 > .nav-item.hover .nav-level-2 > .nav-item-header {
-  background-color: @menu-bg-color;
-  color: @menu-color;
-  border-bottom: 1px solid @gray-light;
-  border-top-left-radius: .25em;
-  border-top-right-radius: .25em;
+#layout:not(.minimal-layout).sidebar-collapsed #menu .nav-level-1 > .nav-item.hover > .nav-level-2 {
+  &:not(.bottom-up)::after {
+    background-color: @menu-bg-color;
+  }
 
-  span {
-    padding-left: 1.375em;
-    padding-right: 0.545em;
-    height: @nav-item-height;
-    line-height: @nav-item-height;
-    display: block;
+  .nav-item-header {
+    background-color: @menu-bg-color;
+    color: @menu-color;
+    border-bottom: 1px solid @gray-light;
+    border-top-left-radius: .25em;
+    border-top-right-radius: .25em;
 
-    font-weight: @font-weight-bold;
-    .text-ellipsis();
+    span {
+      padding-left: 1.375em;
+      padding-right: 0.545em;
+      height: @nav-item-height;
+      line-height: @nav-item-height;
+      display: block;
 
-    > .badge {
-      display: none;
+      font-weight: @font-weight-bold;
+      .text-ellipsis();
+
+      > .badge {
+        display: none;
+      }
     }
   }
 }


### PR DESCRIPTION
## Before:
<img width="271" alt="Screenshot 2025-06-04 at 09 03 52" src="https://github.com/user-attachments/assets/ef08c67b-21c7-41b6-8d2a-def9aa70adf2" />


## After:
<img width="259" alt="Screenshot 2025-06-04 at 09 08 01" src="https://github.com/user-attachments/assets/707c4f64-fe23-4257-8408-a0c5379f31b5" />
