### PR TITLE
Shorten AuthenticationHook#onLogin() doc comment to avoid confusion

### DIFF
--- a/library/Icinga/Application/Hook/AuthenticationHook.php
+++ b/library/Icinga/Application/Hook/AuthenticationHook.php
@@ -20,7 +20,7 @@ abstract class AuthenticationHook
     const NAME = 'authentication';
 
     /**
-     * Triggered after login in Icinga Web and when calling login action even if already authenticated in Icinga Web
+     * Triggered after login in Icinga Web and when calling login action
      *
      * @param User $user
      */


### PR DESCRIPTION
"even if already authenticated in Icinga Web" already made one colleague thinking #onLogin() is called even during authentication from session. Latter is not true and not desired by hook providers, e.g. icinga-notifications-web.

Currently, as authenticated user, I can't even use /authentication/login. It redirects me to the dashboard.