### PR TITLE
Properly load roles for external backend user

### DIFF
--- a/library/Icinga/Authentication/UserGroup/LdapUserGroupBackend.php
+++ b/library/Icinga/Authentication/UserGroup/LdapUserGroupBackend.php
@@ -4,6 +4,7 @@
 namespace Icinga\Authentication\UserGroup;
 
 use Exception;
+use Icinga\Application\Config;
 use Icinga\Authentication\User\UserBackend;
 use Icinga\Authentication\User\LdapUserBackend;
 use Icinga\Application\Logger;
@@ -802,6 +803,7 @@ class LdapUserGroupBackend extends LdapRepository implements Inspectable, UserGr
         }
 
         if ($config->user_backend && $config->user_backend !== 'none') {
+            UserBackend::setConfig(Config::app('authentication'));
             $userBackend = UserBackend::create($config->user_backend);
             if (! $userBackend instanceof LdapUserBackend) {
                 throw new ConfigurationError('User backend "%s" is not of type LDAP', $config->user_backend);


### PR DESCRIPTION
fixes #5464 

### Bootstrap: Module Loading and Authentication Order:
First, `bootstrap->loadEnabledModules()` is executed. Then the authentication configuration (`authentication.ini`) is loaded and initialized via `bootstrap->setupUserBackendFactory()`. Only after these steps, the login form is evaluated, and the user is authenticated.

The problem is caused by the call to `IcingadbSupport::useIcingaDbAsBackend()` in the modules’ run.php file.

When `bootstrap->loadEnabledModules()` loads a module, its `run.php` file is executed immediately. The call to `IcingadbSupport::useIcingaDbAsBackend()` triggers the following call chain: `hasPermission() -> isAuthenticated() -> authExternal()`.

Normally, modules are loaded without an authenticated user because this call chain returns false. However, when an external user logs in, `authExternal()` marks the user as authenticated by calling `setAuthenticated()`.

At this point, `UserBackend::$backends` is not yet initialized. Because of this, user groups and roles cannot be loaded.

Icinga Web 2 shows the following error:
```shell
NOTICE: PHP message: icingaweb2: ERROR - Can't get group memberships for user 'user' from backend 'auth_ldap'. An exception was thrown: Icinga\Exception\ConfigurationError in /icingaweb2/library/Icinga/Authentication/User/UserBackend.php:74 with message: User backends not set up. Please contact your Icinga Web administrator
```
