### PR TITLE
Normalize confirm remove

### DIFF
--- a/application/controllers/DashboardController.php
+++ b/application/controllers/DashboardController.php
@@ -183,7 +183,6 @@ class DashboardController extends ActionController
             }
             return true;
         });
-        $form->setTitle($this->translate('Remove Dashlet From Dashboard'));
         $form->setRedirectUrl('dashboard/settings');
         $form->handleRequest();
         $this->view->pane = $pane;

--- a/application/controllers/GroupController.php
+++ b/application/controllers/GroupController.php
@@ -149,7 +149,7 @@ class GroupController extends AuthBackendController
                 'class'         => 'link-button spinner',
                 'value'         => 'btn_submit',
                 'decorators'    => array('ViewHelper'),
-                'label'         => $this->view->icon('trash'),
+                'label'         => $this->view->icon('cancel'),
                 'title'         => $this->translate('Remove this member')
             ));
             $this->view->removeForm = $removeForm;

--- a/application/controllers/NavigationController.php
+++ b/application/controllers/NavigationController.php
@@ -189,7 +189,7 @@ class NavigationController extends Controller
             'class'         => 'link-button spinner',
             'value'         => 'btn_submit',
             'decorators'    => array('ViewHelper'),
-            'label'         => $this->view->icon('trash'),
+            'label'         => $this->view->icon('cancel'),
             'title'         => $this->translate('Unshare this navigation item')
         ));
 

--- a/application/controllers/RoleController.php
+++ b/application/controllers/RoleController.php
@@ -120,7 +120,7 @@ class RoleController extends AuthBackendController
         $role = new RoleForm();
         $role->setRedirectUrl('__CLOSE__');
         $role->setRepository(new RolesConfig());
-        $role->setSubmitLabel($this->translate('Remove Role'));
+        $role->setSubmitLabel($this->translate('Confirm Removal'));
         $role->remove($name);
 
         try {

--- a/application/controllers/UserController.php
+++ b/application/controllers/UserController.php
@@ -161,7 +161,7 @@ class UserController extends AuthBackendController
                 'class'         => 'link-button spinner',
                 'value'         => 'btn_submit',
                 'decorators'    => array('ViewHelper'),
-                'label'         => $this->view->icon('trash'),
+                'label'         => $this->view->icon('cancel'),
                 'title'         => $this->translate('Cancel this membership')
             ));
             $this->view->removeForm = $removeForm;

--- a/application/forms/Announcement/AnnouncementForm.php
+++ b/application/forms/Announcement/AnnouncementForm.php
@@ -91,7 +91,7 @@ class AnnouncementForm extends RepositoryForm
     protected function createDeleteElements(array $formData)
     {
         $this->setTitle(sprintf($this->translate('Remove announcement %s?'), $this->getIdentifier()));
-        $this->setSubmitLabel($this->translate('Yes'));
+        $this->setSubmitLabel($this->translate('Confirm Removal'));
         $this->setAttrib('class', 'icinga-controls');
     }
 

--- a/application/forms/Config/User/UserForm.php
+++ b/application/forms/Config/User/UserForm.php
@@ -117,7 +117,7 @@ class UserForm extends RepositoryForm
     protected function createDeleteElements(array $formData)
     {
         $this->setTitle(sprintf($this->translate('Remove user %s?'), $this->getIdentifier()));
-        $this->setSubmitLabel($this->translate('Yes'));
+        $this->setSubmitLabel($this->translate('Confirm Removal'));
         $this->setAttrib('class', 'icinga-controls');
     }
 

--- a/application/forms/Config/UserGroup/UserGroupForm.php
+++ b/application/forms/Config/UserGroup/UserGroupForm.php
@@ -65,7 +65,7 @@ class UserGroupForm extends RepositoryForm
             'Note that all users that are currently a member of this group will'
             . ' have their membership cleared automatically.'
         ));
-        $this->setSubmitLabel($this->translate('Yes'));
+        $this->setSubmitLabel($this->translate('Confirm Removal'));
         $this->setAttrib('class', 'icinga-form icinga-controls');
     }
 

--- a/application/views/scripts/dashboard/settings.phtml
+++ b/application/views/scripts/dashboard/settings.phtml
@@ -38,7 +38,8 @@
                             'dashboard/remove-pane',
                             array('pane' => $pane->getName()),
                             array(
-                                'icon'  => 'trash',
+                                'icon'  => 'cancel',
+                                'class' => 'action-link',
                                 'title' => sprintf($this->translate('Remove pane %s'), $pane->getName())
                             )
                         ); ?>
@@ -77,7 +78,8 @@
                                     'dashboard/remove-dashlet',
                                     array('pane' => $pane->getName(), 'dashlet' => $dashlet->getName()),
                                     array(
-                                        'icon'  => 'trash',
+                                        'icon'  => 'cancel',
+                                        'class' => 'action-link',
                                         'title' => sprintf($this->translate('Remove dashlet %s from pane %s'), $dashlet->getTitle(), $pane->getTitle())
                                     )
                                 ); ?>


### PR DESCRIPTION
This PR normalized the use of the phrase "Confirm Removal" in forms that confirm removal.

It also normalizes the use of the "cancel" icon.

See #5428 