### PR TITLE
Introduce missing `first` and `htmlToPdf` methods to `PdfexportHook`

### DIFF
--- a/library/Icinga/Application/Hook/PdfexportHook.php
+++ b/library/Icinga/Application/Hook/PdfexportHook.php
@@ -7,6 +7,7 @@ namespace Icinga\Application\Hook;
 
 use Icinga\Application\Hook;
 use Icinga\Application\Logger;
+use ipl\Html\ValidHtml;
 use RuntimeException;
 use Throwable;
 
@@ -44,15 +45,17 @@ abstract class PdfexportHook
     /**
      * Get whether PDF export is supported
      *
-     * @return  bool
+     * @return bool
      */
     abstract public function isSupported();
 
     /**
      * Render the specified HTML to PDF and stream it to the client
      *
-     * @param   string  $html       The HTML to render to PDF
-     * @param   string  $filename   The filename for the generated PDF
+     * @param ValidHtml $html The HTML to render to PDF
+     * @param string $filename The filename for the generated PDF
+     *
+     * @return never
      */
     abstract public function streamPdfFromHtml($html, $filename);
 

--- a/library/Icinga/Application/Hook/PdfexportHook.php
+++ b/library/Icinga/Application/Hook/PdfexportHook.php
@@ -29,11 +29,9 @@ abstract class PdfexportHook
 
         foreach (Hook::all('Pdfexport') as $exporter) {
             try {
-                if (! $exporter->isSupported()) {
-                    continue;
+                if ($exporter->isSupported()) {
+                    return $exporter;
                 }
-
-                return $exporter;
             } catch (Throwable $e) {
                 Logger::error('PDF exporter reported an error during support check: %s', $e);
             }

--- a/library/Icinga/Application/Hook/PdfexportHook.php
+++ b/library/Icinga/Application/Hook/PdfexportHook.php
@@ -7,6 +7,7 @@ namespace Icinga\Application\Hook;
 
 use Icinga\Application\Hook;
 use Icinga\Application\Logger;
+use Icinga\Exception\IcingaException;
 use ipl\Html\ValidHtml;
 use RuntimeException;
 use Throwable;
@@ -23,21 +24,18 @@ abstract class PdfexportHook
      */
     public static function first()
     {
-        if (! Hook::has('Pdfexport')) {
-            throw new RuntimeException('No PDF exporter available');
-        }
-
         foreach (Hook::all('Pdfexport') as $exporter) {
             try {
                 if ($exporter->isSupported()) {
                     return $exporter;
                 }
             } catch (Throwable $e) {
-                Logger::error('PDF exporter reported an error during support check: %s', $e);
+                Logger::error('PDF exporter reported an error during support check: %s', $e->getMessage());
+                Logger::error("%s\n%s", $e, IcingaException::getConfidentialTraceAsString($e));
             }
         }
 
-        throw new RuntimeException('Not supported PDF exporter available');
+        throw new RuntimeException('No supported PDF exporter available');
     }
 
     /**

--- a/library/Icinga/Application/Hook/PdfexportHook.php
+++ b/library/Icinga/Application/Hook/PdfexportHook.php
@@ -54,4 +54,13 @@ abstract class PdfexportHook
      * @param   string  $filename   The filename for the generated PDF
      */
     abstract public function streamPdfFromHtml($html, $filename);
+
+    /**
+     * Render the specified HTML to PDF and return the PDF document as a string
+     *
+     * @param ValidHtml $html The HTML to render to PDF
+     *
+     * @return string
+     */
+    abstract public function htmlToPdf($html);
 }

--- a/library/Icinga/Application/Hook/PdfexportHook.php
+++ b/library/Icinga/Application/Hook/PdfexportHook.php
@@ -8,6 +8,7 @@ namespace Icinga\Application\Hook;
 use Icinga\Application\Hook;
 use Icinga\Application\Logger;
 use Icinga\Exception\IcingaException;
+use ipl\Html\ValidHtml;
 use RuntimeException;
 use Throwable;
 
@@ -43,15 +44,17 @@ abstract class PdfexportHook
     /**
      * Get whether PDF export is supported
      *
-     * @return  bool
+     * @return bool
      */
     abstract public function isSupported();
 
     /**
      * Render the specified HTML to PDF and stream it to the client
      *
-     * @param   string  $html       The HTML to render to PDF
-     * @param   string  $filename   The filename for the generated PDF
+     * @param ValidHtml $html The HTML to render to PDF
+     * @param string $filename The filename for the generated PDF
+     *
+     * @return never
      */
     abstract public function streamPdfFromHtml($html, $filename);
 

--- a/library/Icinga/Application/Hook/PdfexportHook.php
+++ b/library/Icinga/Application/Hook/PdfexportHook.php
@@ -5,16 +5,39 @@
 
 namespace Icinga\Application\Hook;
 
+use Icinga\Application\Hook;
+use Icinga\Application\Logger;
+use Icinga\Exception\IcingaException;
+use RuntimeException;
+use Throwable;
+
 /**
  * Base class for the PDF Export Hook
  */
 abstract class PdfexportHook
 {
-    use HookEssentials;
-
-    final protected static function getHookName(): string
+    /**
+     * Get the first hook that supports PDF export
+     *
+     * @return static
+     */
+    public static function first()
     {
-        return 'Pdfexport';
+        foreach (Hook::all('Pdfexport') as $exporter) {
+            try {
+                if ($exporter->isSupported()) {
+                    return $exporter;
+                }
+            } catch (Throwable $e) {
+                Logger::error(
+                    "PDF exporter reported an error during support check: %s\n%s",
+                    $e,
+                    IcingaException::getConfidentialTraceAsString($e),
+                );
+            }
+        }
+
+        throw new RuntimeException('No supported PDF exporter available');
     }
 
     /**

--- a/library/Icinga/Application/Hook/PdfexportHook.php
+++ b/library/Icinga/Application/Hook/PdfexportHook.php
@@ -5,11 +5,42 @@
 
 namespace Icinga\Application\Hook;
 
+use Icinga\Application\Hook;
+use Icinga\Application\Logger;
+use RuntimeException;
+use Throwable;
+
 /**
  * Base class for the PDF Export Hook
  */
 abstract class PdfexportHook
 {
+    /**
+     * Get the first hook
+     *
+     * @return static
+     */
+    public static function first()
+    {
+        if (! Hook::has('Pdfexport')) {
+            throw new RuntimeException('No PDF exporter available');
+        }
+
+        foreach (Hook::all('Pdfexport') as $exporter) {
+            try {
+                if (! $exporter->isSupported()) {
+                    continue;
+                }
+
+                return $exporter;
+            } catch (Throwable $e) {
+                Logger::error('PDF exporter reported an error during support check: %s', $e);
+            }
+        }
+
+        throw new RuntimeException('Not supported PDF exporter available');
+    }
+
     /**
      * Get whether PDF export is supported
      *

--- a/library/Icinga/Application/Hook/PdfexportHook.php
+++ b/library/Icinga/Application/Hook/PdfexportHook.php
@@ -55,4 +55,13 @@ abstract class PdfexportHook
      * @param   string  $filename   The filename for the generated PDF
      */
     abstract public function streamPdfFromHtml($html, $filename);
+
+    /**
+     * Render the specified HTML to PDF and return the PDF document as a string
+     *
+     * @param ValidHtml $html The HTML to render to PDF
+     *
+     * @return string
+     */
+    abstract public function htmlToPdf($html);
 }

--- a/library/Icinga/Application/Hook/PdfexportHook.php
+++ b/library/Icinga/Application/Hook/PdfexportHook.php
@@ -30,8 +30,11 @@ abstract class PdfexportHook
                     return $exporter;
                 }
             } catch (Throwable $e) {
-                Logger::error('PDF exporter reported an error during support check: %s', $e->getMessage());
-                Logger::error("%s\n%s", $e, IcingaException::getConfidentialTraceAsString($e));
+                Logger::error(
+                    "PDF exporter reported an error during support check: %s\n%s",
+                    $e,
+                    IcingaException::getConfidentialTraceAsString($e),
+                );
             }
         }
 

