### PR TITLE
Revert "Provide `Icinga` to `ipl/web` behaviors (#5238)"

### DIFF
--- a/library/Icinga/Web/JavaScript.php
+++ b/library/Icinga/Web/JavaScript.php
@@ -240,9 +240,8 @@ class JavaScript
         try {
             $dependencies = $match[2] ? Json::decode($match[2]) : [];
             foreach ($dependencies as &$dependencyName) {
-                if ($dependencyName === 'exports' || str_starts_with($dependencyName, 'icinga/legacy-app/')) {
+                if ($dependencyName === 'exports') {
                     // exports is a special keyword and doesn't need optimization
-                    // 'app/legacy-app/...' is a custom-defined path and doesn’t need optimization either.
                     continue;
                 }
 

--- a/public/js/icinga.js
+++ b/public/js/icinga.js
@@ -101,8 +101,6 @@
             this.events     = new Icinga.Events(this);
             this.history    = new Icinga.History(this);
 
-            define("icinga/legacy-app/Icinga", [], () => Icinga);
-
             // Initialize all available behaviors
             for (const name in Icinga.Behaviors) {
                 const behavior = new Icinga.Behaviors[name](this);


### PR DESCRIPTION
This reverts commit 1ee08d61806d4249f18f74afd7b9126cdc12d605.

It's not needed anymore and I don't see a reason to keep this as it's implementation is rather fragile still.