### PR TITLE
Don't let active `.nav-level-2` menu item overlap the config nav flyout

### DIFF
--- a/public/css/icinga/configmenu.less
+++ b/public/css/icinga/configmenu.less
@@ -234,7 +234,7 @@
   border: 1px solid @gray-lighter;
   background: @body-bg-color;
   box-shadow: 0 0 1em 0 rgba(0,0,0,.25);
-  z-index: 1;
+  z-index: 15;
   .rounded-corners();
 
   a {


### PR DESCRIPTION
fixes #5380 