--- a/library/Icinga/Common/PdfExport.php
+++ b/library/Icinga/Common/PdfExport.php
@@ -5,7 +5,6 @@
 
 namespace Icinga\Common;
 
-use Icinga\Application\Hook;
 use Icinga\Application\Hook\PdfexportHook;
 use Icinga\Application\Icinga;
 use Icinga\Date\DateFormatter;

--- a/library/Icinga/Common/PdfExport.php
+++ b/library/Icinga/Common/PdfExport.php
@@ -5,6 +5,7 @@
 
 namespace Icinga\Common;
 
+use Icinga\Application\Hook\PdfexportHook;
 use Icinga\Application\Icinga;
 use Icinga\Date\DateFormatter;
 use Icinga\Exception\ConfigurationError;
@@ -26,7 +27,8 @@ trait PdfExport
      * Export the requested action to PDF and send it
      *
      * @return never
-     * @throws ConfigurationError If the pdfexport module is not available
+     *
+     * @throws ConfigurationError If no pdfexport module is available
      */
     protected function sendAsPdf()
     {
@@ -71,7 +73,7 @@ trait PdfExport
             $doc->getAttributes()->add('class', 'icinga-module module-' . $moduleName);
         }
 
-        \Icinga\Module\Pdfexport\ProvidedHook\Pdfexport::first()->streamPdfFromHtml($doc, sprintf(
+        PdfexportHook::first()->streamPdfFromHtml($doc, sprintf(
             '%s-%s',
             $this->view->title ?: $this->getRequest()->getActionName(),
             $time

--- a/library/Icinga/Common/PdfExport.php
+++ b/library/Icinga/Common/PdfExport.php
@@ -5,6 +5,8 @@
 
 namespace Icinga\Common;
 
+use Icinga\Application\Hook;
+use Icinga\Application\Hook\PdfexportHook;
 use Icinga\Application\Icinga;
 use Icinga\Date\DateFormatter;
 use Icinga\Exception\ConfigurationError;
@@ -26,7 +28,8 @@ trait PdfExport
      * Export the requested action to PDF and send it
      *
      * @return never
-     * @throws ConfigurationError If the pdfexport module is not available
+     *
+     * @throws ConfigurationError If no pdfexport module is available
      */
     protected function sendAsPdf()
     {
@@ -71,7 +74,7 @@ trait PdfExport
             $doc->getAttributes()->add('class', 'icinga-module module-' . $moduleName);
         }
 
-        \Icinga\Module\Pdfexport\ProvidedHook\Pdfexport::first()->streamPdfFromHtml($doc, sprintf(
+        PdfexportHook::first()->streamPdfFromHtml($doc, sprintf(
             '%s-%s',
             $this->view->title ?: $this->getRequest()->getActionName(),
             $time


### PR DESCRIPTION
This PR adds two methods to the pdfexport hook: `first` and `htmlToPdf`

Both functions were previously called without actually being part of the hook.
The only possible implementation of this hook comes from the pdfexport module which already defines the same two methods.

Intentionally leaving out strict types and `HookEssentials` to be backward compatible with the original hook implementation.