### PR TITLE
Simplify installation command for Ubuntu

### DIFF
--- a/doc/02-Installation.md
+++ b/doc/02-Installation.md
@@ -231,11 +231,8 @@ apt-get install icingaweb2 icingacli
 #### Ubuntu
 <!-- {% endif %} -->
 ```bash
-apt-get install icingaweb2 libapache2-mod-php icingacli
+apt-get install icingaweb2 icingacli
 ```
-
-The additional package `libapache2-mod-php` is necessary on Ubuntu to automatically
-install a web server and PHP and make Icinga Web 2 work out-of-the-box.
 <!-- {% endif %} -->
 
 <!-- {% if centos or rhel or amazon_linux %} -->


### PR DESCRIPTION
The additional package libapache2-mod-php is already a dependency, hence doesn't have to be specified explicitly.

# Test

✅ `apt-get install --no-install-{recommends,suggests} icingaweb2` will also install `libapache2-mod-php`