### PR TITLE
GitHub Actions: Automatically close stale issues per schedule

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,11 @@
+name: Maintenance
+
+on:
+  schedule:
+    - cron: '0 11 * * 1-5' # Every weekday (Mon-Fri) at 11:00 AM UTC
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  php:
+    name: Stale
+    uses: Icinga/github-actions/.github/workflows/stale.yml@main


### PR DESCRIPTION
Use [our reusable workflow](https://github.com/Icinga/github-actions/blob/main/.github/workflows/stale.yml) to automatically close outdated issues on a schedule (Mo-Fri at 11:00 AM UTC) or manually. 

This [dry run](https://github.com/Icinga/icingaweb2/actions/runs/21483815894/job/61887204159) lists which issues will be addressed during the first actual run of this workflow.

refs Icinga/github-actions#19