### PR TITLE
Removed background search icon in high-contrast theme

### DIFF
--- a/public/css/themes/high-contrast.less
+++ b/public/css/themes/high-contrast.less
@@ -225,11 +225,6 @@
   }
 }
 
-.controls input.search,
-input.search {
-  background-image: url(../img/icons/search.png);
-}
-
 .search-bar,
 .button-link,
 .view-mode-switcher > label {


### PR DESCRIPTION
Originally done in commit https://github.com/Icinga/icingaweb2/commit/aa7a60c8933e50d63371e6de4ee82a2adaf30ee8 

Now also for the *high-contrast* theme