### PR TITLE
LoginButtonHook: additional buttons below the login form

### DIFF
--- a/application/controllers/AuthenticationController.php
+++ b/application/controllers/AuthenticationController.php
@@ -3,9 +3,14 @@
 
 namespace Icinga\Controllers;
 
+use GuzzleHttp\Psr7\ServerRequest;
+use Icinga\Application\ClassLoader;
 use Icinga\Application\Hook\AuthenticationHook;
+use Icinga\Application\Hook\LoginButtonHook;
 use Icinga\Application\Icinga;
 use Icinga\Application\Logger;
+use Icinga\Authentication\LoginButton;
+use Icinga\Authentication\LoginButtonForm;
 use Icinga\Common\Database;
 use Icinga\Exception\AuthenticationException;
 use Icinga\Forms\Authentication\LoginForm;
@@ -14,6 +19,7 @@ use Icinga\Web\Helper\CookieHelper;
 use Icinga\Web\RememberMe;
 use Icinga\Web\Url;
 use RuntimeException;
+use Throwable;
 
 /**
  * Application wide controller for authentication
@@ -93,7 +99,33 @@ class AuthenticationController extends Controller
             }
             $form->handleRequest();
         }
+
+        $loginButtons = [];
+        $request = ServerRequest::fromGlobals();
+
+        foreach (LoginButtonHook::all() as $class => $hook) {
+            try {
+                foreach ($hook->getButtons() as $index => $button) {
+                    assert($button instanceof LoginButton);
+
+                    $loginButtons[] = (new LoginButtonForm(
+                        sha1("$class!$index"),
+                        $button,
+                        ClassLoader::classBelongsToModule($class) ? ClassLoader::extractModuleName($class) : null
+                    ))
+                        ->on(LoginButtonForm::ON_SUCCESS, function () use ($button): void {
+                            ($button->onClick)();
+                        })
+                        ->handleRequest($request);
+                }
+            } catch (Throwable $e) {
+                Logger::error('Failed to execute login button hook: %s', $e);
+                continue;
+            }
+        }
+
         $this->view->form = $form;
+        $this->view->loginButtons = $loginButtons;
         $this->view->defaultTitle = $this->translate('Icinga Web 2 Login');
         $this->view->requiresSetup = $requiresSetup;
     }

--- a/application/views/scripts/authentication/login.phtml
+++ b/application/views/scripts/authentication/login.phtml
@@ -22,6 +22,7 @@
             ) ?></p>
         <?php endif ?>
         <?= $this->form ?>
+        <?= implode('', $this->loginButtons) ?>
         <div id="login-footer">
             <p>Icinga Web 2 &copy; 2013-<?= date('Y') ?></p>
             <?= $this->qlink($this->translate('icinga.com'), 'https://icinga.com') ?>

--- a/library/Icinga/Application/Hook/LoginButtonHook.php
+++ b/library/Icinga/Application/Hook/LoginButtonHook.php
@@ -1,0 +1,47 @@
+<?php
+/* Icinga Web 2 | (c) 2026 Icinga GmbH | GPLv2+ */
+
+namespace Icinga\Application\Hook;
+
+use Icinga\Application\Hook;
+use Icinga\Authentication\LoginButton;
+
+/**
+ * Hook for adding custom buttons below the login form
+ *
+ * Extend this class to display additional buttons on the Icinga Web login page,
+ * e.g. for alternative authentication flows such as SSO.
+ * To register your implementation, call `YourLoginButtons::register()` during module initialization.
+ */
+abstract class LoginButtonHook
+{
+    /**
+     * Get the buttons to display below the login form
+     *
+     * Implement this method to return any number of {@link LoginButton} instances.
+     * Each button is rendered below the standard login form in the order provided.
+     *
+     * @return LoginButton[]
+     */
+    abstract public function getButtons(): array;
+
+    /**
+     * Get all registered implementations
+     *
+     * @return static[]
+     */
+    public static function all(): array
+    {
+        return Hook::all('LoginButton');
+    }
+
+    /**
+     * Register the class as a LoginButton hook implementation
+     *
+     * Call this method on your implementation during module initialization to make Icinga Web aware of your hook.
+     */
+    public static function register(): void
+    {
+        Hook::register('LoginButton', static::class, static::class, true);
+    }
+}

--- a/library/Icinga/Authentication/LoginButton.php
+++ b/library/Icinga/Authentication/LoginButton.php
@@ -1,0 +1,25 @@
+<?php
+/* Icinga Web 2 | (c) 2026 Icinga GmbH | GPLv2+ */
+
+namespace Icinga\Authentication;
+
+use Closure;
+use ipl\Html\Attributes;
+use ipl\Html\ValidHtml;
+
+readonly class LoginButton
+{
+    /**
+     * Create an additional button to be displayed below the login form
+     *
+     * @param Closure $onClick What to do if the button is pressed
+     * @param ValidHtml $content What to show in the button, see also {@link Html::wantHtml()}
+     * @param ?Attributes $attributes Additional <button> attributes, e.g. title
+     */
+    public function __construct(
+        public Closure $onClick,
+        public ValidHtml $content,
+        public ?Attributes $attributes = null
+    ) {
+    }
+}

--- a/library/Icinga/Authentication/LoginButtonForm.php
+++ b/library/Icinga/Authentication/LoginButtonForm.php
@@ -1,0 +1,41 @@
+<?php
+/* Icinga Web 2 | (c) 2026 Icinga GmbH | GPLv2+ */
+
+namespace Icinga\Authentication;
+
+use Icinga\Web\Session;
+use ipl\Html\Form;
+use ipl\Html\FormElement\SubmitButtonElement;
+use ipl\Web\Common\CsrfCounterMeasure;
+use ipl\Web\Common\FormUid;
+
+/**
+ * Form for user authentication via external identity providers
+ */
+class LoginButtonForm extends Form
+{
+    use FormUid;
+    use CsrfCounterMeasure;
+
+    public function __construct(
+        string $name,
+        protected readonly LoginButton $button,
+        protected readonly ?string $moduleName = null
+    ) {
+        /** {@link assemble} calls {@link createUidElement} which requires the name attribute */
+        $this->defaultAttributes['name'] = $name;
+    }
+
+    protected function assemble(): void
+    {
+        $button = new SubmitButtonElement('btn_submit', $this->button->attributes);
+
+        if ($this->moduleName) {
+            $button->addAttributes(['class' => "icinga-module module-$this->moduleName"]);
+        }
+
+        $this->addElement($button->addHtml($this->button->content));
+        $this->addHtml($this->createUidElement());
+        $this->addElement($this->createCsrfCounterMeasure(Session::getSession()->getId()));
+    }
+}

--- a/public/css/icinga/login.less
+++ b/public/css/icinga/login.less
@@ -74,12 +74,12 @@
     }
   }
 
-  input[type="submit"]:focus {
-    outline: 3px solid;
-    outline-color: @icinga-blue-light;
-  }
+  input[type="submit"], button {
+    &:focus {
+      outline: 3px solid;
+      outline-color: @icinga-blue-light;
+    }
 
-  input[type=submit] {
     border-radius: .25em;
     background: @icinga-secondary;
     color: white;


### PR DESCRIPTION
Introduces `LoginButtonHook`, a new hook for rendering additional buttons below the login form. Extend this class to display custom buttons on the Icinga Web login page — useful for alternative authentication flows such as SSO. Register your implementation by calling `YourLoginButtons::register()` during module initialization.