### PR TITLE
GitHub Actions: Add `monitoring` as dependency

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -24,7 +24,8 @@ jobs:
           "./icinga-php/vendor"             : "https://github.com/Icinga/icinga-php-thirdparty.git#snapshot/nightly",
           "./icingaweb2-modules/icingadb"   : "https://github.com/Icinga/icingadb-web.git",
           "./icingaweb2-modules/pdfexport"  : "https://github.com/Icinga/icingaweb2-module-pdfexport.git",
-          "./icingaweb2-modules/x509"       : "https://github.com/Icinga/icingaweb2-module-x509.git"
+          "./icingaweb2-modules/x509"       : "https://github.com/Icinga/icingaweb2-module-x509.git",
+          "./icingaweb2-modules/monitoring" : "https://github.com/Icinga/icingaweb2-module-monitoring.git"
         }
       env: |
         {


### PR DESCRIPTION
Since the `monitoring` module has been separated from `Icingaweb2`, PHPStan fails to load files that refer to the monitoring module. The module must therefore be added as a dependency in `php.yml`.
