### PR TITLE
Introduce `HookEssentials`

### DIFF
--- a/library/Icinga/Application/ApplicationBootstrap.php
+++ b/library/Icinga/Application/ApplicationBootstrap.php
@@ -741,7 +741,7 @@ abstract class ApplicationBootstrap
      */
     protected function registerApplicationHooks(): self
     {
-        Hook::register('DbMigration', DbMigration::class, DbMigration::class);
+        DbMigration::register();
 
         return $this;
     }

--- a/library/Icinga/Application/Hook.php
+++ b/library/Icinga/Application/Hook.php
@@ -68,6 +68,8 @@ class Hook
      * @param   string  $name   One of the predefined hook names
      *
      * @return  bool
+     *
+     * @deprecated Use {@link Hook\HookEssentials::isRegistered} instead
      */
     public static function has($name)
     {
@@ -267,6 +269,8 @@ class Hook
      * @param   string  $name   One of the predefined hook names
      *
      * @return  array
+     *
+     * @deprecated Use {@link Hook\HookEssentials::all} instead
      */
     public static function all($name): array
     {
@@ -291,6 +295,8 @@ class Hook
      * @param   string  $name   One of the predefined hook names
      *
      * @return  null|mixed
+     *
+     * @deprecated Use {@link Hook\HookEssentials::first} instead
      */
     public static function first($name)
     {
@@ -314,6 +320,8 @@ class Hook
      * @param   string      $class          Your class name, must inherit one of the
      *                                      classes in the Icinga/Application/Hook folder
      * @param   bool        $alwaysRun      To run the hook always (e.g. without permission check)
+     *
+     * @deprecated Use {@link Hook\HookEssentials::register} instead
      */
     public static function register($name, $key, $class, $alwaysRun = false)
     {

--- a/library/Icinga/Application/Hook.php
+++ b/library/Icinga/Application/Hook.php
@@ -68,6 +68,8 @@ class Hook
      * @param   string  $name   One of the predefined hook names
      *
      * @return  bool
+     *
+     * @deprecated Use {@link Hook\Essentials::isRegistered} instead
      */
     public static function has($name)
     {
@@ -267,6 +269,8 @@ class Hook
      * @param   string  $name   One of the predefined hook names
      *
      * @return  array
+     *
+     * @deprecated Use {@link Hook\Essentials::all} instead
      */
     public static function all($name): array
     {
@@ -291,6 +295,8 @@ class Hook
      * @param   string  $name   One of the predefined hook names
      *
      * @return  null|mixed
+     *
+     * @deprecated Use {@link Hook\Essentials::first} instead
      */
     public static function first($name)
     {
@@ -314,6 +320,8 @@ class Hook
      * @param   string      $class          Your class name, must inherit one of the
      *                                      classes in the Icinga/Application/Hook folder
      * @param   bool        $alwaysRun      To run the hook always (e.g. without permission check)
+     *
+     * @deprecated Use {@link Hook\Essentials::register} instead
      */
     public static function register($name, $key, $class, $alwaysRun = false)
     {

--- a/library/Icinga/Application/Hook/ApplicationStateHook.php
+++ b/library/Icinga/Application/Hook/ApplicationStateHook.php
@@ -5,7 +5,6 @@
 
 namespace Icinga\Application\Hook;
 
-use Icinga\Application\Hook;
 use Icinga\Application\Logger;
 
 /**
@@ -73,12 +72,11 @@ abstract class ApplicationStateHook
     {
         $messages = [];
 
-        if (! Hook::has('ApplicationState')) {
+        if (! static::isRegistered()) {
             return $messages;
         }
 
-        foreach (Hook::all('ApplicationState') as $hook) {
-            /** @var self $hook */
+        foreach (static::all() as $hook) {
             try {
                 $hook->collectMessages();
             } catch (\Exception $e) {

--- a/library/Icinga/Application/Hook/ApplicationStateHook.php
+++ b/library/Icinga/Application/Hook/ApplicationStateHook.php
@@ -13,9 +13,16 @@ use Icinga\Application\Logger;
  */
 abstract class ApplicationStateHook
 {
+    use HookEssentials;
+
     const ERROR = 'error';
 
     private $messages = [];
+
+    final protected static function getHookName(): string
+    {
+        return 'ApplicationState';
+    }
 
     final public function hasMessages()
     {

--- a/library/Icinga/Application/Hook/ApplicationStateHook.php
+++ b/library/Icinga/Application/Hook/ApplicationStateHook.php
@@ -13,9 +13,16 @@ use Icinga\Application\Logger;
  */
 abstract class ApplicationStateHook
 {
+    use Essentials;
+
     const ERROR = 'error';
 
     private $messages = [];
+
+    protected static function getHookName(): string
+    {
+        return 'ApplicationState';
+    }
 
     final public function hasMessages()
     {

--- a/library/Icinga/Application/Hook/AuditHook.php
+++ b/library/Icinga/Application/Hook/AuditHook.php
@@ -8,11 +8,17 @@ namespace Icinga\Application\Hook;
 use Exception;
 use InvalidArgumentException;
 use Icinga\Authentication\Auth;
-use Icinga\Application\Hook;
 use Icinga\Application\Logger;
 
 abstract class AuditHook
 {
+    use HookEssentials;
+
+    final protected static function getHookName(): string
+    {
+        return 'audit';
+    }
+
     /**
      * Log an activity to the audit log
      *

--- a/library/Icinga/Application/Hook/AuditHook.php
+++ b/library/Icinga/Application/Hook/AuditHook.php
@@ -33,7 +33,7 @@ abstract class AuditHook
      */
     public static function logActivity($type, $message, ?array $data = null, $identity = null, $time = null)
     {
-        if (! Hook::has('audit')) {
+        if (! static::isRegistered()) {
             return;
         }
 
@@ -45,8 +45,7 @@ abstract class AuditHook
             $time = time();
         }
 
-        foreach (Hook::all('audit') as $hook) {
-            /** @var self $hook */
+        foreach (static::all() as $hook) {
             try {
                 $formattedMessage = $message;
                 if ($data !== null) {

--- a/library/Icinga/Application/Hook/AuditHook.php
+++ b/library/Icinga/Application/Hook/AuditHook.php
@@ -34,7 +34,7 @@ abstract class AuditHook
      */
     public static function logActivity($type, $message, ?array $data = null, $identity = null, $time = null)
     {
-        if (! Hook::has('audit')) {
+        if (! static::isRegistered()) {
             return;
         }
 
@@ -46,8 +46,7 @@ abstract class AuditHook
             $time = time();
         }
 
-        foreach (Hook::all('audit') as $hook) {
-            /** @var self $hook */
+        foreach (static::all() as $hook) {
             try {
                 $formattedMessage = $message;
                 if ($data !== null) {

--- a/library/Icinga/Application/Hook/AuditHook.php
+++ b/library/Icinga/Application/Hook/AuditHook.php
@@ -13,6 +13,13 @@ use Icinga\Application\Logger;
 
 abstract class AuditHook
 {
+    use Essentials;
+
+    protected static function getHookName(): string
+    {
+        return 'audit';
+    }
+
     /**
      * Log an activity to the audit log
      *

--- a/library/Icinga/Application/Hook/AuthenticationHook.php
+++ b/library/Icinga/Application/Hook/AuthenticationHook.php
@@ -18,10 +18,17 @@ use Throwable;
  */
 abstract class AuthenticationHook
 {
+    use HookEssentials;
+
     /**
      * Name of the hook
      */
     const NAME = 'authentication';
+
+    final protected static function getHookName(): string
+    {
+        return static::NAME;
+    }
 
     /**
      * Triggered after login in Icinga Web and when calling login action

--- a/library/Icinga/Application/Hook/AuthenticationHook.php
+++ b/library/Icinga/Application/Hook/AuthenticationHook.php
@@ -6,7 +6,6 @@
 namespace Icinga\Application\Hook;
 
 use Icinga\User;
-use Icinga\Web\Hook;
 use Icinga\Application\Logger;
 use Throwable;
 
@@ -64,8 +63,7 @@ abstract class AuthenticationHook
      */
     public static function triggerAuthFromSession(User $user): void
     {
-        /** @var static $hook */
-        foreach (Hook::all(self::NAME) as $hook) {
+        foreach (static::all() as $hook) {
             try {
                 $hook->onAuthFromSession($user);
             } catch (Throwable $e) {
@@ -82,8 +80,7 @@ abstract class AuthenticationHook
      */
     public static function triggerLogin(User $user)
     {
-        /** @var AuthenticationHook $hook */
-        foreach (Hook::all(self::NAME) as $hook) {
+        foreach (static::all() as $hook) {
             try {
                 $hook->onLogin($user);
             } catch (\Exception $e) {
@@ -100,8 +97,7 @@ abstract class AuthenticationHook
      */
     public static function triggerLogout(User $user)
     {
-        /** @var AuthenticationHook $hook */
-        foreach (Hook::all(self::NAME) as $hook) {
+        foreach (static::all() as $hook) {
             try {
                 $hook->onLogout($user);
             } catch (\Exception $e) {

--- a/library/Icinga/Application/Hook/AuthenticationHook.php
+++ b/library/Icinga/Application/Hook/AuthenticationHook.php
@@ -18,10 +18,17 @@ use Throwable;
  */
 abstract class AuthenticationHook
 {
+    use Essentials;
+
     /**
      * Name of the hook
      */
     const NAME = 'authentication';
+
+    protected static function getHookName(): string
+    {
+        return static::NAME;
+    }
 
     /**
      * Triggered after login in Icinga Web and when calling login action

--- a/library/Icinga/Application/Hook/ConfigFormEventsHook.php
+++ b/library/Icinga/Application/Hook/ConfigFormEventsHook.php
@@ -102,14 +102,13 @@ abstract class ConfigFormEventsHook
     {
         self::$lastErrors = [];
 
-        if (! Hook::has('ConfigFormEvents')) {
+        if (! static::isRegistered()) {
             return true;
         }
 
         $success = true;
 
-        foreach (Hook::all('ConfigFormEvents') as $hook) {
-            /** @var self $hook */
+        foreach (static::all() as $hook) {
             if (! $hook->runAppliesTo($form)) {
                 continue;
             }

--- a/library/Icinga/Application/Hook/ConfigFormEventsHook.php
+++ b/library/Icinga/Application/Hook/ConfigFormEventsHook.php
@@ -5,7 +5,6 @@
 
 namespace Icinga\Application\Hook;
 
-use Icinga\Application\Hook;
 use Icinga\Application\Logger;
 use Icinga\Exception\IcingaException;
 use Icinga\Web\Form;
@@ -15,8 +14,15 @@ use Icinga\Web\Form;
  */
 abstract class ConfigFormEventsHook
 {
+    use HookEssentials;
+
     /** @var array Array of errors found while processing the form event hooks */
     private static $lastErrors = [];
+
+    final protected static function getHookName(): string
+    {
+        return 'ConfigFormEvents';
+    }
 
     /**
      * Get whether the hook applies to the given config form

--- a/library/Icinga/Application/Hook/ConfigFormEventsHook.php
+++ b/library/Icinga/Application/Hook/ConfigFormEventsHook.php
@@ -15,8 +15,15 @@ use Icinga\Web\Form;
  */
 abstract class ConfigFormEventsHook
 {
+    use Essentials;
+
     /** @var array Array of errors found while processing the form event hooks */
     private static $lastErrors = [];
+
+    protected static function getHookName(): string
+    {
+        return 'ConfigFormEvents';
+    }
 
     /**
      * Get whether the hook applies to the given config form

--- a/library/Icinga/Application/Hook/ConfigFormEventsHook.php
+++ b/library/Icinga/Application/Hook/ConfigFormEventsHook.php
@@ -103,14 +103,13 @@ abstract class ConfigFormEventsHook
     {
         self::$lastErrors = [];
 
-        if (! Hook::has('ConfigFormEvents')) {
+        if (! static::isRegistered()) {
             return true;
         }
 
         $success = true;
 
-        foreach (Hook::all('ConfigFormEvents') as $hook) {
-            /** @var self $hook */
+        foreach (static::all() as $hook) {
             if (! $hook->runAppliesTo($form)) {
                 continue;
             }

--- a/library/Icinga/Application/Hook/DbMigrationHook.php
+++ b/library/Icinga/Application/Hook/DbMigrationHook.php
@@ -35,6 +35,7 @@ use stdClass;
  */
 abstract class DbMigrationHook implements Countable
 {
+    use HookEssentials;
     use Translation;
 
     public const MYSQL_UPGRADE_DIR = 'schema/mysql-upgrades';
@@ -54,6 +55,11 @@ abstract class DbMigrationHook implements Countable
 
     /** @var ?string The current version of this hook */
     protected $version;
+
+    final protected static function getHookName(): string
+    {
+        return 'DbMigration';
+    }
 
     /**
      * Get whether the specified table exists in the given database

--- a/library/Icinga/Application/Hook/DbMigrationHook.php
+++ b/library/Icinga/Application/Hook/DbMigrationHook.php
@@ -35,6 +35,7 @@ use stdClass;
  */
 abstract class DbMigrationHook implements Countable
 {
+    use Essentials;
     use Translation;
 
     public const MYSQL_UPGRADE_DIR = 'schema/mysql-upgrades';
@@ -54,6 +55,11 @@ abstract class DbMigrationHook implements Countable
 
     /** @var ?string The current version of this hook */
     protected $version;
+
+    protected static function getHookName(): string
+    {
+        return 'DbMigration';
+    }
 
     /**
      * Get whether the specified table exists in the given database

--- a/library/Icinga/Application/Hook/Essentials.php
+++ b/library/Icinga/Application/Hook/Essentials.php
@@ -1,0 +1,59 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Icinga\Application\Hook;
+
+use Icinga\Application\Hook;
+
+/**
+ * All hooks are provided and consumed - this trait provides the mechanism
+ */
+trait Essentials
+{
+    /**
+     * Get the name for {@link Hook::register} and {@link Hook::all}
+     */
+    abstract protected static function getHookName(): string;
+
+    /**
+     * Get whether the hook is registered
+     *
+     * @return bool
+     */
+    public static function isRegistered(): bool
+    {
+        return Hook::has(static::getHookName());
+    }
+
+    /**
+     * Get all instances of the hook
+     *
+     * @return static[]
+     */
+    public static function all(): array
+    {
+        return Hook::all(static::getHookName());
+    }
+
+    /**
+     * Get the first hook if any
+     *
+     * @return ?static
+     */
+    public static function first(): ?static
+    {
+        return Hook::first(static::getHookName());
+    }
+
+    /**
+     * Register a hook provider
+     *
+     * @param bool $alwaysRun Whether to always run the hook, without permission check
+     */
+    public static function register(bool $alwaysRun = false): void
+    {
+        Hook::register(static::getHookName(), static::class, static::class, $alwaysRun);
+    }
+}

--- a/library/Icinga/Application/Hook/GrapherHook.php
+++ b/library/Icinga/Application/Hook/GrapherHook.php
@@ -16,6 +16,8 @@ use Icinga\Module\Monitoring\Object\MonitoredObject;
  */
 abstract class GrapherHook extends WebBaseHook
 {
+    use HookEssentials;
+
     /**
      * Whether this grapher provides previews
      *
@@ -29,6 +31,11 @@ abstract class GrapherHook extends WebBaseHook
      * @var bool
      */
     protected $hasTinyPreviews = false;
+
+    final protected static function getHookName(): string
+    {
+        return 'grapher';
+    }
 
     /**
      * Constructor must live without arguments right now

--- a/library/Icinga/Application/Hook/GrapherHook.php
+++ b/library/Icinga/Application/Hook/GrapherHook.php
@@ -16,6 +16,8 @@ use Icinga\Module\Monitoring\Object\MonitoredObject;
  */
 abstract class GrapherHook extends WebBaseHook
 {
+    use Essentials;
+
     /**
      * Whether this grapher provides previews
      *
@@ -29,6 +31,11 @@ abstract class GrapherHook extends WebBaseHook
      * @var bool
      */
     protected $hasTinyPreviews = false;
+
+    protected static function getHookName(): string
+    {
+        return 'grapher';
+    }
 
     /**
      * Constructor must live without arguments right now

--- a/library/Icinga/Application/Hook/HealthHook.php
+++ b/library/Icinga/Application/Hook/HealthHook.php
@@ -15,6 +15,8 @@ use LogicException;
 
 abstract class HealthHook
 {
+    use HookEssentials;
+
     /** @var int */
     const STATE_OK = 0;
 
@@ -38,6 +40,11 @@ abstract class HealthHook
 
     /** @var Url Url to a graphical representation of the available metrics */
     protected $url;
+
+    final protected static function getHookName(): string
+    {
+        return 'health';
+    }
 
     /**
      * Get overall state

--- a/library/Icinga/Application/Hook/HealthHook.php
+++ b/library/Icinga/Application/Hook/HealthHook.php
@@ -6,7 +6,6 @@
 namespace Icinga\Application\Hook;
 
 use Exception;
-use Icinga\Application\Hook;
 use Icinga\Application\Logger;
 use Icinga\Data\DataArray\ArrayDatasource;
 use Icinga\Exception\IcingaException;
@@ -150,9 +149,7 @@ abstract class HealthHook
     final public static function collectHealthData()
     {
         $checks = [];
-        foreach (Hook::all('health') as $hook) {
-            /** @var self $hook */
-
+        foreach (static::all() as $hook) {
             try {
                 $hook->checkHealth();
                 $url = $hook->getUrl();

--- a/library/Icinga/Application/Hook/HealthHook.php
+++ b/library/Icinga/Application/Hook/HealthHook.php
@@ -15,6 +15,8 @@ use LogicException;
 
 abstract class HealthHook
 {
+    use Essentials;
+
     /** @var int */
     const STATE_OK = 0;
 
@@ -38,6 +40,11 @@ abstract class HealthHook
 
     /** @var Url Url to a graphical representation of the available metrics */
     protected $url;
+
+    protected static function getHookName(): string
+    {
+        return 'health';
+    }
 
     /**
      * Get overall state

--- a/library/Icinga/Application/Hook/HookEssentials.php
+++ b/library/Icinga/Application/Hook/HookEssentials.php
@@ -1,0 +1,61 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Icinga\Application\Hook;
+
+use Icinga\Application\Hook;
+
+/**
+ * Provides the mechanism for hook registration and retrieval
+ */
+trait HookEssentials
+{
+    /**
+     * Get the name that identifies this hook type
+     *
+     * @return string
+     */
+    abstract protected static function getHookName(): string;
+
+    /**
+     * Get whether the hook is registered
+     *
+     * @return bool
+     */
+    public static function isRegistered(): bool
+    {
+        return Hook::has(static::getHookName());
+    }
+
+    /**
+     * Get all instances of the hook
+     *
+     * @return static[]
+     */
+    public static function all(): array
+    {
+        return Hook::all(static::getHookName());
+    }
+
+    /**
+     * Get the first hook if any
+     *
+     * @return ?static
+     */
+    public static function first(): ?static
+    {
+        return Hook::first(static::getHookName());
+    }
+
+    /**
+     * Register the hook
+     *
+     * @param bool $alwaysRun Whether to always run the hook, without permission check
+     */
+    public static function register(bool $alwaysRun = false): void
+    {
+        Hook::register(static::getHookName(), static::class, static::class, $alwaysRun);
+    }
+}

--- a/library/Icinga/Application/Hook/HookEssentials.php
+++ b/library/Icinga/Application/Hook/HookEssentials.php
@@ -52,10 +52,26 @@ trait HookEssentials
     /**
      * Register the hook
      *
-     * @param bool $alwaysRun Whether to always run the hook, without permission check
+     * @param ?bool $alwaysRun Whether to always run the hook without permission check.
+     *   Defaults to {@see isAlwaysRun()}.
      */
-    public static function register(bool $alwaysRun = false): void
+    public static function register(?bool $alwaysRun = null): void
     {
-        Hook::register(static::getHookName(), static::class, static::class, $alwaysRun);
+        Hook::register(
+            static::getHookName(),
+            static::class,
+            static::class,
+            $alwaysRun ?? static::isAlwaysRun()
+        );
+    }
+
+    /**
+     * Get whether the hook always runs without a permission check
+     *
+     * Override this in a hook base class to change the default.
+     */
+    protected static function isAlwaysRun(): bool
+    {
+        return false;
     }
 }

--- a/library/Icinga/Application/Hook/HookEssentials.php
+++ b/library/Icinga/Application/Hook/HookEssentials.php
@@ -5,7 +5,10 @@
 
 namespace Icinga\Application\Hook;
 
+use Icinga\Application\ClassLoader;
 use Icinga\Application\Hook;
+use Icinga\Application\Icinga;
+use Icinga\Application\Modules\Module;
 
 /**
  * Provides the mechanism for hook registration and retrieval
@@ -47,6 +50,24 @@ trait HookEssentials
     public static function first(): ?static
     {
         return Hook::first(static::getHookName());
+    }
+
+    /**
+     * Get the module this hook belongs to, if any
+     *
+     * Returns null when the hook class is not part of a module namespace.
+     *
+     * @return ?Module
+     */
+    public function getModule(): ?Module
+    {
+        if (! ClassLoader::classBelongsToModule(static::class)) {
+            return null;
+        }
+
+        $moduleName = ClassLoader::extractModuleName(static::class);
+
+        return Icinga::app()->getModuleManager()->getModule($moduleName);
     }
 
     /**

--- a/library/Icinga/Application/Hook/LoginButtonHook.php
+++ b/library/Icinga/Application/Hook/LoginButtonHook.php
@@ -16,8 +16,19 @@ use Icinga\Authentication\LoginButton;
  */
 abstract class LoginButtonHook
 {
-    use HookEssentials {
-        register as protected parentRegister;
+    use HookEssentials;
+
+    /**
+     * Always runs without a permission check
+     *
+     * Login button hooks are intended to render on the login page, where
+     * permissions are not applicable.
+     *
+     * @return bool
+     */
+    protected static function isAlwaysRun(): bool
+    {
+        return true;
     }
 
     final protected static function getHookName(): string
@@ -34,14 +45,4 @@ abstract class LoginButtonHook
      * @return LoginButton[]
      */
     abstract public function getButtons(): array;
-
-    /**
-     * Register a hook provider
-     *
-     * Always runs the hook, without permission check. Latter makes no sense on the login page.
-     */
-    public static function register(): void
-    {
-        static::parentRegister(true);
-    }
 }

--- a/library/Icinga/Application/Hook/LoginButtonHook.php
+++ b/library/Icinga/Application/Hook/LoginButtonHook.php
@@ -5,7 +5,6 @@
 
 namespace Icinga\Application\Hook;
 
-use Icinga\Application\Hook;
 use Icinga\Authentication\LoginButton;
 
 /**
@@ -17,6 +16,15 @@ use Icinga\Authentication\LoginButton;
  */
 abstract class LoginButtonHook
 {
+    use HookEssentials {
+        register as protected parentRegister;
+    }
+
+    final protected static function getHookName(): string
+    {
+        return 'LoginButton';
+    }
+
     /**
      * Get the buttons to display below the login form
      *
@@ -28,22 +36,12 @@ abstract class LoginButtonHook
     abstract public function getButtons(): array;
 
     /**
-     * Get all registered implementations
+     * Register a hook provider
      *
-     * @return static[]
-     */
-    public static function all(): array
-    {
-        return Hook::all('LoginButton');
-    }
-
-    /**
-     * Register the class as a LoginButton hook implementation
-     *
-     * Call this method on your implementation during module initialization to make Icinga Web aware of your hook.
+     * Always runs the hook, without permission check. Latter makes no sense on the login page.
      */
     public static function register(): void
     {
-        Hook::register('LoginButton', static::class, static::class, true);
+        static::parentRegister(true);
     }
 }

--- a/library/Icinga/Application/Hook/LoginButtonHook.php
+++ b/library/Icinga/Application/Hook/LoginButtonHook.php
@@ -17,6 +17,15 @@ use Icinga\Authentication\LoginButton;
  */
 abstract class LoginButtonHook
 {
+    use Essentials {
+        register as protected parentRegister;
+    }
+
+    protected static function getHookName(): string
+    {
+        return 'LoginButton';
+    }
+
     /**
      * Get the buttons to display below the login form
      *
@@ -28,22 +37,12 @@ abstract class LoginButtonHook
     abstract public function getButtons(): array;
 
     /**
-     * Get all registered implementations
+     * Register a hook provider
      *
-     * @return static[]
-     */
-    public static function all(): array
-    {
-        return Hook::all('LoginButton');
-    }
-
-    /**
-     * Register the class as a LoginButton hook implementation
-     *
-     * Call this method on your implementation during module initialization to make Icinga Web aware of your hook.
+     * Always runs the hook, without permission check. Latter makes no sense on the login page.
      */
     public static function register(): void
     {
-        Hook::register('LoginButton', static::class, static::class, true);
+        static::parentRegister(true);
     }
 }

--- a/library/Icinga/Application/Hook/PdfexportHook.php
+++ b/library/Icinga/Application/Hook/PdfexportHook.php
@@ -10,6 +10,13 @@ namespace Icinga\Application\Hook;
  */
 abstract class PdfexportHook
 {
+    use HookEssentials;
+
+    final protected static function getHookName(): string
+    {
+        return 'Pdfexport';
+    }
+
     /**
      * Get whether PDF export is supported
      *

--- a/library/Icinga/Application/Hook/PdfexportHook.php
+++ b/library/Icinga/Application/Hook/PdfexportHook.php
@@ -10,6 +10,13 @@ namespace Icinga\Application\Hook;
  */
 abstract class PdfexportHook
 {
+    use Essentials;
+
+    protected static function getHookName(): string
+    {
+        return 'Pdfexport';
+    }
+
     /**
      * Get whether PDF export is supported
      *

--- a/library/Icinga/Application/Hook/RequestHook.php
+++ b/library/Icinga/Application/Hook/RequestHook.php
@@ -11,8 +11,19 @@ use Throwable;
 
 abstract class RequestHook
 {
-    use HookEssentials {
-        register as protected parentRegister;
+    use HookEssentials;
+
+    /**
+     * Always runs without a permission check
+     *
+     * Request hooks are system-level concerns that fire on every request as
+     * part of the framework dispatch cycle, independent of user permissions.
+     *
+     * @return bool
+     */
+    protected static function isAlwaysRun(): bool
+    {
+        return true;
     }
 
     final protected static function getHookName(): string
@@ -45,15 +56,5 @@ abstract class RequestHook
                 Logger::error('Failed to execute hook on request: %s', $e);
             }
         }
-    }
-
-    /**
-     * Register the class as a RequestHook implementation
-     *
-     * Call this method on your implementation during module initialization to make Icinga Web aware of your hook.
-     */
-    public static function register(): void
-    {
-        static::parentRegister(true);
     }
 }

--- a/library/Icinga/Application/Hook/RequestHook.php
+++ b/library/Icinga/Application/Hook/RequestHook.php
@@ -5,13 +5,21 @@
 
 namespace Icinga\Application\Hook;
 
-use Icinga\Application\Hook;
 use Icinga\Application\Logger;
 use Icinga\Web\Request;
 use Throwable;
 
 abstract class RequestHook
 {
+    use HookEssentials {
+        register as protected parentRegister;
+    }
+
+    final protected static function getHookName(): string
+    {
+        return 'RequestHook';
+    }
+
     /**
      * Triggered after a request has been dispatched
      *
@@ -40,22 +48,12 @@ abstract class RequestHook
     }
 
     /**
-     * Get all registered implementations
-     *
-     * @return static[]
-     */
-    public static function all(): array
-    {
-        return Hook::all('RequestHook');
-    }
-
-    /**
      * Register the class as a RequestHook implementation
      *
      * Call this method on your implementation during module initialization to make Icinga Web aware of your hook.
      */
     public static function register(): void
     {
-        Hook::register('RequestHook', static::class, static::class, true);
+        static::parentRegister(true);
     }
 }

--- a/library/Icinga/Application/Hook/RequestHook.php
+++ b/library/Icinga/Application/Hook/RequestHook.php
@@ -12,6 +12,15 @@ use Throwable;
 
 abstract class RequestHook
 {
+    use Essentials {
+        register as protected parentRegister;
+    }
+
+    protected static function getHookName(): string
+    {
+        return 'RequestHook';
+    }
+
     /**
      * Triggered after a request has been dispatched
      *
@@ -40,22 +49,12 @@ abstract class RequestHook
     }
 
     /**
-     * Get all registered implementations
-     *
-     * @return static[]
-     */
-    public static function all(): array
-    {
-        return Hook::all('RequestHook');
-    }
-
-    /**
      * Register the class as a RequestHook implementation
      *
      * Call this method on your implementation during module initialization to make Icinga Web aware of your hook.
      */
     public static function register(): void
     {
-        Hook::register('RequestHook', static::class, static::class, true);
+        static::parentRegister(true);
     }
 }

--- a/library/Icinga/Application/Hook/ThemeLoaderHook.php
+++ b/library/Icinga/Application/Hook/ThemeLoaderHook.php
@@ -13,6 +13,13 @@ namespace Icinga\Application\Hook;
  */
 abstract class ThemeLoaderHook
 {
+    use HookEssentials;
+
+    final protected static function getHookName(): string
+    {
+        return 'ThemeLoader';
+    }
+
     /**
      * Get the path for the given theme
      *

--- a/library/Icinga/Application/Hook/ThemeLoaderHook.php
+++ b/library/Icinga/Application/Hook/ThemeLoaderHook.php
@@ -13,6 +13,13 @@ namespace Icinga\Application\Hook;
  */
 abstract class ThemeLoaderHook
 {
+    use Essentials;
+
+    protected static function getHookName(): string
+    {
+        return 'ThemeLoader';
+    }
+
     /**
      * Get the path for the given theme
      *

--- a/library/Icinga/Application/Hook/TicketHook.php
+++ b/library/Icinga/Application/Hook/TicketHook.php
@@ -19,12 +19,19 @@ use Icinga\Exception\IcingaException;
  */
 abstract class TicketHook
 {
+    use HookEssentials;
+
     /**
      * Last error, if any
      *
      * @var string|null
      */
     protected $lastError;
+
+    final protected static function getHookName(): string
+    {
+        return 'ticket';
+    }
 
     /**
      * Create a new ticket hook

--- a/library/Icinga/Application/Hook/TicketHook.php
+++ b/library/Icinga/Application/Hook/TicketHook.php
@@ -19,12 +19,19 @@ use Icinga\Exception\IcingaException;
  */
 abstract class TicketHook
 {
+    use Essentials;
+
     /**
      * Last error, if any
      *
      * @var string|null
      */
     protected $lastError;
+
+    protected static function getHookName(): string
+    {
+        return 'ticket';
+    }
 
     /**
      * Create a new ticket hook

--- a/library/Icinga/Application/MigrationManager.php
+++ b/library/Icinga/Application/MigrationManager.php
@@ -302,8 +302,7 @@ final class MigrationManager implements Countable
     {
         $this->pendingMigrations = [];
 
-        /** @var DbMigrationHook $hook */
-        foreach (Hook::all('DbMigration') as $hook) {
+        foreach (DbMigrationHook::all() as $hook) {
             if (empty($hook->getMigrations())) {
                 continue;
             }

--- a/library/Icinga/Application/Modules/Module.php
+++ b/library/Icinga/Application/Modules/Module.php
@@ -1432,6 +1432,8 @@ class Module
      * @param   bool    $alwaysRun      To run the hook always (e.g. without permission check)
      *
      * @return  $this
+     *
+     * @deprecated Use {@link Hook\HookEssentials::register} instead
      */
     protected function provideHook($name, $implementation = null, $alwaysRun = false)
     {

--- a/library/Icinga/Application/Modules/Module.php
+++ b/library/Icinga/Application/Modules/Module.php
@@ -1432,6 +1432,8 @@ class Module
      * @param   bool    $alwaysRun      To run the hook always (e.g. without permission check)
      *
      * @return  $this
+     *
+     * @deprecated Use {@link Hook\Essentials::register} instead
      */
     protected function provideHook($name, $implementation = null, $alwaysRun = false)
     {

--- a/library/Icinga/File/Pdf.php
+++ b/library/Icinga/File/Pdf.php
@@ -8,11 +8,11 @@ namespace Icinga\File;
 use Dompdf\Dompdf;
 use Dompdf\Options;
 use Exception;
+use Icinga\Application\Hook\PdfexportHook;
 use Icinga\Application\Icinga;
 use Icinga\Exception\ProgrammingError;
 use Icinga\Util\Environment;
 use Icinga\Web\FileCache;
-use Icinga\Web\Hook;
 use Icinga\Web\Url;
 
 class Pdf
@@ -56,8 +56,8 @@ class Pdf
 
         $request = $controller->getRequest();
 
-        if (Hook::has('Pdfexport')) {
-            $pdfexport = Hook::first('Pdfexport');
+        if (PdfexportHook::isRegistered()) {
+            $pdfexport = PdfexportHook::first();
             $pdfexport->streamPdfFromHtml($html, sprintf(
                 '%s-%s-%d',
                 $request->getControllerName(),

--- a/library/Icinga/File/Pdf.php
+++ b/library/Icinga/File/Pdf.php
@@ -8,6 +8,7 @@ namespace Icinga\File;
 use Dompdf\Dompdf;
 use Dompdf\Options;
 use Exception;
+use Icinga\Application\Hook\PdfexportHook;
 use Icinga\Application\Icinga;
 use Icinga\Exception\ProgrammingError;
 use Icinga\Util\Environment;
@@ -56,7 +57,7 @@ class Pdf
 
         $request = $controller->getRequest();
 
-        if (Hook::has('Pdfexport')) {
+        if (PdfexportHook::isRegistered()) {
             $pdfexport = Hook::first('Pdfexport');
             $pdfexport->streamPdfFromHtml($html, sprintf(
                 '%s-%s-%d',

--- a/library/Icinga/Web/StyleSheet.php
+++ b/library/Icinga/Web/StyleSheet.php
@@ -6,6 +6,7 @@
 namespace Icinga\Web;
 
 use Exception;
+use Icinga\Application\Hook\ThemeLoaderHook;
 use Icinga\Application\Icinga;
 use Icinga\Application\Logger;
 use Icinga\Authentication\Auth;
@@ -309,9 +310,9 @@ class StyleSheet
         $app = Icinga::app();
 
         if ($theme && $theme !== self::DEFAULT_THEME) {
-            if (Hook::has('ThemeLoader')) {
+            if (ThemeLoaderHook::isRegistered()) {
                 try {
-                    $path = Hook::first('ThemeLoader')->getThemeFile($theme);
+                    $path = ThemeLoaderHook::first()->getThemeFile($theme);
                 } catch (Exception $e) {
                     Logger::error('Failed to call ThemeLoader hook: %s', $e);
                     $path = null;

--- a/library/Icinga/Web/StyleSheet.php
+++ b/library/Icinga/Web/StyleSheet.php
@@ -6,6 +6,7 @@
 namespace Icinga\Web;
 
 use Exception;
+use Icinga\Application\Hook\ThemeLoaderHook;
 use Icinga\Application\Icinga;
 use Icinga\Application\Logger;
 use Icinga\Authentication\Auth;
@@ -313,7 +314,7 @@ class StyleSheet
         $app = Icinga::app();
 
         if ($theme && $theme !== self::DEFAULT_THEME) {
-            if (Hook::has('ThemeLoader')) {
+            if (ThemeLoaderHook::isRegistered()) {
                 try {
                     $path = Hook::first('ThemeLoader')->getThemeFile($theme);
                 } catch (Exception $e) {

--- a/library/Icinga/Web/Widget/Tabextension/OutputFormat.php
+++ b/library/Icinga/Web/Widget/Tabextension/OutputFormat.php
@@ -5,6 +5,7 @@
 
 namespace Icinga\Web\Widget\Tabextension;
 
+use Icinga\Application\Hook\PdfexportHook;
 use Icinga\Application\Platform;
 use Icinga\Application\Hook;
 use Icinga\Web\Url;
@@ -84,7 +85,7 @@ class OutputFormat implements Tabextension
     {
         $supportedTypes = array();
 
-        $pdfexport = Hook::has('Pdfexport');
+        $pdfexport = PdfexportHook::isRegistered();
 
         if ($pdfexport || Platform::extensionLoaded('gd')) {
             $supportedTypes[self::TYPE_PDF] = array(


### PR DESCRIPTION
Introduce `Icinga\Application\Hook\HookEssentials` as the shared API for hook base classes to register and retrieve hook implementations through their own type.

This moves existing core hook classes to methods such as `register()`, `all()`, `first()`, and `isRegistered()`, while keeping the underlying hook registry behavior unchanged.

The new trait centralizes common hook behavior and lets hook base classes define their registry name once through `getHookName()`. It also adds `getModule()` for hook implementations that belong to a module namespace.

Existing direct uses of `Hook::has()`, `Hook::all()`, `Hook::first()`, and `Hook::register()` are replaced where a typed hook base class is available. The old low-level APIs and `Module::provideHook()` are marked as deprecated in favor of `Hook\HookEssentials`.