### PR TITLE
Remove whitespace around config which couldn't be stored

### DIFF
--- a/application/views/scripts/showConfiguration.phtml
+++ b/application/views/scripts/showConfiguration.phtml
@@ -21,7 +21,5 @@
   <?= $this->translate('In case you can access the file by yourself, you can open it and insert the config manually:'); ?>
 </p>
 <p>
-  <pre>
-    <code><?= $this->escape($configString); ?></code>
-  </pre>
+  <pre><code><?= $this->escape($configString); ?></code></pre>
 </p>


### PR DESCRIPTION
If I change settings in the web UI, but latter can't write to /etc/icingaweb2, it shows me the desired file contents, so I can deploy them myself – with strange whitespace around it. Screenshots say it all:

## Before

<img width="1920" height="1080" alt="Bildschirmfoto 2025-08-07 um 11 20 31" src="https://github.com/user-attachments/assets/0d149104-e8c0-410b-9e20-20b5f94e0b79" />

## After

<img width="1920" height="1080" alt="Bildschirmfoto 2025-08-07 um 11 19 44" src="https://github.com/user-attachments/assets/491829a3-71f9-46c5-9e01-55fc1debfaaa" />