### PR TITLE
Declare a redirect to __REFRESH__ as autorefresh

### DIFF
--- a/public/js/icinga/loader.js
+++ b/public/js/icinga/loader.js
@@ -498,7 +498,8 @@
         processRedirectHeader: function(req) {
             var icinga      = this.icinga,
                 $redirectTarget  = req.$redirectTarget,
-                redirect    = req.getResponseHeader('X-Icinga-Redirect');
+                redirect    = req.getResponseHeader('X-Icinga-Redirect'),
+                autorefresh = false;
 
             if (! redirect) {
                 return false;
@@ -599,6 +600,8 @@
                     icinga.logger.error('Unable to refresh. Not a primary column: ', req.$redirectTarget);
                     return false;
                 }
+
+                autorefresh = true;
             }
 
             var useHttp = req.getResponseHeader('X-Icinga-Redirect-Http');
@@ -607,7 +610,7 @@
                 return true;
             }
 
-            this.redirectToUrl(redirect, $redirectTarget, req);
+            this.redirectToUrl(redirect, $redirectTarget, req, autorefresh);
             return true;
         },
 

--- a/public/js/icinga/loader.js
+++ b/public/js/icinga/loader.js
@@ -617,8 +617,13 @@
          * @param {string}  url
          * @param {object}  $target
          * @param {XMLHttpRequest} referrer
+         * @param {boolean} autorefresh
          */
-        redirectToUrl: function (url, $target, referrer) {
+        redirectToUrl: function (url, $target, referrer, autorefresh) {
+            if (typeof autorefresh === 'undefined') {
+                autorefresh = false;
+            }
+
             var icinga = this.icinga,
                 rerenderLayout,
                 autoRefreshInterval,
@@ -640,7 +645,7 @@
                 var parts = url.split(/#!/);
                 url = parts.shift();
                 var redirectionUrl = icinga.utils.addUrlFlag(url, 'renderLayout');
-                var r = this.loadUrl(redirectionUrl, $('#layout'));
+                var r = this.loadUrl(redirectionUrl, $('#layout'), undefined, undefined, undefined, autorefresh);
                 r.historyUrl = url;
                 r.referrer = referrer;
                 if (parts.length) {
@@ -664,10 +669,10 @@
                 if (url.match(/#!/)) {
                     var parts = url.split(/#!/);
                     icinga.ui.layout2col();
-                    this.loadUrl(parts.shift(), $('#col1'));
-                    this.loadUrl(parts.shift(), $('#col2'));
+                    this.loadUrl(parts.shift(), $('#col1'), undefined, undefined, undefined, autorefresh);
+                    this.loadUrl(parts.shift(), $('#col2'), undefined, undefined, undefined, autorefresh);
                 } else {
-                    var req = this.loadUrl(url, $target);
+                    var req = this.loadUrl(url, $target, undefined, undefined, undefined, autorefresh);
                     req.forceFocus = url === origin ? forceFocus : null;
                     req.autoRefreshInterval = autoRefreshInterval;
                     req.referrer = referrer;


### PR DESCRIPTION
to preserve scroll position when a modal is closed.

* E.g https://github.com/Icinga/netrp/issues/150

If this is explicitly unwanted in a particular case(?), we can add a `__RELOAD__` with the old behavior.