### PR TITLE
Only collapse the y-axis for collapsible elements

### DIFF
--- a/public/css/icinga/main.less
+++ b/public/css/icinga/main.less
@@ -385,7 +385,7 @@ details.collapsible:not([open]) > .collapsible-control {
 // Collapsibles
 
 .collapsible.collapsed:not(details) {
-  overflow: hidden;
+  overflow-y: clip;
 }
 
 .collapsible.collapsed:not([data-toggle-element], details) {


### PR DESCRIPTION
Only collapse the y-axis if an collapsible item is collapsed. Additional styling in the horizontal level that overflows the x-axis  should still be possible.