### PR TITLE
Streamline authentication process

### DIFF
--- a/doc/80-Upgrading.md
+++ b/doc/80-Upgrading.md
@@ -5,6 +5,12 @@ v2.6 to v2.8 requires to follow the instructions for v2.7 too.
 
 ## Upgrading to Icinga Web 2.14
 
+**Deprecations**
+
+* Providing a custom user or group backend inside a module's configuration.php is deprecated and won't work as of v2.15.
+  * It continues to work under the same circumstances as before and remains broken where it was already broken.
+  * To keep it working as of v2.15 or make it work now, provide the custom backend inside the module's run.php instead.
+
 **Framework changes affecting third-party code**
 
 * Our JavaScript implementation to update relative times in the UI has been removed from Icinga Web, and an updated

--- a/doc/80-Upgrading.md
+++ b/doc/80-Upgrading.md
@@ -5,6 +5,12 @@ v2.6 to v2.8 requires to follow the instructions for v2.7 too.
 
 ## Upgrading to Icinga Web 2.14
 
+**Deprecations**
+
+* Providing a custom user or group backend inside a module's configuration.php is deprecated and won't work as of v2.15.
+  * It will still work as previously under the right circumstances, but will still be broken if it broke beforehand.
+  * To keep it working as of v2.15 or make it work now, provide the custom backend inside the module's run.php instead.
+
 **Framework changes affecting third-party code**
 
 * Our JavaScript implementation to update relative times in the UI has been removed from Icinga Web, and an updated

