### PR TITLE
Remove `text-overflow: ellipsis` for user-nav-item link

### DIFF
--- a/public/css/icinga/configmenu.less
+++ b/public/css/icinga/configmenu.less
@@ -4,6 +4,10 @@
 
 .sidebar-collapsed #menu {
   margin-bottom: 8em;
+
+  .config-menu > ul .user-nav-item > a {
+    text-overflow: clip;
+  }
 }
 
 #menu .config-menu {


### PR DESCRIPTION
... if sidebar is collapsed. The title was automatically generated by `text-overflow: ellipsis` and only in Safari browser.

fixes #5368 