### PR TITLE
Warn about db name wildcards

### DIFF
--- a/application/forms/MigrationForm.php
+++ b/application/forms/MigrationForm.php
@@ -133,6 +133,18 @@ class MigrationForm extends CompatForm
                             . ' that has the appropriate credentials to resolve this issue.'
                         ),
                         implode(', ', $mm->getRequiredDatabasePrivileges())
+                    ))),
+                    new HtmlElement('br'),
+                    new HtmlElement('br'),
+                    new HtmlElement('span', null, Text::create(sprintf(
+                        $this->translate(
+                            'The database name may contain either an underscore or a percent sign.'
+                            . ' In MySQL these characters represent a wildcard. If part of a database name,'
+                            . ' they might not have been escaped when manually granting privileges.'
+                            . ' Privileges might not be detected in this case. Check the documentation and'
+                            . ' update your grants accordingly: %s'
+                        ),
+                        'https://dev.mysql.com/doc/refman/8.0/en/grant.html#grant-quoting'
                     )))
                 )
             );

--- a/modules/setup/application/forms/DatabaseCreationPage.php
+++ b/modules/setup/application/forms/DatabaseCreationPage.php
@@ -91,6 +91,19 @@ class DatabaseCreationPage extends Form
      */
     public function createElements(array $formData)
     {
+        if ($this->config['db'] === 'mysql' && preg_match('/[_%]/', $this->config['dbname'])) {
+            $this->warning(sprintf(
+                $this->translate(
+                    'The database name may contain either an underscore or a percent sign.'
+                    . ' In MySQL these characters represent a wildcard. If part of a database name,'
+                    . ' they might not have been escaped when manually granting privileges.'
+                    . ' Privileges might not be detected in this case. Check the documentation and'
+                    . ' update your grants accordingly: %s'
+                ),
+                'https://dev.mysql.com/doc/refman/8.0/en/grant.html#grant-quoting'
+            ));
+        }
+
         $skipValidation = isset($formData['skip_validation']) && $formData['skip_validation'];
         $this->addElement(
             'text',


### PR DESCRIPTION
On the migration overview, there is no way to verify that the privileges checked are for a MySQL database, as there is no access to which migration this has caused.

It looks like this:

<img width="1274" height="652" alt="image" src="https://github.com/user-attachments/assets/55bfbc0f-5dec-4578-843e-1394d362f0d4" />
<img width="2308" height="594" alt="image" src="https://github.com/user-attachments/assets/ef1f33bd-4555-4040-a5a0-dc8f84951140" />
