### PR TITLE
Rename rule: ignore NotPascalCase in views/helpers

### DIFF
--- a/icingaweb2.ruleset.xml
+++ b/icingaweb2.ruleset.xml
@@ -41,7 +41,7 @@
         <exclude-pattern>*/application/views/helpers/*</exclude-pattern>
         <exclude-pattern>*/library/Icinga/Web/Paginator/ScrollingStyle/SlidingWithBorder.php</exclude-pattern>
     </rule>
-    <rule ref="Squiz.Classes.ValidClassName.NotCamelCaps">
+    <rule ref="Squiz.Classes.ValidClassName.NotPascalCase">
         <exclude-pattern>*/application/views/helpers/*</exclude-pattern>
         <exclude-pattern>*/library/Icinga/Web/Paginator/ScrollingStyle/SlidingWithBorder.php</exclude-pattern>
     </rule>


### PR DESCRIPTION
PHP_CodeSniffer 4.0 renamed the class name NotCamelCaps to
NotPascalCase.
Reference: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Version-4.0-User-Upgrade-Guide#upgrading-5

Because of this change, our current configuration was no longer compatible.
I tested the update inside a Docker container: after switching to the new class name `NotPascalCase`, the error message disappeared and the rules are applied as expected.