--- a/library/Icinga/Application/EmbeddedWeb.php
+++ b/library/Icinga/Application/EmbeddedWeb.php
@@ -122,14 +122,9 @@ class EmbeddedWeb extends ApplicationBootstrap
     protected function setupUser(): static
     {
         $auth = Auth::getInstance();
-        if (! $this->request->isXmlHttpRequest() && $this->request->isApiRequest() && ! $auth->isAuthenticated()) {
-            $auth->authHttp();
-        }
-
-        if ($auth->isAuthenticated()) {
-            $user = $auth->getUser();
-            $this->getRequest()->setUser($user);
-            $this->user = $user;
+        if ($auth->authenticate()->isAuthenticated()) {
+            $this->user = $auth->getUser();
+            $this->getRequest()->setUser($this->user);
         }
 
         return $this;

--- a/library/Icinga/Application/EmbeddedWeb.php
+++ b/library/Icinga/Application/EmbeddedWeb.php
@@ -7,6 +7,8 @@ namespace Icinga\Application;
 
 require_once dirname(__FILE__) . '/ApplicationBootstrap.php';
 
+use Icinga\Authentication\Auth;
+use Icinga\User;
 use Icinga\Web\Request;
 use Icinga\Web\Response;
 use ipl\I18n\NoopTranslator;
@@ -38,6 +40,13 @@ class EmbeddedWeb extends ApplicationBootstrap
     protected $response;
 
     /**
+     * User object
+     *
+     * @var ?User
+     */
+    protected ?User $user = null;
+
+    /**
      * Get the request
      *
      * @return  Request
@@ -67,10 +76,10 @@ class EmbeddedWeb extends ApplicationBootstrap
     protected function bootstrap()
     {
         return $this
+            ->setupLogging()
             ->setupErrorHandling()
             ->loadLibraries()
             ->loadConfig()
-            ->setupLogging()
             ->setupLogger()
             ->setupRequest()
             ->setupResponse()
@@ -78,6 +87,8 @@ class EmbeddedWeb extends ApplicationBootstrap
             ->prepareFakeInternationalization()
             ->setupModuleManager()
             ->loadEnabledModules()
+            ->setupUserBackendFactory()
+            ->setupUser()
             ->registerApplicationHooks();
     }
 
@@ -100,6 +111,27 @@ class EmbeddedWeb extends ApplicationBootstrap
     protected function setupResponse()
     {
         $this->response = new Response();
+        return $this;
+    }
+
+    /**
+     * Create user object
+     *
+     * @return $this
+     */
+    protected function setupUser(): static
+    {
+        $auth = Auth::getInstance();
+        if (! $this->request->isXmlHttpRequest() && $this->request->isApiRequest() && ! $auth->isAuthenticated()) {
+            $auth->authHttp();
+        }
+
+        if ($auth->isAuthenticated()) {
+            $user = $auth->getUser();
+            $this->getRequest()->setUser($user);
+            $this->user = $user;
+        }
+
         return $this;
     }
 

--- a/library/Icinga/Application/Modules/Manager.php
+++ b/library/Icinga/Application/Modules/Manager.php
@@ -5,6 +5,7 @@
 
 namespace Icinga\Application\Modules;
 
+use Fiber;
 use Icinga\Application\ApplicationBootstrap;
 use Icinga\Application\Icinga;
 use Icinga\Application\Logger;
@@ -189,8 +190,23 @@ class Manager
     public function loadEnabledModules()
     {
         if (! $this->loadedAllEnabledModules) {
+            $async = ! $this->app->isCli();
             foreach ($this->listEnabledModules() as $name) {
-                $this->loadModule($name);
+                if ($async) {
+                    // May be suspended during authentication and resumed upon finish
+                    (new Fiber(function () use ($name) {
+                        Logger::debug(
+                            'Loading enabled module "%s" asynchronously (Process %d; Fiber %d)',
+                            $name,
+                            getmypid() ?: 0,
+                            spl_object_id(Fiber::getCurrent())
+                        );
+
+                        $this->loadModule($name);
+                    }))->start();
+                } else {
+                    $this->loadModule($name);
+                }
             }
 
             $this->loadedAllEnabledModules = true;

--- a/library/Icinga/Application/Modules/Module.php
+++ b/library/Icinga/Application/Modules/Module.php
@@ -6,6 +6,7 @@
 namespace Icinga\Application\Modules;
 
 use Exception;
+use Fiber;
 use Icinga\Application\ApplicationBootstrap;
 use Icinga\Application\Config;
 use Icinga\Application\Hook;
@@ -1084,7 +1085,22 @@ class Module
      */
     public function getUserBackends()
     {
-        $this->launchConfigScript();
+        // TODO: Remove with v2.15
+        if (Fiber::getCurrent() === null) {
+            (new Fiber(function () {
+                Logger::debug(
+                    'Running config script of module "%s" asynchronously (Process %d; Fiber %d)',
+                    $this->getName(),
+                    getmypid() ?: 0,
+                    spl_object_id(Fiber::getCurrent())
+                );
+
+                $this->launchConfigScript();
+            }))->start();
+        } else {
+            $this->launchConfigScript();
+        }
+
         return $this->userBackends;
     }
 
@@ -1095,7 +1111,22 @@ class Module
      */
     public function getUserGroupBackends()
     {
-        $this->launchConfigScript();
+        // TODO: Remove with v2.15
+        if (Fiber::getCurrent() === null) {
+            (new Fiber(function () {
+                Logger::debug(
+                    'Running config script of module "%s" asynchronously (Process %d; Fiber %d)',
+                    $this->getName(),
+                    getmypid() ?: 0,
+                    spl_object_id(Fiber::getCurrent())
+                );
+
+                $this->launchConfigScript();
+            }))->start();
+        } else {
+            $this->launchConfigScript();
+        }
+
         return $this->userGroupBackends;
     }
 
@@ -1196,6 +1227,21 @@ class Module
      */
     protected function provideUserBackend($identifier, $className)
     {
+        if ($this->registered) {
+            trigger_error(sprintf(
+                'Module "%s" already registered. Providing user backend "%s" in configuration.php'
+                . ' has no effect as of version 2.15. Put it in run.php instead.',
+                $this->getName(),
+                $identifier
+            ), E_USER_DEPRECATED);
+            Logger::warning(
+                'Module "%s" already registered. Providing user backend "%s" in configuration.php'
+                . ' has no effect as of version 2.15. Put it in run.php instead.',
+                $this->getName(),
+                $identifier
+            );
+        }
+
         $this->userBackends[strtolower($identifier)] = $className;
         return $this;
     }
@@ -1210,6 +1256,21 @@ class Module
      */
     protected function provideUserGroupBackend($identifier, $className)
     {
+        if ($this->registered) {
+            trigger_error(sprintf(
+                'Module "%s" already registered. Providing user group backend "%s" in configuration.php'
+                . ' has no effect as of version 2.15. Put it in run.php instead.',
+                $this->getName(),
+                $identifier
+            ), E_USER_DEPRECATED);
+            Logger::warning(
+                'Module "%s" already registered. Providing user group backend "%s" in configuration.php'
+                . ' has no effect as of version 2.15. Put it in run.php instead.',
+                $this->getName(),
+                $identifier
+            );
+        }
+
         $this->userGroupBackends[strtolower($identifier)] = $className;
         return $this;
     }

--- a/library/Icinga/Application/Modules/Module.php
+++ b/library/Icinga/Application/Modules/Module.php
@@ -20,7 +20,6 @@ use Icinga\Web\Widget;
 use ipl\I18n\GettextTranslator;
 use ipl\I18n\StaticTranslator;
 use ipl\I18n\Translation;
-use Zend_Controller_Router_Route;
 use Zend_Controller_Router_Route_Abstract;
 use Zend_Controller_Router_Route_Regex;
 
@@ -1341,18 +1340,6 @@ class Module
         foreach ($this->routes as $name => $route) {
             $router->addRoute($name, $route);
         }
-        $router->addRoute(
-            $this->name . '_jsprovider',
-            new Zend_Controller_Router_Route(
-                'js/' . $this->name . '/:file',
-                array(
-                    'action'        => 'javascript',
-                    'controller'    => 'static',
-                    'module'        => 'default',
-                    'module_name'   => $this->name
-                )
-            )
-        );
         $router->addRoute(
             $this->name . '_img',
             new Zend_Controller_Router_Route_Regex(

--- a/library/Icinga/Application/Web.php
+++ b/library/Icinga/Application/Web.php
@@ -18,14 +18,11 @@ use Zend_Layout;
 use Zend_Paginator;
 use Zend_View_Helper_PaginationControl;
 use Icinga\Authentication\Auth;
-use Icinga\User;
 use Icinga\Util\DirectoryIterator;
 use Icinga\Util\TimezoneDetect;
 use Icinga\Web\Controller\Dispatcher;
 use Icinga\Web\Navigation\Navigation;
 use Icinga\Web\Notification;
-use Icinga\Web\Session;
-use Icinga\Web\Session\Session as BaseSession;
 use Icinga\Web\StyleSheet;
 use Icinga\Web\View;
 
@@ -54,20 +51,6 @@ class Web extends EmbeddedWeb
      */
     private $frontController;
 
-    /**
-     * Session object
-     *
-     * @var BaseSession
-     */
-    private $session;
-
-    /**
-     * User object
-     *
-     * @var User
-     */
-    private $user;
-
     /** @var array */
     protected $accessibleMenuItems;
 
@@ -92,7 +75,6 @@ class Web extends EmbeddedWeb
             ->loadConfig()
             ->setupLogger()
             ->setupRequest()
-            ->setupSession()
             ->setupNotifications()
             ->setupResponse()
             ->setupZendMvc()
@@ -315,48 +297,25 @@ class Web extends EmbeddedWeb
         return $this;
     }
 
-    /**
-     * Create user object
-     *
-     * @return $this
-     */
-    private function setupUser()
+    protected function setupUser(): static
     {
-        $auth = Auth::getInstance();
-        if (! $this->request->isXmlHttpRequest() && $this->request->isApiRequest() && ! $auth->isAuthenticated()) {
-            $auth->authHttp();
-        }
-        if ($auth->isAuthenticated()) {
-            $user = $auth->getUser();
-            $this->getRequest()->setUser($user);
-            $this->user = $user;
+        parent::setupUser();
 
-            if ($user->can('user/application/stacktraces')) {
-                $displayExceptions = $this->user->getPreferences()->getValue(
-                    'icingaweb',
-                    'show_stacktraces'
+        if ($this->user !== null && $this->user->can('user/application/stacktraces')) {
+            $displayExceptions = $this->user->getPreferences()->getValue(
+                'icingaweb',
+                'show_stacktraces'
+            );
+
+            if ($displayExceptions !== null) {
+                $this->frontController->setParams(
+                    array(
+                        'displayExceptions' => $displayExceptions
+                    )
                 );
-
-                if ($displayExceptions !== null) {
-                    $this->frontController->setParams(
-                        array(
-                            'displayExceptions' => $displayExceptions
-                        )
-                    );
-                }
             }
         }
-        return $this;
-    }
 
-    /**
-     * Initialize a session provider
-     *
-     * @return $this
-     */
-    private function setupSession()
-    {
-        $this->session = Session::create();
         return $this;
     }
 

--- a/library/Icinga/Application/Web.php
+++ b/library/Icinga/Application/Web.php
@@ -13,7 +13,6 @@ use ipl\I18n\Locale;
 use ipl\I18n\StaticTranslator;
 use Zend_Controller_Action_HelperBroker;
 use Zend_Controller_Front;
-use Zend_Controller_Router_Route;
 use Zend_Layout;
 use Zend_Paginator;
 use Zend_View_Helper_PaginationControl;
@@ -82,7 +81,6 @@ class Web extends EmbeddedWeb
             ->setupModuleManager()
             ->loadSetupModuleIfNecessary()
             ->loadEnabledModules()
-            ->setupRoute()
             ->setupPagination()
             ->setupUserBackendFactory()
             ->setupUser()
@@ -117,27 +115,6 @@ class Web extends EmbeddedWeb
             }
         }
         return array_combine($themes, $themes);
-    }
-
-    /**
-     * Prepare routing
-     *
-     * @return $this
-     */
-    private function setupRoute()
-    {
-        $this->frontController->getRouter()->addRoute(
-            'module_javascript',
-            new Zend_Controller_Router_Route(
-                'js/components/:module_name/:file',
-                array(
-                    'controller' => 'static',
-                    'action'     => 'javascript'
-                )
-            )
-        );
-
-        return $this;
     }
 
     /**

--- a/library/Icinga/Authentication/Auth.php
+++ b/library/Icinga/Authentication/Auth.php
@@ -21,6 +21,8 @@ use Icinga\User\Preferences;
 use Icinga\User\Preferences\PreferencesStore;
 use Icinga\Web\Session;
 use Icinga\Web\StyleSheet;
+use LogicException;
+use RuntimeException;
 
 class Auth
 {
@@ -52,6 +54,12 @@ class Auth
      */
     private $user;
 
+    /**
+     * Whether an authentication attempt has been performed
+     *
+     * @var bool
+     */
+    private bool $authPerformed = false;
 
     /**
      * @see getInstance()
@@ -90,14 +98,14 @@ class Auth
      */
     public function isAuthenticated()
     {
-        if ($this->user !== null) {
-            return true;
+        if (! $this->authPerformed) {
+            throw new RuntimeException(
+                'This should not happen. Please report this as a bug.'
+                . 'Include the full stack trace in your report and a list of *all* installed modules.'
+            );
         }
-        $this->authenticateFromSession();
-        if ($this->user === null && ! $this->authExternal()) {
-            return false;
-        }
-        return true;
+
+        return $this->user !== null;
     }
 
     public function setAuthenticated(User $user, $persist = true)
@@ -127,7 +135,7 @@ class Auth
             }
         }
 
-        $this->user = $user;
+        $this->setUser($user);
         if ($persist) {
             $this->persistCurrentUser();
         }
@@ -212,6 +220,40 @@ class Auth
     public function setUser(User $user)
     {
         $this->user = $user;
+        $this->authPerformed = true;
+
+        return $this;
+    }
+
+    /**
+     * Authenticate the user
+     *
+     * This method will try to authenticate the user using the session first, then external backends and finally HTTP
+     * authentication. If authentication has already been performed, an exception will be thrown.
+     *
+     * @throws LogicException If authentication has already been performed
+     *
+     * @return $this
+     */
+    public function authenticate(): static
+    {
+        if ($this->authPerformed) {
+            throw new LogicException('Cannot perform authentication more than once');
+        }
+
+        $this->authenticateFromSession();
+        if ($this->user === null) {
+            $this->authExternal();
+
+            if ($this->user === null
+                && $this->getRequest()->isApiRequest()
+                && ! $this->getRequest()->isXmlHttpRequest()
+            ) {
+                $this->authHttp();
+            }
+        }
+
+        $this->authPerformed = true;
 
         return $this;
     }

--- a/library/Icinga/Authentication/Auth.php
+++ b/library/Icinga/Authentication/Auth.php
@@ -6,6 +6,7 @@
 namespace Icinga\Authentication;
 
 use Exception;
+use Fiber;
 use Icinga\Application\Config;
 use Icinga\Application\Hook\AuditHook;
 use Icinga\Application\Hook\AuthenticationHook;
@@ -22,7 +23,6 @@ use Icinga\User\Preferences\PreferencesStore;
 use Icinga\Web\Session;
 use Icinga\Web\StyleSheet;
 use LogicException;
-use RuntimeException;
 
 class Auth
 {
@@ -62,6 +62,15 @@ class Auth
     private bool $authPerformed = false;
 
     /**
+     * Fibers that were suspended during authentication
+     *
+     * This is used to resume fibers after authentication has been performed.
+     *
+     * @var Fiber[]
+     */
+    private array $suspendedFibers = [];
+
+    /**
      * @see getInstance()
      */
     private function __construct()
@@ -99,10 +108,22 @@ class Auth
     public function isAuthenticated()
     {
         if (! $this->authPerformed) {
-            throw new RuntimeException(
-                'This should not happen. Please report this as a bug.'
-                . 'Include the full stack trace in your report and a list of *all* installed modules.'
-            );
+            $fiber = Fiber::getCurrent();
+            if ($fiber !== null) {
+                Logger::debug(
+                    'Fiber %d of process %d attempts authentication, suspending it.',
+                    spl_object_id($fiber),
+                    getmypid() ?: 0
+                );
+
+                $this->suspendedFibers[] = $fiber;
+                Fiber::suspend();
+            } else {
+                throw new LogicException(
+                    'Authentication has not been performed yet.'
+                    . ' Call Auth::authenticate() during bootstrap before calling isAuthenticated().'
+                );
+            }
         }
 
         return $this->user !== null;
@@ -254,6 +275,18 @@ class Auth
         }
 
         $this->authPerformed = true;
+
+        foreach ($this->suspendedFibers as $fiber) {
+            Logger::debug(
+                'Authentication performed, resuming fiber %d of process %d.',
+                spl_object_id($fiber),
+                getmypid() ?: 0
+            );
+
+            $fiber->resume();
+        }
+
+        $this->suspendedFibers = [];
 
         return $this;
     }

--- a/library/Icinga/Authentication/Auth.php
+++ b/library/Icinga/Authentication/Auth.php
@@ -6,6 +6,7 @@
 namespace Icinga\Authentication;
 
 use Exception;
+use Fiber;
 use Icinga\Application\Config;
 use Icinga\Application\Hook\AuditHook;
 use Icinga\Application\Hook\AuthenticationHook;
@@ -22,7 +23,6 @@ use Icinga\User\Preferences\PreferencesStore;
 use Icinga\Web\Session;
 use Icinga\Web\StyleSheet;
 use LogicException;
-use RuntimeException;
 
 class Auth
 {
@@ -64,6 +64,15 @@ class Auth
     private bool $authenticated = false;
 
     /**
+     * Fibers that were suspended during authentication
+     *
+     * This is used to resume fibers after authentication has been performed.
+     *
+     * @var Fiber[]
+     */
+    private array $suspendedFibers = [];
+
+    /**
      * @see getInstance()
      */
     private function __construct()
@@ -101,10 +110,22 @@ class Auth
     public function isAuthenticated()
     {
         if (! $this->authenticated) {
-            throw new RuntimeException(
-                'This should not happen. Please report this as a bug.'
-                . 'Include the full stack trace in your report and a list of *all* installed modules.'
-            );
+            $fiber = Fiber::getCurrent();
+            if ($fiber !== null) {
+                Logger::debug(
+                    'Fiber %d of process %d attempts authentication, suspending it.',
+                    spl_object_id($fiber),
+                    getmypid() ?: 0
+                );
+
+                $this->suspendedFibers[] = $fiber;
+                Fiber::suspend();
+            } else {
+                throw new LogicException(
+                    'Authentication has not been performed yet.'
+                    . ' Call Auth::authenticate() during bootstrap before calling isAuthenticated().'
+                );
+            }
         }
 
         return $this->user !== null;
@@ -256,6 +277,18 @@ class Auth
         }
 
         $this->authenticated = true;
+
+        foreach ($this->suspendedFibers as $fiber) {
+            Logger::debug(
+                'Authentication performed, resuming fiber %d of process %d.',
+                spl_object_id($fiber),
+                getmypid() ?: 0
+            );
+
+            $fiber->resume();
+        }
+
+        $this->suspendedFibers = [];
 
         return $this;
     }

--- a/library/Icinga/Authentication/Auth.php
+++ b/library/Icinga/Authentication/Auth.php
@@ -21,6 +21,8 @@ use Icinga\User\Preferences;
 use Icinga\User\Preferences\PreferencesStore;
 use Icinga\Web\Session;
 use Icinga\Web\StyleSheet;
+use LogicException;
+use RuntimeException;
 
 class Auth
 {
@@ -52,6 +54,14 @@ class Auth
      */
     private $user;
 
+    /**
+     * Whether the user has been authenticated
+     *
+     * If true, this does NOT mean authentication was successful.
+     *
+     * @var bool
+     */
+    private bool $authenticated = false;
 
     /**
      * @see getInstance()
@@ -90,14 +100,14 @@ class Auth
      */
     public function isAuthenticated()
     {
-        if ($this->user !== null) {
-            return true;
+        if (! $this->authenticated) {
+            throw new RuntimeException(
+                'This should not happen. Please report this as a bug.'
+                . 'Include the full stack trace in your report and a list of *all* installed modules.'
+            );
         }
-        $this->authenticateFromSession();
-        if ($this->user === null && ! $this->authExternal()) {
-            return false;
-        }
-        return true;
+
+        return $this->user !== null;
     }
 
     public function setAuthenticated(User $user, $persist = true)
@@ -212,6 +222,40 @@ class Auth
     public function setUser(User $user)
     {
         $this->user = $user;
+        $this->authenticated = true;
+
+        return $this;
+    }
+
+    /**
+     * Authenticate the user
+     *
+     * This method will try to authenticate the user using the session first, then external backends and finally HTTP
+     * authentication. If authentication has already been performed, an exception will be thrown.
+     *
+     * @throws LogicException If authentication has already been performed
+     *
+     * @return $this
+     */
+    public function authenticate(): static
+    {
+        if ($this->authenticated) {
+            throw new LogicException('Cannot perform authentication more than once');
+        }
+
+        $this->authenticateFromSession();
+        if ($this->user === null) {
+            $this->authExternal();
+
+            if ($this->user === null
+                && $this->getRequest()->isApiRequest()
+                && ! $this->getRequest()->isXmlHttpRequest()
+            ) {
+                $this->authHttp();
+            }
+        }
+
+        $this->authenticated = true;
 
         return $this;
     }


### PR DESCRIPTION
This is split into four distinct parts: (One commit is only performing a clean up)

### 1. EmbeddedWeb: Explicitly perform authentication

It is nowadays no exception that stylesheet may be dependent on who's using the app. So to avoid race conditions like in https://github.com/Icinga/icingaweb2/issues/5385 authentication is an explicit step during bootstrap now.
`EmbeddedWeb` now knows about and is responsible to initially set up the user object. So this does not change when `Web` sets up the user, it just allows `EmbeddedWeb` to do it.

A small side-effect introduced by this change is fully optional, but doesn't break anything either: Method `Web::setupSession()` and the accompanying `Web::$session` property are gone now as the property was obsolete already. Initializing the session is still done at the previous stage though, but implicitly by `Web::setupNotifications()`.

### 2. Auth: Perform authentication only once and not lazily

Since authentication is now performed even for static resources, there's no reason anymore to support implicit authentication. This also limits authentication attempts to a single one, previously failed attempts were repeated. Requiring authentication during bootstrapping, i.e. before authentication has been performed, will now throw an error.

This conflicts with #5430 as it also affects `Auth::isAuthenticated()`. But this should be easy to resolve.

### 3. Manager: Perform module loading asynchronously

So that authentication can suspend it. There are cases, e.g. cube, where authentication is required in run.php. During bootstrapping loading modules is mostly required to load libraries, register routes and hooks. Most of the time authentication is not required for these, but if it is, evaluation is now interrupted and continued after authentication has actually been performed.

I don't see a real risk for any breaking change here, since authentication happens shortly after. It actually avoids a breaking change, since without this, cube's Icinga DB support would break or at least malfunction.

And cube is only a single example. As long as the *monitoring* module is still supported by them, they will keep being affected.

Enable the *monitoring* module and Icinga DB Web in an environment and look at the debug log to see this change in effect.

### 4. Module: Expect user and group backends upon registration

Providing a user or user group backend in configuration.php now triggers a deprecation or warning. They are expected to be announced in run.php, just like hooks. Authentication attempts during a configuration.php run, while Authentication has not been performed yet, will be also suspended now. This ensures that the current behavior, being broken or working, stays the same.

You might think that this is a breaking change, but it was rather always broken and only worked in such particular situations that custom backends were never used in conjunction with any of the official modules mentioned in 3.

Removing the compatibility layer (the suspension part) with v2.15 might indeed be a bit hasty. But I rather like to get rid of this as early as possible and I think those who have custom extensions like this, in a functional state, are a minority and known to us. (i.e. Icinga partners which we can forewarn)