### PR TITLE
Replace `array()` with `[]`

### DIFF
--- a/application/clicommands/AutocompleteCommand.php
+++ b/application/clicommands/AutocompleteCommand.php
@@ -55,7 +55,7 @@ class AutocompleteCommand extends Command
         $search_word = $bare_params[$cword];
         if ($search_word === '--') {
             // TODO: Unfinished, completion missing
-            return $this->suggest(array('--verbose', '--help', '--debug'));
+            return $this->suggest(['--verbose', '--help', '--debug']);
         }
 
         $search = $params->shift();
@@ -68,7 +68,7 @@ class AutocompleteCommand extends Command
         if ($found) {
             // Do not return suggestions if we are already on the next word:
             if ($bare_params[$cword] === $search) {
-                return $this->suggest(array($found));
+                return $this->suggest([$found]);
             }
         } else {
             return $this->suggest($loader->getLastSuggestions());
@@ -90,7 +90,7 @@ class AutocompleteCommand extends Command
             if ($command) {
                 // Do not return suggestions if we are already on the next word:
                 if ($bare_params[$cword] === $search) {
-                    return $this->suggest(array($command));
+                    return $this->suggest([$command]);
                 }
                 $obj = $loader->getModuleCommandInstance(
                     $module,
@@ -112,7 +112,7 @@ class AutocompleteCommand extends Command
             );
             if ($action) {
                 if ($bare_params[$cword] === $search) {
-                    return $this->suggest(array($action));
+                    return $this->suggest([$action]);
                 }
             } else {
                 return $this->suggest($loader->getLastSuggestions());

--- a/application/clicommands/ModuleCommand.php
+++ b/application/clicommands/ModuleCommand.php
@@ -40,7 +40,7 @@ class ModuleCommand extends Command
     public function listAction()
     {
         if ($type = $this->params->shift()) {
-            if (! in_array($type, array('enabled', 'installed'))) {
+            if (! in_array($type, ['enabled', 'installed'])) {
                 return $this->showUsage();
             }
         } else {

--- a/application/controllers/AboutController.php
+++ b/application/controllers/AboutController.php
@@ -19,11 +19,11 @@ class AboutController extends Controller
         $this->view->title = $this->translate('About');
         $this->view->tabs = $this->getTabs()->add(
             'about',
-            array(
+            [
                 'label' => $this->translate('About'),
                 'title' => $this->translate('About Icinga Web 2'),
                 'url'   => 'about'
-            )
+            ]
         )->activate('about');
     }
 }

--- a/application/controllers/AccountController.php
+++ b/application/controllers/AccountController.php
@@ -25,23 +25,23 @@ class AccountController extends Controller
     public function init()
     {
         $this->getTabs()
-            ->add('account', array(
+            ->add('account', [
                 'title' => $this->translate('Update your account'),
                 'label' => $this->translate('My Account'),
                 'url'   => 'account'
-            ))
-            ->add('navigation', array(
+            ])
+            ->add('navigation', [
                 'title' => $this->translate('List and configure your own navigation items'),
                 'label' => $this->translate('Navigation'),
                 'url'   => 'navigation'
-            ))
+            ])
             ->add(
                 'devices',
-                array(
+                [
                     'title' => $this->translate('List of devices you are logged in'),
                     'label' => $this->translate('My Devices'),
                     'url'   => 'my-devices'
-                )
+                ]
             );
     }
 
@@ -72,9 +72,9 @@ class AccountController extends Controller
         $form = new PreferenceForm();
         $form->setPreferences($user->getPreferences());
         if (isset($config->config_resource)) {
-            $form->setStore(PreferencesStore::create(new ConfigObject(array(
-                'resource'  => $config->config_resource
-            )), $user));
+            $form->setStore(PreferencesStore::create(new ConfigObject([
+                'resource' => $config->config_resource
+            ]), $user));
         }
         $form->handleRequest();
 

--- a/application/controllers/AnnouncementsController.php
+++ b/application/controllers/AnnouncementsController.php
@@ -28,12 +28,12 @@ class AnnouncementsController extends Controller
     {
         $this->getTabs()->add(
             'announcements',
-            array(
+            [
                 'active'    => true,
                 'label'     => $this->translate('Announcements'),
                 'title'     => $this->translate('List All Announcements'),
                 'url'       => Url::fromPath('announcements')
-            )
+            ]
         );
 
         $announcements = (new AnnouncementIniRepository())

--- a/application/controllers/ConfigController.php
+++ b/application/controllers/ConfigController.php
@@ -38,30 +38,30 @@ class ConfigController extends Controller
     {
         $tabs = $this->getTabs();
         if ($this->hasPermission('config/general')) {
-            $tabs->add('general', array(
+            $tabs->add('general', [
                 'title' => $this->translate('Adjust the general configuration of Icinga Web 2'),
                 'label' => $this->translate('General'),
                 'url'   => 'config/general',
                 'baseTarget' => '_main'
-            ));
+            ]);
         }
         if ($this->hasPermission('config/resources')) {
-            $tabs->add('resource', array(
+            $tabs->add('resource', [
                 'title' => $this->translate('Configure which resources are being utilized by Icinga Web 2'),
                 'label' => $this->translate('Resources'),
                 'url'   => 'config/resource',
                 'baseTarget' => '_main'
-            ));
+            ]);
         }
         if ($this->hasPermission('config/access-control/users')
             || $this->hasPermission('config/access-control/groups')
         ) {
-            $tabs->add('authentication', array(
+            $tabs->add('authentication', [
                 'title' => $this->translate('Configure the user and group backends'),
                 'label' => $this->translate('Access Control Backends'),
                 'url'   => 'config/userbackend',
                 'baseTarget' => '_main'
-            ));
+            ]);
         }
 
         return $tabs;
@@ -125,11 +125,11 @@ class ConfigController extends Controller
         // Overwrite tabs created in init
         // @TODO(el): This seems not natural to me. Module configuration should have its own controller.
         $this->view->tabs = Widget::create('tabs')
-            ->add('modules', array(
+            ->add('modules', [
                 'label' => $this->translate('Modules'),
                 'title' => $this->translate('List intalled modules'),
                 'url'   => 'config/modules'
-            ))
+            ])
             ->activate('modules');
         $this->view->modules = Icinga::app()->getModuleManager()->select()
             ->from('modules')
@@ -418,10 +418,10 @@ class ConfigController extends Controller
     public function createresourceAction()
     {
         $this->assertPermission('config/resources');
-        $this->getTabs()->add('resources/new', array(
+        $this->getTabs()->add('resources/new', [
             'label' => $this->translate('New Resource'),
             'url'   => Url::fromRequest()
-        ))->activate('resources/new');
+        ])->activate('resources/new');
         $form = new ResourceConfigForm();
         $form->addDescription($this->translate('Resources are entities that provide data to Icinga Web 2.'));
         $form->setIniConfig(Config::app('resources'));
@@ -439,10 +439,10 @@ class ConfigController extends Controller
     public function editresourceAction()
     {
         $this->assertPermission('config/resources');
-        $this->getTabs()->add('resources/update', array(
+        $this->getTabs()->add('resources/update', [
             'label' => $this->translate('Update Resource'),
             'url'   => Url::fromRequest()
-        ))->activate('resources/update');
+        ])->activate('resources/update');
         $form = new ResourceConfigForm();
         $form->setIniConfig(Config::app('resources'));
         $form->setRedirectUrl('config/resource');
@@ -459,11 +459,11 @@ class ConfigController extends Controller
     public function removeresourceAction()
     {
         $this->assertPermission('config/resources');
-        $this->getTabs()->add('resources/remove', array(
+        $this->getTabs()->add('resources/remove', [
             'label' => $this->translate('Remove Resource'),
             'url'   => Url::fromRequest()
-        ))->activate('resources/remove');
-        $form = new ConfirmRemovalForm(array(
+        ])->activate('resources/remove');
+        $form = new ConfirmRemovalForm([
             'onSuccess' => function ($form) {
                 $configForm = new ResourceConfigForm();
                 $configForm->setIniConfig(Config::app('resources'));
@@ -482,7 +482,7 @@ class ConfigController extends Controller
                     return false;
                 }
             }
-        ));
+        ]);
         $form->setRedirectUrl('config/resource');
         $form->handleRequest();
 

--- a/application/controllers/DashboardController.php
+++ b/application/controllers/DashboardController.php
@@ -40,11 +40,11 @@ class DashboardController extends ActionController
     public function newDashletAction()
     {
         $form = new DashletForm();
-        $this->getTabs()->add('new-dashlet', array(
+        $this->getTabs()->add('new-dashlet', [
             'active'    => true,
             'label'     => $this->translate('New Dashlet'),
             'url'       => Url::fromRequest()
-        ));
+        ]);
         $dashboard = $this->dashboard;
         $form->setDashboard($dashboard);
         if ($this->_request->getParam('url')) {
@@ -84,11 +84,11 @@ class DashboardController extends ActionController
 
     public function updateDashletAction()
     {
-        $this->getTabs()->add('update-dashlet', array(
+        $this->getTabs()->add('update-dashlet', [
             'active'    => true,
             'label'     => $this->translate('Update Dashlet'),
             'url'       => Url::fromRequest()
-        ));
+        ]);
         $dashboard = $this->dashboard;
         $form = new DashletForm();
         $form->setDashboard($dashboard);
@@ -149,11 +149,11 @@ class DashboardController extends ActionController
     public function removeDashletAction()
     {
         $form = new ConfirmRemovalForm();
-        $this->getTabs()->add('remove-dashlet', array(
+        $this->getTabs()->add('remove-dashlet', [
             'active'    => true,
             'label'     => $this->translate('Remove Dashlet'),
             'url'       => Url::fromRequest()
-        ));
+        ]);
         $dashboard = $this->dashboard;
         if (! $this->_request->getParam('pane')) {
             throw new Zend_Controller_Action_Exception(
@@ -205,23 +205,23 @@ class DashboardController extends ActionController
         $form->addElement(
             'text',
             'name',
-            array(
+            [
                 'required'  => true,
                 'label'     => $this->translate('Name')
-            )
+            ]
         );
         $form->addElement(
             'text',
             'title',
-            array(
+            [
                 'required'  => true,
                 'label'     => $this->translate('Title')
-            )
+            ]
         );
-        $form->setDefaults(array(
+        $form->setDefaults([
             'name'  => $paneName,
             'title' => $this->dashboard->getPane($paneName)->getTitle()
-        ));
+        ]);
         $form->setOnSuccess(function ($form) use ($paneName) {
             $newName = $form->getValue('name');
             $newTitle = $form->getValue('title');
@@ -241,10 +241,10 @@ class DashboardController extends ActionController
         $this->view->form = $form;
         $this->getTabs()->add(
             'update-pane',
-            array(
+            [
                 'title' => $this->translate('Update Pane'),
                 'url'   => $this->getRequest()->getUrl()
-            )
+            ]
         )->activate('update-pane');
     }
 
@@ -306,11 +306,11 @@ class DashboardController extends ActionController
             );
             if (empty($panes)) {
                 $this->view->title = 'Dashboard';
-                $this->getTabs()->add('dashboard', array(
+                $this->getTabs()->add('dashboard', [
                     'active'    => true,
                     'title'     => $this->translate('Dashboard'),
                     'url'       => Url::fromRequest()
-                ));
+                ]);
             } else {
                 if ($this->_getParam('pane')) {
                     $pane = $this->_getParam('pane');

--- a/application/controllers/ErrorController.php
+++ b/application/controllers/ErrorController.php
@@ -65,7 +65,7 @@ class ErrorController extends ActionController
             case Zend_Controller_Plugin_ErrorHandler::EXCEPTION_NO_CONTROLLER:
             case Zend_Controller_Plugin_ErrorHandler::EXCEPTION_NO_ACTION:
                 $this->getResponse()->setHttpResponseCode(404);
-                $this->view->messages = array($this->translate('Page not found.'));
+                $this->view->messages = [$this->translate('Page not found.')];
                 if ($isAuthenticated) {
                     if ($modules->hasInstalled($moduleName) && ! $modules->hasEnabled($moduleName)) {
                         $this->view->messages[0] .= ' ' . sprintf(
@@ -136,10 +136,10 @@ class ErrorController extends ActionController
                     }
                 }
 
-                $this->view->messages = array();
+                $this->view->messages = [];
 
                 if ($this->getInvokeArg('displayExceptions')) {
-                    $this->view->stackTraces = array();
+                    $this->view->stackTraces = [];
 
                     do {
                         $this->view->messages[] = $exception->getMessage();
@@ -168,11 +168,11 @@ class ErrorController extends ActionController
             $this->view->hideControls = true;
         } else {
             $this->view->hideControls = false;
-            $this->getTabs()->add('error', array(
+            $this->getTabs()->add('error', [
                 'active'    => true,
                 'label'     => $this->translate('Error'),
                 'url'       => Url::fromRequest()
-            ));
+            ]);
         }
     }
 }

--- a/application/controllers/GroupController.php
+++ b/application/controllers/GroupController.php
@@ -55,12 +55,12 @@ class GroupController extends AuthBackendController
         $this->view->backendSelection->addElement(
             'select',
             'backend',
-            array(
+            [
                 'autosubmit'    => true,
                 'label'         => $this->translate('User Group Backend'),
                 'multiOptions'  => array_combine($backendNames, $backendNames),
                 'value'         => $this->params->get('backend')
-            )
+            ]
         );
 
         $backend = $this->getUserGroupBackend($this->params->get('backend'));
@@ -69,7 +69,7 @@ class GroupController extends AuthBackendController
             return;
         }
 
-        $query = $backend->select(array('group_name'));
+        $query = $backend->select(['group_name']);
 
         $this->view->groups = $query;
         $this->view->backend = $backend;
@@ -78,11 +78,11 @@ class GroupController extends AuthBackendController
         $this->setupFilterControl($query);
         $this->setupLimitControl();
         $this->setupSortControl(
-            array(
+            [
                 'group_name'    => $this->translate('User Group'),
                 'created_at'    => $this->translate('Created at'),
                 'last_modified' => $this->translate('Last modified')
-            ),
+            ],
             $query
         );
     }
@@ -96,29 +96,29 @@ class GroupController extends AuthBackendController
         $groupName = $this->params->getRequired('group');
         $backend = $this->getUserGroupBackend($this->params->getRequired('backend'));
 
-        $group = $backend->select(array(
+        $group = $backend->select([
             'group_name',
             'created_at',
             'last_modified'
-        ))->where('group_name', $groupName)->fetchRow();
+        ])->where('group_name', $groupName)->fetchRow();
         if ($group === false) {
             $this->httpNotFound(sprintf($this->translate('Group "%s" not found'), $groupName));
         }
 
         $members = $backend
             ->select()
-            ->from('group_membership', array('user_name'))
+            ->from('group_membership', ['user_name'])
             ->where('group_name', $groupName);
 
-        $this->setupFilterControl($members, null, array('user'), array('group'));
+        $this->setupFilterControl($members, null, ['user'], ['group']);
         $this->setupPaginationControl($members);
         $this->setupLimitControl();
         $this->setupSortControl(
-            array(
+            [
                 'user_name'     => $this->translate('Username'),
                 'created_at'    => $this->translate('Created at'),
                 'last_modified' => $this->translate('Last modified')
-            ),
+            ],
             $members
         );
 
@@ -132,28 +132,28 @@ class GroupController extends AuthBackendController
             $removeForm->setUidDisabled();
             $removeForm->setAttrib('class', 'inline');
             $removeForm->setAction(
-                Url::fromPath('group/removemember', array('backend' => $backend->getName(), 'group' => $groupName))
+                Url::fromPath('group/removemember', ['backend' => $backend->getName(), 'group' => $groupName])
             );
-            $removeForm->addElement('hidden', 'user_name', array(
+            $removeForm->addElement('hidden', 'user_name', [
                 'isArray'       => true,
-                'decorators'    => array('ViewHelper')
-            ));
-            $removeForm->addElement('hidden', 'redirect', array(
-                'value'         => Url::fromPath('group/show', array(
+                'decorators'    => ['ViewHelper']
+            ]);
+            $removeForm->addElement('hidden', 'redirect', [
+                'value'         => Url::fromPath('group/show', [
                     'backend'   => $backend->getName(),
                     'group'     => $groupName
-                )),
-                'decorators'    => array('ViewHelper')
-            ));
-            $removeForm->addElement('button', 'btn_submit', array(
+                ]),
+                'decorators'    => ['ViewHelper']
+            ]);
+            $removeForm->addElement('button', 'btn_submit', [
                 'escape'        => false,
                 'type'          => 'submit',
                 'class'         => 'link-button spinner',
                 'value'         => 'btn_submit',
-                'decorators'    => array('ViewHelper'),
+                'decorators'    => ['ViewHelper'],
                 'label'         => $this->view->icon('cancel'),
                 'title'         => $this->translate('Remove this member')
-            ));
+            ]);
             $this->view->removeForm = $removeForm;
         }
     }
@@ -166,7 +166,7 @@ class GroupController extends AuthBackendController
         $this->assertPermission('config/access-control/groups');
         $backend = $this->getUserGroupBackend($this->params->getRequired('backend'), 'Icinga\Data\Extensible');
         $form = new UserGroupForm();
-        $form->setRedirectUrl(Url::fromPath('group/list', array('backend' => $backend->getName())));
+        $form->setRedirectUrl(Url::fromPath('group/list', ['backend' => $backend->getName()]));
         $form->setRepository($backend);
         $form->add()->handleRequest();
 
@@ -184,7 +184,7 @@ class GroupController extends AuthBackendController
 
         $form = new UserGroupForm();
         $form->setRedirectUrl(
-            Url::fromPath('group/show', array('backend' => $backend->getName(), 'group' => $groupName))
+            Url::fromPath('group/show', ['backend' => $backend->getName(), 'group' => $groupName])
         );
         $form->setRepository($backend);
 
@@ -207,7 +207,7 @@ class GroupController extends AuthBackendController
         $backend = $this->getUserGroupBackend($this->params->getRequired('backend'), 'Icinga\Data\Reducible');
 
         $form = new UserGroupForm();
-        $form->setRedirectUrl(Url::fromPath('group/list', array('backend' => $backend->getName())));
+        $form->setRedirectUrl(Url::fromPath('group/list', ['backend' => $backend->getName()]));
         $form->setRepository($backend);
 
         try {
@@ -233,7 +233,7 @@ class GroupController extends AuthBackendController
             ->setBackend($backend)
             ->setGroupName($groupName)
             ->setRedirectUrl(
-                Url::fromPath('group/show', array('backend' => $backend->getName(), 'group' => $groupName))
+                Url::fromPath('group/show', ['backend' => $backend->getName(), 'group' => $groupName])
             )
             ->setUidDisabled();
 
@@ -256,7 +256,7 @@ class GroupController extends AuthBackendController
         $groupName = $this->params->getRequired('group');
         $backend = $this->getUserGroupBackend($this->params->getRequired('backend'), 'Icinga\Data\Reducible');
 
-        $form = new Form(array(
+        $form = new Form([
             'onSuccess' => function ($form) use ($groupName, $backend) {
                 foreach ($form->getValue('user_name') as $userName) {
                     try {
@@ -286,10 +286,10 @@ class GroupController extends AuthBackendController
 
                 return true;
             }
-        ));
+        ]);
         $form->setUidDisabled();
         $form->setSubmitLabel('btn_submit'); // Required to ensure that isSubmitted() is called
-        $form->addElement('hidden', 'user_name', array('required' => true, 'isArray' => true));
+        $form->addElement('hidden', 'user_name', ['required' => true, 'isArray' => true]);
         $form->addElement('hidden', 'redirect');
 
         try {
@@ -306,7 +306,7 @@ class GroupController extends AuthBackendController
      */
     protected function fetchUsers()
     {
-        $users = array();
+        $users = [];
         foreach ($this->loadUserBackends('Icinga\Data\Selectable') as $backend) {
             try {
                 if ($backend instanceof DomainAwareInterface) {
@@ -314,7 +314,7 @@ class GroupController extends AuthBackendController
                 } else {
                     $domain = null;
                 }
-                foreach ($backend->select(array('user_name')) as $user) {
+                foreach ($backend->select(['user_name']) as $user) {
                     $userObj = new User($user->user_name);
                     if ($domain !== null) {
                         if ($userObj->hasDomain() && $userObj->getDomain() !== $domain) {
@@ -354,11 +354,11 @@ class GroupController extends AuthBackendController
         $tabs = $this->getTabs();
         $tabs->add(
             'group/show',
-            array(
+            [
                 'title'     => sprintf($this->translate('Show group %s'), $groupName),
                 'label'     => $this->translate('Group'),
-                'url'       => Url::fromPath('group/show', array('backend' => $backendName, 'group' => $groupName))
-            )
+                'url'       => Url::fromPath('group/show', ['backend' => $backendName, 'group' => $groupName])
+            ]
         );
 
         return $tabs;
@@ -374,14 +374,14 @@ class GroupController extends AuthBackendController
         if ($this->hasPermission('config/access-control/roles')) {
             $tabs->add(
                 'role/list',
-                array(
+                [
                     'baseTarget'    => '_main',
                     'label'         => $this->translate('Roles'),
                     'title'         => $this->translate(
                         'Configure roles to permit or restrict users and groups accessing Icinga Web 2'
                     ),
                     'url'           => 'role/list'
-                )
+                ]
             );
 
             $tabs->add(
@@ -398,21 +398,21 @@ class GroupController extends AuthBackendController
         if ($this->hasPermission('config/access-control/users')) {
             $tabs->add(
                 'user/list',
-                array(
+                [
                     'title'     => $this->translate('List users of authentication backends'),
                     'label'     => $this->translate('Users'),
                     'url'       => 'user/list'
-                )
+                ]
             );
         }
 
         $tabs->add(
             'group/list',
-            array(
+            [
                 'title'     => $this->translate('List groups of user group backends'),
                 'label'     => $this->translate('User Groups'),
                 'url'       => 'group/list'
-            )
+            ]
         );
 
         return $tabs;

--- a/application/controllers/ListController.php
+++ b/application/controllers/ListController.php
@@ -27,10 +27,10 @@ class ListController extends Controller
      */
     protected function addTitleTab($action)
     {
-        $this->getTabs()->add($action, array(
+        $this->getTabs()->add($action, [
             'label' => ucfirst($action),
             'url'   => Url::fromPath('list/' . str_replace(' ', '', $action))
-        ))->extend(new OutputFormat())->extend(new DashboardAction())->extend(new MenuAction())->activate($action);
+        ])->extend(new OutputFormat())->extend(new DashboardAction())->extend(new MenuAction())->activate($action);
     }
 
     /**
@@ -46,12 +46,12 @@ class ListController extends Controller
 
         $this->addTitleTab('application log');
 
-        $resource = new FileReader(new ConfigObject(array(
+        $resource = new FileReader(new ConfigObject([
             'filename'  => Config::app()->get('logging', 'file'),
             'fields'    => '/(?<!.)(?<datetime>[0-9]{4}(?:-[0-9]{2}){2}'    // date
                 . 'T[0-9]{2}(?::[0-9]{2}){2}(?:[\+\-][0-9]{2}:[0-9]{2})?)'  // time
                 . ' - (?<loglevel>[A-Za-z]+) - (?<message>.*)(?!.)/msS'     // loglevel, message
-        )));
+        ]));
         $this->view->logData = $resource->select()->order('DESC');
 
         $this->setupLimitControl();

--- a/application/controllers/ManageUserDevicesController.php
+++ b/application/controllers/ManageUserDevicesController.php
@@ -32,12 +32,12 @@ class ManageUserDevicesController extends CompatController
         $this->getTabs()
             ->add(
                 'manage-user-devices',
-                array(
+                [
                     'title'             => $this->translate('List of users who stay logged in'),
                     'label'             => $this->translate('Users'),
                     'url'               => 'manage-user-devices',
                     'data-base-target'  => '_self'
-                )
+                ]
             )->activate('manage-user-devices');
 
         $usersList = (new RememberMeUserList())
@@ -58,11 +58,11 @@ class ManageUserDevicesController extends CompatController
         $this->getTabs()
             ->add(
                 'manage-devices',
-                array(
+                [
                     'title' => $this->translate('List of devices'),
                     'label' => $this->translate('Devices'),
                     'url'   => 'manage-user-devices/devices'
-                )
+                ]
             )->activate('manage-devices');
 
         $name = $this->params->getRequired('name');

--- a/application/controllers/MyDevicesController.php
+++ b/application/controllers/MyDevicesController.php
@@ -25,27 +25,27 @@ class MyDevicesController extends CompatController
         $this->getTabs()
             ->add(
                 'account',
-                array(
+                [
                     'title' => $this->translate('Update your account'),
                     'label' => $this->translate('My Account'),
                     'url'   => 'account'
-                )
+                ]
             )
             ->add(
                 'navigation',
-                array(
+                [
                     'title'     => $this->translate('List and configure your own navigation items'),
                     'label'     => $this->translate('Navigation'),
                     'url'       => 'navigation'
-                )
+                ]
             )
             ->add(
                 'devices',
-                array(
+                [
                     'title' => $this->translate('List of devices you are logged in'),
                     'label' => $this->translate('My Devices'),
                     'url'   => 'my-devices'
-                )
+                ]
             )->activate('devices');
     }
 

--- a/application/controllers/NavigationController.php
+++ b/application/controllers/NavigationController.php
@@ -59,7 +59,7 @@ class NavigationController extends Controller
      */
     protected function listItemTypes()
     {
-        $types = array();
+        $types = [];
         foreach ($this->itemTypeConfig as $type => $options) {
             $types[$type] = isset($options['label']) ? $options['label'] : $type;
         }
@@ -76,7 +76,7 @@ class NavigationController extends Controller
      */
     protected function fetchSharedNavigationItemConfigs($owner = null)
     {
-        $configs = array();
+        $configs = [];
         foreach ($this->itemTypeConfig as $type => $_) {
             $config = Config::navigation($type);
             $config->getConfigObject()->setKeyColumn('name');
@@ -102,7 +102,7 @@ class NavigationController extends Controller
      */
     protected function fetchUserNavigationItemConfigs($username)
     {
-        $configs = array();
+        $configs = [];
         foreach ($this->itemTypeConfig as $type => $_) {
             $config = Config::navigation($type, $username);
             $config->getConfigObject()->setKeyColumn('name');
@@ -133,35 +133,35 @@ class NavigationController extends Controller
         $this->getTabs()
         ->add(
             'account',
-            array(
+            [
                 'title' => $this->translate('Update your account'),
                 'label' => $this->translate('My Account'),
                 'url'   => 'account'
-            )
+            ]
         )
         ->add(
             'navigation',
-            array(
+            [
                 'active'    => true,
                 'title'     => $this->translate('List and configure your own navigation items'),
                 'label'     => $this->translate('Navigation'),
                 'url'       => 'navigation'
-            )
+            ]
         )
         ->add(
             'devices',
-            array(
+            [
                 'title' => $this->translate('List of devices you are logged in'),
                 'label' => $this->translate('My Devices'),
                 'url'   => 'my-devices'
-            )
+            ]
         );
         $this->setupSortControl(
-            array(
+            [
                 'type'  => $this->translate('Type'),
                 'owner' => $this->translate('Shared'),
                 'name'  => $this->translate('Navigation')
-            ),
+            ],
             $query
         );
     }
@@ -178,22 +178,22 @@ class NavigationController extends Controller
         $removeForm = new Form();
         $removeForm->setUidDisabled();
         $removeForm->setAttrib('class', 'inline');
-        $removeForm->addElement('hidden', 'name', array(
-            'decorators'    => array('ViewHelper')
-        ));
-        $removeForm->addElement('hidden', 'redirect', array(
+        $removeForm->addElement('hidden', 'name', [
+            'decorators'    => ['ViewHelper']
+        ]);
+        $removeForm->addElement('hidden', 'redirect', [
             'value'         => Url::fromPath('navigation/shared'),
-            'decorators'    => array('ViewHelper')
-        ));
-        $removeForm->addElement('button', 'btn_submit', array(
+            'decorators'    => ['ViewHelper']
+        ]);
+        $removeForm->addElement('button', 'btn_submit', [
             'escape'        => false,
             'type'          => 'submit',
             'class'         => 'link-button spinner',
             'value'         => 'btn_submit',
-            'decorators'    => array('ViewHelper'),
+            'decorators'    => ['ViewHelper'],
             'label'         => $this->view->icon('cancel'),
             'title'         => $this->translate('Unshare this navigation item')
-        ));
+        ]);
 
         $this->view->removeForm = $removeForm;
         $this->view->types = $this->listItemTypes();
@@ -202,18 +202,18 @@ class NavigationController extends Controller
         $this->view->title = $this->translate('Shared Navigation');
         $this->getTabs()->add(
             'navigation/shared',
-            array(
+            [
                 'title'     => $this->translate('List and configure shared navigation items'),
                 'label'     => $this->translate('Shared Navigation'),
                 'url'       => 'navigation/shared'
-            )
+            ]
         )->activate('navigation/shared');
         $this->setupSortControl(
-            array(
+            [
                 'type'  => $this->translate('Type'),
                 'owner' => $this->translate('Owner'),
                 'name'  => $this->translate('Shared Navigation')
-            ),
+            ],
             $query
         );
     }
@@ -376,7 +376,7 @@ class NavigationController extends Controller
         $navigationConfigForm->setShareConfig(Config::navigation($itemType));
         $navigationConfigForm->setUserConfig(Config::navigation($itemType, $itemOwner));
 
-        $form = new Form(array(
+        $form = new Form([
             'onSuccess' => function ($form) use ($navigationConfigForm) {
                 $itemName = $form->getValue('name');
 
@@ -412,10 +412,10 @@ class NavigationController extends Controller
 
                 return true;
             }
-        ));
+        ]);
         $form->setUidDisabled();
         $form->setSubmitLabel('btn_submit'); // Required to ensure that isSubmitted() is called
-        $form->addElement('hidden', 'name', array('required' => true));
+        $form->addElement('hidden', 'name', ['required' => true]);
         $form->addElement('hidden', 'redirect');
 
         try {
@@ -429,11 +429,11 @@ class NavigationController extends Controller
     {
         $name = $this->params->getRequired('name');
 
-        $this->getTabs()->add('dashboard', array(
+        $this->getTabs()->add('dashboard', [
             'active'    => true,
             'label'     => ucwords($name),
             'url'       => Url::fromRequest()
-        ));
+        ]);
 
         $menu = new Menu();
 

--- a/application/controllers/RoleController.php
+++ b/application/controllers/RoleController.php
@@ -345,14 +345,14 @@ class RoleController extends AuthBackendController
         $tabs = $this->getTabs();
         $tabs->add(
             'role/list',
-            array(
+            [
                 'baseTarget'    => '_main',
                 'label'         => $this->translate('Roles'),
                 'title'         => $this->translate(
                     'Configure roles to permit or restrict users and groups accessing Icinga Web 2'
                 ),
                 'url'           => 'role/list'
-            )
+            ]
         );
 
         $tabs->add(
@@ -368,22 +368,22 @@ class RoleController extends AuthBackendController
         if ($this->hasPermission('config/access-control/users')) {
             $tabs->add(
                 'user/list',
-                array(
+                [
                     'title'     => $this->translate('List users of authentication backends'),
                     'label'     => $this->translate('Users'),
                     'url'       => 'user/list'
-                )
+                ]
             );
         }
 
         if ($this->hasPermission('config/access-control/groups')) {
             $tabs->add(
                 'group/list',
-                array(
+                [
                     'title'     => $this->translate('List groups of user group backends'),
                     'label'     => $this->translate('User Groups'),
                     'url'       => 'group/list'
-                )
+                ]
             );
         }
 

--- a/application/controllers/UserController.php
+++ b/application/controllers/UserController.php
@@ -55,12 +55,12 @@ class UserController extends AuthBackendController
         $this->view->backendSelection->addElement(
             'select',
             'backend',
-            array(
+            [
                 'autosubmit'    => true,
                 'label'         => $this->translate('User Backend'),
                 'multiOptions'  => array_combine($backendNames, $backendNames),
                 'value'         => $this->params->get('backend')
-            )
+            ]
         );
 
         $backend = $this->getUserBackend($this->params->get('backend'));
@@ -69,7 +69,7 @@ class UserController extends AuthBackendController
             return;
         }
 
-        $query = $backend->select(array('user_name'));
+        $query = $backend->select(['user_name']);
 
         $this->view->users = $query;
         $this->view->backend = $backend;
@@ -78,12 +78,12 @@ class UserController extends AuthBackendController
         $this->setupFilterControl($query);
         $this->setupLimitControl();
         $this->setupSortControl(
-            array(
+            [
                 'user_name'     => $this->translate('Username'),
                 'is_active'     => $this->translate('Active'),
                 'created_at'    => $this->translate('Created at'),
                 'last_modified' => $this->translate('Last modified')
-            ),
+            ],
             $query
         );
     }
@@ -97,12 +97,12 @@ class UserController extends AuthBackendController
         $userName = $this->params->getRequired('user');
         $backend = $this->getUserBackend($this->params->getRequired('backend'));
 
-        $user = $backend->select(array(
+        $user = $backend->select([
             'user_name',
             'is_active',
             'created_at',
             'last_modified'
-        ))->where('user_name', $userName)->fetchRow();
+        ])->where('user_name', $userName)->fetchRow();
         if ($user === false) {
             $this->httpNotFound(sprintf($this->translate('User "%s" not found'), $userName));
         }
@@ -116,16 +116,16 @@ class UserController extends AuthBackendController
 
         $this->setupFilterControl(
             $memberships,
-            array('group_name' => t('User Group')),
-            array('group'),
-            array('user')
+            ['group_name' => t('User Group')],
+            ['group'],
+            ['user']
         );
         $this->setupPaginationControl($memberships);
         $this->setupLimitControl();
         $this->setupSortControl(
-            array(
+            [
                 'group_name' => $this->translate('Group')
-            ),
+            ],
             $memberships
         );
 
@@ -145,27 +145,27 @@ class UserController extends AuthBackendController
             $removeForm = new Form();
             $removeForm->setUidDisabled();
             $removeForm->setAttrib('class', 'inline');
-            $removeForm->addElement('hidden', 'user_name', array(
+            $removeForm->addElement('hidden', 'user_name', [
                 'isArray'       => true,
                 'value'         => $userName,
-                'decorators'    => array('ViewHelper')
-            ));
-            $removeForm->addElement('hidden', 'redirect', array(
-                'value'         => Url::fromPath('user/show', array(
+                'decorators'    => ['ViewHelper']
+            ]);
+            $removeForm->addElement('hidden', 'redirect', [
+                'value'         => Url::fromPath('user/show', [
                     'backend'   => $backend->getName(),
                     'user'      => $userName
-                )),
-                'decorators'    => array('ViewHelper')
-            ));
-            $removeForm->addElement('button', 'btn_submit', array(
+                ]),
+                'decorators'    => ['ViewHelper']
+            ]);
+            $removeForm->addElement('button', 'btn_submit', [
                 'escape'        => false,
                 'type'          => 'submit',
                 'class'         => 'link-button spinner',
                 'value'         => 'btn_submit',
-                'decorators'    => array('ViewHelper'),
+                'decorators'    => ['ViewHelper'],
                 'label'         => $this->view->icon('cancel'),
                 'title'         => $this->translate('Cancel this membership')
-            ));
+            ]);
             $this->view->removeForm = $removeForm;
         }
 
@@ -183,7 +183,7 @@ class UserController extends AuthBackendController
         $this->assertPermission('config/access-control/users');
         $backend = $this->getUserBackend($this->params->getRequired('backend'), 'Icinga\Data\Extensible');
         $form = new UserForm();
-        $form->setRedirectUrl(Url::fromPath('user/list', array('backend' => $backend->getName())));
+        $form->setRedirectUrl(Url::fromPath('user/list', ['backend' => $backend->getName()]));
         $form->setRepository($backend);
         $form->add()->handleRequest();
 
@@ -200,7 +200,7 @@ class UserController extends AuthBackendController
         $backend = $this->getUserBackend($this->params->getRequired('backend'), 'Icinga\Data\Updatable');
 
         $form = new UserForm();
-        $form->setRedirectUrl(Url::fromPath('user/show', array('backend' => $backend->getName(), 'user' => $userName)));
+        $form->setRedirectUrl(Url::fromPath('user/show', ['backend' => $backend->getName(), 'user' => $userName]));
         $form->setRepository($backend);
 
         try {
@@ -222,7 +222,7 @@ class UserController extends AuthBackendController
         $backend = $this->getUserBackend($this->params->getRequired('backend'), 'Icinga\Data\Reducible');
 
         $form = new UserForm();
-        $form->setRedirectUrl(Url::fromPath('user/list', array('backend' => $backend->getName())));
+        $form->setRedirectUrl(Url::fromPath('user/list', ['backend' => $backend->getName()]));
         $form->setRepository($backend);
 
         try {
@@ -257,7 +257,7 @@ class UserController extends AuthBackendController
         $form = new CreateMembershipForm();
         $form->setBackends($backends)
             ->setUsername($userName)
-            ->setRedirectUrl(Url::fromPath('user/show', array('backend' => $backend->getName(), 'user' => $userName)))
+            ->setRedirectUrl(Url::fromPath('user/show', ['backend' => $backend->getName(), 'user' => $userName]))
             ->handleRequest();
 
         $this->renderForm($form, $this->translate('Create New Membership'));
@@ -272,7 +272,7 @@ class UserController extends AuthBackendController
      */
     protected function loadMemberships(User $user)
     {
-        $groups = $alreadySeen = array();
+        $groups = $alreadySeen = [];
         foreach ($this->loadUserGroupBackends() as $backend) {
             try {
                 foreach ($backend->getMemberships($user) as $groupName) {
@@ -281,11 +281,11 @@ class UserController extends AuthBackendController
                     }
 
                     $alreadySeen[$groupName] = null;
-                    $groups[] = (object) array(
+                    $groups[] = (object) [
                         'group_name'    => $groupName,
                         'group'         => $groupName,
                         'backend'       => $backend
-                    );
+                    ];
                 }
             } catch (Exception $e) {
                 Logger::error($e);
@@ -310,11 +310,11 @@ class UserController extends AuthBackendController
         $tabs = $this->getTabs();
         $tabs->add(
             'user/show',
-            array(
+            [
                 'title'     => sprintf($this->translate('Show user %s'), $userName),
                 'label'     => $this->translate('User'),
-                'url'       => Url::fromPath('user/show', array('backend' => $backendName, 'user' => $userName))
-            )
+                'url'       => Url::fromPath('user/show', ['backend' => $backendName, 'user' => $userName])
+            ]
         );
 
         return $tabs;
@@ -330,14 +330,14 @@ class UserController extends AuthBackendController
         if ($this->hasPermission('config/access-control/roles')) {
             $tabs->add(
                 'role/list',
-                array(
+                [
                     'baseTarget'    => '_main',
                     'label'         => $this->translate('Roles'),
                     'title'         => $this->translate(
                         'Configure roles to permit or restrict users and groups accessing Icinga Web 2'
                     ),
                     'url'           => 'role/list'
-                )
+                ]
             );
 
             $tabs->add(
@@ -353,21 +353,21 @@ class UserController extends AuthBackendController
 
         $tabs->add(
             'user/list',
-            array(
+            [
                 'title'     => $this->translate('List users of authentication backends'),
                 'label'     => $this->translate('Users'),
                 'url'       => 'user/list'
-            )
+            ]
         );
 
         if ($this->hasPermission('config/access-control/groups')) {
             $tabs->add(
                 'group/list',
-                array(
+                [
                     'title'     => $this->translate('List groups of user group backends'),
                     'label'     => $this->translate('User Groups'),
                     'url'       => 'group/list'
-                )
+                ]
             );
         }
 

--- a/application/forms/Account/ChangePasswordForm.php
+++ b/application/forms/Account/ChangePasswordForm.php
@@ -39,29 +39,29 @@ class ChangePasswordForm extends Form
         $this->addElement(
             'password',
             'old_password',
-            array(
+            [
                 'label'         => $this->translate('Old Password'),
                 'required'      => true
-            )
+            ]
         );
         $this->addElement(
             'password',
             'new_password',
-            array(
+            [
                 'label'         => $this->translate('New Password'),
                 'required'      => true
-            )
+            ]
         );
         $this->addElement(
             'password',
             'new_password_confirmation',
-            array(
+            [
                 'label'         => $this->translate('Confirm New Password'),
                 'required'      => true,
-                'validators'        => array(
-                    array('identical', false, array('new_password'))
-                )
-            )
+                'validators'        => [
+                    ['identical', false, ['new_password']]
+                ]
+            ]
         );
     }
 
@@ -73,7 +73,7 @@ class ChangePasswordForm extends Form
         $backend = $this->getBackend();
         $backend->update(
             $backend->getBaseTable(),
-            array('password' => $this->getElement('new_password')->getValue()),
+            ['password' => $this->getElement('new_password')->getValue()],
             Filter::where('user_name', $this->Auth()->getUser()->getUsername())
         );
         Notification::success($this->translate('Account updated'));

--- a/application/forms/Announcement/AcknowledgeAnnouncementForm.php
+++ b/application/forms/Announcement/AcknowledgeAnnouncementForm.php
@@ -31,18 +31,18 @@ class AcknowledgeAnnouncementForm extends Form
         $this->addElement(
             'button',
             'btn_submit',
-            array(
+            [
                 'class'         => 'link-button spinner',
-                'decorators'    => array(
+                'decorators'    => [
                     'ViewHelper',
-                    array('HtmlTag', array('tag' => 'div', 'class' => 'control-group form-controls'))
-                ),
+                    ['HtmlTag', ['tag' => 'div', 'class' => 'control-group form-controls']]
+                ],
                 'escape'        => false,
                 'ignore'        => true,
                 'label'         => $this->getView()->icon('cancel'),
                 'title'         => $this->translate('Acknowledge this announcement'),
                 'type'          => 'submit'
-            )
+            ]
         );
         return $this;
     }
@@ -50,20 +50,20 @@ class AcknowledgeAnnouncementForm extends Form
     /**
      * {@inheritdoc}
      */
-    public function createElements(array $formData = array())
+    public function createElements(array $formData = [])
     {
         $this->addElements(
-            array(
-                array(
+            [
+                [
                     'hidden',
                     'hash',
-                    array(
+                    [
                         'required' => true,
-                        'validators' => array('NotEmpty'),
-                        'decorators' => array('ViewHelper')
-                    )
-                )
-            )
+                        'validators' => ['NotEmpty'],
+                        'decorators' => ['ViewHelper']
+                    ]
+                ]
+            ]
         );
 
         return $this;
@@ -77,12 +77,12 @@ class AcknowledgeAnnouncementForm extends Form
         $cookie = new AnnouncementCookie();
         $repo = new AnnouncementIniRepository();
         $query = $repo->findActive();
-        $filter = array();
+        $filter = [];
         foreach ($cookie->getAcknowledged() as $hash) {
             $filter[] = Filter::expression('hash', '=', $hash);
         }
         $query->addFilter(Filter::matchAny($filter));
-        $acknowledged = array();
+        $acknowledged = [];
         foreach ($query as $row) {
             $acknowledged[] = $row->hash;
         }

--- a/application/forms/Announcement/AnnouncementForm.php
+++ b/application/forms/Announcement/AnnouncementForm.php
@@ -38,40 +38,40 @@ class AnnouncementForm extends RepositoryForm
         $this->addElement(
             'text',
             'author',
-            array(
+            [
                 'disabled'  => ! $this->getRequest()->isApiRequest(),
                 'required'  => true,
                 'value'     => Auth::getInstance()->getUser()->getUsername()
-            )
+            ]
         );
         $this->addElement(
             'textarea',
             'message',
-            array(
+            [
                 'description'   => $this->translate('The message to display to users'),
                 'label'         => $this->translate('Message'),
                 'required'      => true
-            )
+            ]
         );
         $this->addElement(
             'dateTimePicker',
             'start',
-            array(
+            [
                 'description'   => $this->translate('The time to display the announcement from'),
                 'label'         => $this->translate('Start'),
                 'placeholder'   => new DateTime('tomorrow'),
                 'required'      => true
-            )
+            ]
         );
         $this->addElement(
             'dateTimePicker',
             'end',
-            array(
+            [
                 'description'   => $this->translate('The time to display the announcement until'),
                 'label'         => $this->translate('End'),
                 'placeholder'   => new DateTime('tomorrow +1day'),
                 'required'      => true
-            )
+            ]
         );
 
         $this->setTitle($this->translate('Create a new announcement'));

--- a/application/forms/AutoRefreshForm.php
+++ b/application/forms/AutoRefreshForm.php
@@ -67,19 +67,19 @@ class AutoRefreshForm extends Form
             $value = $this->translate('Disable auto refresh');
         }
 
-        $this->addElements(array(
-            array(
+        $this->addElements([
+            [
                 'button',
                 'btn_submit',
-                array(
+                [
                     'ignore'        => true,
                     'type'          => 'submit',
                     'value'         => $value,
-                    'decorators'    => array('ViewHelper'),
+                    'decorators'    => ['ViewHelper'],
                     'escape'        => false,
                     'class'         => 'link-like'
-                )
-            )
-        ));
+                ]
+            ]
+        ]);
     }
 }

--- a/application/forms/Config/General/ApplicationConfigForm.php
+++ b/application/forms/Config/General/ApplicationConfigForm.php
@@ -34,27 +34,27 @@ class ApplicationConfigForm extends Form
         $this->addElement(
             'checkbox',
             'global_show_stacktraces',
-            array(
+            [
                 'value'         => true,
                 'label'         => $this->translate('Show Stacktraces'),
                 'description'   => $this->translate(
                     'Set whether to show an exception\'s stacktrace by default. This can also'
                     . ' be set in a user\'s preferences with the appropriate permission.'
                 )
-            )
+            ]
         );
 
         $this->addElement(
             'checkbox',
             'global_show_application_state_messages',
-            array(
+            [
                 'value'         => true,
                 'label'         => $this->translate('Show Application State Messages'),
                 'description'   => $this->translate(
                     "Set whether to show application state messages."
                     . " This can also be set in a user's preferences."
                 )
-            )
+            ]
         );
 
         $this->addElement(
@@ -72,7 +72,7 @@ class ApplicationConfigForm extends Form
         $this->addElement(
             'text',
             'global_module_path',
-            array(
+            [
                 'label'         => $this->translate('Module Path'),
                 'required'      => true,
                 'value'         => implode(':', Icinga::app()->getModuleManager()->getModuleDirs()),
@@ -81,7 +81,7 @@ class ApplicationConfigForm extends Form
                     . 'colons. Modules that don\'t exist in these directories can still be symlinked in '
                     . 'the module folder, but won\'t show up in the list of disabled modules.'
                 )
-            )
+            ]
         );
 
         $backends = array_keys(ResourceFactory::getResourceConfigs()->toArray());
@@ -90,7 +90,7 @@ class ApplicationConfigForm extends Form
         $this->addElement(
             'select',
             'global_config_resource',
-            array(
+            [
                 'required'      => true,
                 'multiOptions'  => array_merge(
                     ['' => sprintf(' - %s - ', $this->translate('Please choose'))],
@@ -99,7 +99,7 @@ class ApplicationConfigForm extends Form
                 'disable'       => [''],
                 'value'         => '',
                 'label'         => $this->translate('Configuration Database')
-            )
+            ]
         );
 
         return $this;

--- a/application/forms/Config/General/DefaultAuthenticationDomainConfigForm.php
+++ b/application/forms/Config/General/DefaultAuthenticationDomainConfigForm.php
@@ -32,7 +32,7 @@ class DefaultAuthenticationDomainConfigForm extends Form
         $this->addElement(
             'text',
             'authentication_default_domain',
-            array(
+            [
                 'label'         => $this->translate('Default Login Domain'),
                 'description'   => $this->translate(
                     'If a user logs in without specifying any domain (e.g. "jdoe" instead of "jdoe@example.com"),'
@@ -40,7 +40,7 @@ class DefaultAuthenticationDomainConfigForm extends Form
                     . ' backends are configured to be responsible for this domain or if none of your authentication'
                     . ' backends holds usernames with the domain part, users will not be able to login.'
                 )
-            )
+            ]
         );
 
         return $this;

--- a/application/forms/Config/General/LoggingConfigForm.php
+++ b/application/forms/Config/General/LoggingConfigForm.php
@@ -37,44 +37,44 @@ class LoggingConfigForm extends Form
         $this->addElement(
             'select',
             'logging_log',
-            array(
+            [
                 'required'      => true,
                 'autosubmit'    => true,
                 'label'         => $this->translate('Logging Type'),
                 'description'   => $this->translate('The type of logging to utilize.'),
                 'value'         => $defaultType,
-                'multiOptions'  => array(
+                'multiOptions'  => [
                     'syslog'    => 'Syslog',
                     'php'       => $this->translate('Webserver Log', 'app.config.logging.type'),
                     'file'      => $this->translate('File', 'app.config.logging.type'),
                     'none'      => $this->translate('None', 'app.config.logging.type')
-                )
-            )
+                ]
+            ]
         );
 
         if (! isset($formData['logging_log']) || $formData['logging_log'] !== 'none') {
             $this->addElement(
                 'select',
                 'logging_level',
-                array(
+                [
                     'required'      => true,
                     'label'         => $this->translate('Logging Level'),
                     'description'   => $this->translate('The maximum logging level to emit.'),
-                    'multiOptions'  => array(
+                    'multiOptions'  => [
                         Logger::$levels[Logger::ERROR]   => $this->translate('Error', 'app.config.logging.level'),
                         Logger::$levels[Logger::WARNING] => $this->translate('Warning', 'app.config.logging.level'),
                         Logger::$levels[Logger::INFO]    => $this->translate('Information', 'app.config.logging.level'),
                         Logger::$levels[Logger::DEBUG]   => $this->translate('Debug', 'app.config.logging.level')
-                    )
-                )
+                    ]
+                ]
             );
         }
 
-        if (! isset($formData['logging_log']) || in_array($formData['logging_log'], array('syslog', 'php'))) {
+        if (! isset($formData['logging_log']) || in_array($formData['logging_log'], ['syslog', 'php'])) {
             $this->addElement(
                 'text',
                 'logging_application',
-                array(
+                [
                     'required'      => true,
                     'label'         => $this->translate('Application Prefix'),
                     'description'   => $this->translate(
@@ -82,21 +82,21 @@ class LoggingConfigForm extends Form
                     ),
                     'requirement'   => $this->translate('The application prefix must not contain whitespace.'),
                     'value'         => 'icingaweb2',
-                    'validators'    => array(
-                        array(
+                    'validators'    => [
+                        [
                             'Regex',
                             false,
-                            array(
+                            [
                                 'pattern'  => '/^\S+$/',
-                                'messages' => array(
+                                'messages' => [
                                     'regexNotMatch' => $this->translate(
                                         'The application prefix must not contain whitespace.'
                                     )
-                                )
-                            )
-                        )
-                    )
-                )
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
             );
 
             if ((isset($formData['logging_log']) ? $formData['logging_log'] : $defaultType) === 'syslog') {
@@ -105,23 +105,23 @@ class LoggingConfigForm extends Form
                     $this->addElement(
                         'hidden',
                         'logging_facility',
-                        array(
+                        [
                             'value' => 'user',
                             'disabled' => true
-                        )
+                        ]
                     );
                 } else {
                     $facilities = array_keys(SyslogWriter::$facilities);
                     $this->addElement(
                         'select',
                         'logging_facility',
-                        array(
+                        [
                             'required' => true,
                             'label' => $this->translate('Facility'),
                             'description' => $this->translate('The syslog facility to utilize.'),
                             'value' => 'user',
                             'multiOptions' => array_combine($facilities, $facilities)
-                        )
+                        ]
                     );
                 }
             }
@@ -129,13 +129,13 @@ class LoggingConfigForm extends Form
             $this->addElement(
                 'text',
                 'logging_file',
-                array(
+                [
                     'required'      => true,
                     'label'         => $this->translate('File path'),
                     'description'   => $this->translate('The full path to the log file to write messages to.'),
                     'value'         => '/var/log/icingaweb2/icingaweb2.log',
-                    'validators'    => array('WritablePathValidator')
-                )
+                    'validators'    => ['WritablePathValidator']
+                ]
             );
         }
 

--- a/application/forms/Config/General/ThemingConfigForm.php
+++ b/application/forms/Config/General/ThemingConfigForm.php
@@ -38,26 +38,26 @@ class ThemingConfigForm extends Form
         $this->addElement(
             'select',
             'themes_default',
-            array(
+            [
                 'description'   => $this->translate('The default theme', 'Form element description'),
                 'disabled'      => count($themes) < 2 ? 'disabled' : null,
                 'label'         => $this->translate('Default Theme', 'Form element label'),
                 'multiOptions'  => $themes,
                 'value'         => StyleSheet::DEFAULT_THEME
-            )
+            ]
         );
 
         $this->addElement(
             'checkbox',
             'themes_disabled',
-            array(
+            [
                 'description'   => $this->translate(
                     'Check this box for disallowing users to change the theme. If a default theme is set, it will be'
                     . ' used nonetheless',
                     'Form element description'
                 ),
                 'label'         => $this->translate('Users Can\'t Change Theme', 'Form element label')
-            )
+            ]
         );
 
         return $this;

--- a/application/forms/Config/Resource/DbResourceForm.php
+++ b/application/forms/Config/Resource/DbResourceForm.php
@@ -29,7 +29,7 @@ class DbResourceForm extends Form
      */
     public function createElements(array $formData)
     {
-        $dbChoices = array();
+        $dbChoices = [];
         if (Platform::hasMysqlSupport()) {
             $dbChoices['mysql'] = 'MySQL';
         }
@@ -81,158 +81,158 @@ class DbResourceForm extends Form
         $this->addElement(
             'text',
             'name',
-            array(
+            [
                 'required'      => true,
                 'label'         => $this->translate('Resource Name'),
                 'description'   => $this->translate('The unique name of this resource')
-            )
+            ]
         );
         $this->addElement(
             'select',
             'db',
-            array(
+            [
                 'required'      => true,
                 'autosubmit'    => true,
                 'label'         => $this->translate('Database Type'),
                 'description'   => $this->translate('The type of SQL database'),
                 'multiOptions'  => $dbChoices
-            )
+            ]
         );
         if ($dbChoice === 'sqlite') {
             $this->addElement(
                 'text',
                 'dbname',
-                array(
+                [
                     'required'      => true,
                     'label'         => $this->translate('Database Name'),
                     'description'   => $this->translate('The name of the database to use')
-                )
+                ]
             );
         } else {
             $this->addElement(
                 'text',
                 'host',
-                array (
+                [
                     'required'      => $hostIsRequired,
                     'label'         => $this->translate('Host'),
                     'description'   => $this->translate('The hostname of the database')
                         . ($socketInfo ? '. ' . $socketInfo : ''),
                     'value'         => $hostIsRequired ? 'localhost' : ''
-                )
+                ]
             );
             $this->addElement(
                 'number',
                 'port',
-                array(
+                [
                     'description'       => $this->translate('The port to use'),
                     'label'             => $this->translate('Port'),
                     'preserveDefault'   => true,
                     'required'          => $offerPostgres,
                     'value'             => $offerPostgres ? 5432 : null
-                )
+                ]
             );
             $this->addElement(
                 'text',
                 'dbname',
-                array(
+                [
                     'required'      => true,
                     'label'         => $this->translate('Database Name'),
                     'description'   => $this->translate('The name of the database to use')
-                )
+                ]
             );
             $this->addElement(
                 'text',
                 'username',
-                array (
+                [
                     'required'      => true,
                     'label'         => $this->translate('Username'),
                     'description'   => $this->translate('The user name to use for authentication')
-                )
+                ]
             );
             $this->addElement(
                 'password',
                 'password',
-                array(
+                [
                     'required'          => true,
                     'renderPassword'    => true,
                     'label'             => $this->translate('Password'),
                     'description'       => $this->translate('The password to use for authentication'),
                     'autocomplete'      => 'new-password'
-                )
+                ]
             );
             $this->addElement(
                 'text',
                 'charset',
-                array (
+                [
                     'description'   => $this->translate('The character set for the database'),
                     'label'         => $this->translate('Character Set')
-                )
+                ]
             );
             $this->addElement(
                 'checkbox',
                 'use_ssl',
-                array(
+                [
                     'autosubmit'    => true,
                     'label'         => $this->translate('Use SSL'),
                     'description'   => $this->translate(
                         'Whether to encrypt the connection or to authenticate using certificates'
                     )
-                )
+                ]
             );
             if (isset($formData['use_ssl']) && $formData['use_ssl']) {
                 if (defined(Mysql::class . '::ATTR_SSL_VERIFY_SERVER_CERT')) {
                     $this->addElement(
                         'checkbox',
                         'ssl_do_not_verify_server_cert',
-                        array(
+                        [
                             'label'             => $this->translate('SSL Do Not Verify Server Certificate'),
                             'description'       => $this->translate(
                                 'Whether to disable verification of the server certificate'
                             )
-                        )
+                        ]
                     );
                 }
                 $this->addElement(
                     'text',
                     'ssl_key',
-                    array(
+                    [
                         'label'             => $this->translate('SSL Key'),
                         'description'       => $this->translate('The client key file path')
-                    )
+                    ]
                 );
                 $this->addElement(
                     'text',
                     'ssl_cert',
-                    array(
+                    [
                         'label'             => $this->translate('SSL Certificate'),
                         'description'       => $this->translate('The certificate file path')
-                    )
+                    ]
                 );
                 $this->addElement(
                     'text',
                     'ssl_ca',
-                    array(
+                    [
                         'label'             => $this->translate('SSL CA'),
                         'description'       => $this->translate('The CA certificate file path')
-                    )
+                    ]
                 );
                 $this->addElement(
                     'text',
                     'ssl_capath',
-                    array(
+                    [
                         'label'             => $this->translate('SSL CA Path'),
                         'description'       => $this->translate(
                             'The trusted CA certificates in PEM format directory path'
                         )
-                    )
+                    ]
                 );
                 $this->addElement(
                     'text',
                     'ssl_cipher',
-                    array(
+                    [
                         'label'             => $this->translate('SSL Cipher'),
                         'description'       => $this->translate('The list of permissible ciphers')
-                    )
+                    ]
                 );
             }
         }

--- a/application/forms/Config/Resource/FileResourceForm.php
+++ b/application/forms/Config/Resource/FileResourceForm.php
@@ -29,21 +29,21 @@ class FileResourceForm extends Form
         $this->addElement(
             'text',
             'name',
-            array(
+            [
                 'required'      => true,
                 'label'         => $this->translate('Resource Name'),
                 'description'   => $this->translate('The unique name of this resource')
-            )
+            ]
         );
         $this->addElement(
             'text',
             'filename',
-            array(
+            [
                 'required'      => true,
                 'label'         => $this->translate('Filepath'),
                 'description'   => $this->translate('The filename to fetch information from'),
-                'validators'    => array('ReadablePathValidator')
-            )
+                'validators'    => ['ReadablePathValidator']
+            ]
         );
         $callbackValidator = new Zend_Validate_Callback(function ($value) {
             return @preg_match($value, '') !== false;
@@ -55,13 +55,13 @@ class FileResourceForm extends Form
         $this->addElement(
             'text',
             'fields',
-            array(
+            [
                 'required'      => true,
                 'label'         => $this->translate('Pattern'),
                 'description'   => $this->translate('The pattern by which to identify columns.'),
                 'requirement'   => $this->translate('The column pattern must be a valid regular expression.'),
-                'validators'    => array($callbackValidator)
-            )
+                'validators'    => [$callbackValidator]
+            ]
         );
 
         return $this;

--- a/application/forms/Config/Resource/LdapResourceForm.php
+++ b/application/forms/Config/Resource/LdapResourceForm.php
@@ -34,16 +34,16 @@ class LdapResourceForm extends Form
         $this->addElement(
             'text',
             'name',
-            array(
+            [
                 'required'      => true,
                 'label'         => $this->translate('Resource Name'),
                 'description'   => $this->translate('The unique name of this resource')
-            )
+            ]
         );
         $this->addElement(
             'text',
             'hostname',
-            array(
+            [
                 'required'      => true,
                 'label'         => $this->translate('Host'),
                 'description'   => $this->translate(
@@ -51,23 +51,23 @@ class LdapResourceForm extends Form
                     . ' You can also provide multiple hosts separated by a space'
                 ),
                 'value'         => 'localhost'
-            )
+            ]
         );
         $this->addElement(
             'number',
             'port',
-            array(
+            [
                 'required'          => true,
                 'preserveDefault'   => true,
                 'label'             => $this->translate('Port'),
                 'description'       => $this->translate('The port of the LDAP server to use for authentication'),
                 'value'             => $defaultPort
-            )
+            ]
         );
         $this->addElement(
             'select',
             'encryption',
-            array(
+            [
                 'required'      => true,
                 'autosubmit'    => true,
                 'label'         => $this->translate('Encryption'),
@@ -75,55 +75,55 @@ class LdapResourceForm extends Form
                     'Whether to encrypt communication. Choose STARTTLS or LDAPS for encrypted communication or'
                     . ' none for unencrypted communication'
                 ),
-                'multiOptions'  => array(
+                'multiOptions'  => [
                     'none'                      => $this->translate('None', 'resource.ldap.encryption'),
                     LdapConnection::STARTTLS    => 'STARTTLS',
                     LdapConnection::LDAPS       => 'LDAPS'
-                )
-            )
+                ]
+            ]
         );
 
         $this->addElement(
             'text',
             'root_dn',
-            array(
+            [
                 'required'      => true,
                 'label'         => $this->translate('Root DN'),
                 'description'   => $this->translate(
                     'Only the root and its child nodes will be accessible on this resource.'
                 )
-            )
+            ]
         );
         $this->addElement(
             'text',
             'bind_dn',
-            array(
+            [
                 'label'         => $this->translate('Bind DN'),
                 'description'   => $this->translate(
                     'The user dn to use for querying the ldap server. Leave the dn and password empty for attempting'
                     . ' an anonymous bind'
                 )
-            )
+            ]
         );
         $this->addElement(
             'password',
             'bind_pw',
-            array(
+            [
                 'renderPassword'    => true,
                 'label'             => $this->translate('Bind Password'),
                 'description'       => $this->translate('The password to use for querying the ldap server')
-            )
+            ]
         );
 
         $this->addElement(
             'number',
             'timeout',
-            array(
+            [
                 'preserveDefault'   => true,
                 'label'             => $this->translate('Timeout'),
                 'description'       => $this->translate('Connection timeout for every LDAP connection'),
                 'value'             => 5 // see LdapConnection::__construct()
-            )
+            ]
         );
 
         return $this;

--- a/application/forms/Config/Resource/SshResourceForm.php
+++ b/application/forms/Config/Resource/SshResourceForm.php
@@ -33,23 +33,23 @@ class SshResourceForm extends Form
         $this->addElement(
             'text',
             'name',
-            array(
+            [
                 'required'      => true,
                 'label'         => $this->translate('Resource Name'),
                 'description'   => $this->translate('The unique name of this resource')
-            )
+            ]
         );
         $this->addElement(
             'text',
             'user',
-            array(
+            [
                 'required'      => true,
                 'label'         => $this->translate('User'),
                 'description'   => $this->translate(
                     'User to log in as on the remote Icinga instance. Please note that key-based SSH login must be'
                     . ' possible for this user'
                 )
-            )
+            ]
         );
 
         if ($this->getRequest()->getActionName() != 'editresource') {
@@ -70,31 +70,31 @@ class SshResourceForm extends Form
             $this->addElement(
                 'textarea',
                 'private_key',
-                array(
+                [
                     'required'      => true,
                     'label'         => $this->translate('Private Key'),
                     'description'   => $this->translate('The private key which will be used for the SSH connections'),
                     'class'         => 'resource ssh-identity',
-                    'validators'    => array($callbackValidator)
-                )
+                    'validators'    => [$callbackValidator]
+                ]
             );
         } else {
             $resourceName = $formData['name'];
             $this->addElement(
                 'note',
                 'private_key_note',
-                array(
+                [
                     'escape'        => false,
                     'label'         => $this->translate('Private Key'),
                     'value'         => sprintf(
                         '<a href="%1$s" data-base-target="_next" title="%2$s" aria-label="%2$s">%3$s</a>',
-                        $this->getView()->url('config/removeresource', array('resource' => $resourceName)),
+                        $this->getView()->url('config/removeresource', ['resource' => $resourceName]),
                         $this->getView()->escape(sprintf($this->translate(
                             'Remove the %s resource'
                         ), $resourceName)),
                         $this->translate('To modify the private key you must recreate this resource.')
                     )
-                )
+                ]
             );
         }
 

--- a/application/forms/Config/ResourceConfigForm.php
+++ b/application/forms/Config/ResourceConfigForm.php
@@ -244,12 +244,12 @@ class ResourceConfigForm extends ConfigForm
         return $this->createElement(
             'checkbox',
             'force_creation',
-            array(
+            [
                 'order'         => 0,
                 'ignore'        => true,
                 'label'         => $this->translate('Force Changes'),
                 'description'   => $this->translate('Check this box to enforce changes without connectivity validation')
-            )
+            ]
         );
     }
 
@@ -260,10 +260,10 @@ class ResourceConfigForm extends ConfigForm
     {
         $resourceType = isset($formData['type']) ? $formData['type'] : 'db';
 
-        $resourceTypes = array(
+        $resourceTypes = [
             'file'          => $this->translate('File'),
             'ssh'           => $this->translate('SSH Identity'),
-        );
+        ];
         if ($resourceType === 'ldap' || Platform::hasLdapSupport()) {
             $resourceTypes['ldap'] = 'LDAP';
         }
@@ -274,14 +274,14 @@ class ResourceConfigForm extends ConfigForm
         $this->addElement(
             'select',
             'type',
-            array(
+            [
                 'required'          => true,
                 'autosubmit'        => true,
                 'label'             => $this->translate('Resource Type'),
                 'description'       => $this->translate('The type of resource'),
                 'multiOptions'      => $resourceTypes,
                 'value'             => $resourceType
-            )
+            ]
         );
 
         if (isset($formData['force_creation']) && $formData['force_creation']) {
@@ -329,15 +329,15 @@ class ResourceConfigForm extends ConfigForm
                 $this->addElement(
                     'note',
                     'inspection_output',
-                    array(
+                    [
                         'order'         => 0,
                         'value'         => '<strong>' . $this->translate('Validation Log') . "</strong>\n\n"
                             . join("\n", array_map($join, $inspection->toArray())),
-                        'decorators'    => array(
+                        'decorators'    => [
                             'ViewHelper',
-                            array('HtmlTag', array('tag' => 'pre', 'class' => 'log-output')),
-                        )
-                    )
+                            ['HtmlTag', ['tag' => 'pre', 'class' => 'log-output']],
+                        ]
+                    ]
                 );
 
                 if ($inspection->hasError()) {
@@ -366,40 +366,40 @@ class ResourceConfigForm extends ConfigForm
     {
         parent::addSubmitButton()
             ->getElement('btn_submit')
-            ->setDecorators(array('ViewHelper'));
+            ->setDecorators(['ViewHelper']);
 
         $this->addElement(
             'submit',
             'resource_validation',
-            array(
+            [
                 'ignore'                => true,
                 'label'                 => $this->translate('Validate Configuration'),
                 'data-progress-label'   => $this->translate('Validation In Progress'),
-                'decorators'            => array('ViewHelper')
-            )
+                'decorators'            => ['ViewHelper']
+            ]
         );
 
         $this->setAttrib('data-progress-element', 'resource-progress');
         $this->addElement(
             'note',
             'resource-progress',
-            array(
-                'decorators'    => array(
+            [
+                'decorators'    => [
                     'ViewHelper',
-                    array('Spinner', array('id' => 'resource-progress'))
-                )
-            )
+                    ['Spinner', ['id' => 'resource-progress']]
+                ]
+            ]
         );
 
         $this->addDisplayGroup(
-            array('btn_submit', 'resource_validation', 'resource-progress'),
+            ['btn_submit', 'resource_validation', 'resource-progress'],
             'submit_validation',
-            array(
-                'decorators' => array(
+            [
+                'decorators' => [
                     'FormElements',
-                    array('HtmlTag', array('tag' => 'div', 'class' => 'control-group form-controls'))
-                )
-            )
+                    ['HtmlTag', ['tag' => 'div', 'class' => 'control-group form-controls']]
+                ]
+            ]
         );
 
         return $this;

--- a/application/forms/Config/User/CreateMembershipForm.php
+++ b/application/forms/Config/User/CreateMembershipForm.php
@@ -65,9 +65,9 @@ class CreateMembershipForm extends Form
      */
     public function createElements(array $formData)
     {
-        $query = $this->createDataSource()->select()->from('group', array('group_name', 'backend_name'));
+        $query = $this->createDataSource()->select()->from('group', ['group_name', 'backend_name']);
 
-        $options = array();
+        $options = [];
         foreach ($query as $row) {
             $options[$row->backend_name . ';' . $row->group_name] = $row->group_name . ' (' . $row->backend_name . ')';
         }
@@ -75,7 +75,7 @@ class CreateMembershipForm extends Form
         $this->addElement(
             'multiselect',
             'groups',
-            array(
+            [
                 'required'      => true,
                 'multiOptions'  => $options,
                 'label'         => $this->translate('Groups'),
@@ -84,7 +84,7 @@ class CreateMembershipForm extends Form
                     $this->userName
                 ),
                 'class'         => 'grant-permissions'
-            )
+            ]
         );
 
         $this->setTitle(sprintf($this->translate('Create memberships for %s'), $this->userName));
@@ -109,7 +109,7 @@ class CreateMembershipForm extends Form
      */
     public function onSuccess()
     {
-        $backendMap = array();
+        $backendMap = [];
         foreach ($this->backends as $backend) {
             $backendMap[$backend->getName()] = $backend;
         }
@@ -121,10 +121,10 @@ class CreateMembershipForm extends Form
             try {
                 $backendMap[$backendName]->insert(
                     'group_membership',
-                    array(
+                    [
                         'group_name'    => $groupName,
                         'user_name'     => $this->userName
-                    )
+                    ]
                 );
             } catch (Exception $e) {
                 Notification::error(sprintf(
@@ -157,22 +157,22 @@ class CreateMembershipForm extends Form
      */
     protected function createDataSource()
     {
-        $groups = $failures = array();
+        $groups = $failures = [];
         foreach ($this->backends as $backend) {
             try {
                 $memberships = $backend
                     ->select()
-                    ->from('group_membership', array('group_name'))
+                    ->from('group_membership', ['group_name'])
                     ->where('user_name', $this->userName)
                     ->fetchColumn();
-                foreach ($backend->select(array('group_name')) as $row) {
+                foreach ($backend->select(['group_name']) as $row) {
                     if (! in_array($row->group_name, $memberships)) { // TODO(jom): Apply this as native query filter
                         $row->backend_name = $backend->getName();
                         $groups[] = $row;
                     }
                 }
             } catch (Exception $e) {
-                $failures[] = array($backend->getName(), $e);
+                $failures[] = [$backend->getName(), $e];
             }
         }
 

--- a/application/forms/Config/User/UserForm.php
+++ b/application/forms/Config/User/UserForm.php
@@ -22,27 +22,27 @@ class UserForm extends RepositoryForm
         $this->addElement(
             'checkbox',
             'is_active',
-            array(
+            [
                 'value'         => true,
                 'label'         => $this->translate('Active'),
                 'description'   => $this->translate('Prevents the user from logging in if unchecked')
-            )
+            ]
         );
         $this->addElement(
             'text',
             'user_name',
-            array(
+            [
                 'required'  => true,
                 'label'     => $this->translate('Username')
-            )
+            ]
         );
         $this->addElement(
             'password',
             'password',
-            array(
+            [
                 'required'  => true,
                 'label'     => $this->translate('Password')
-            )
+            ]
         );
 
         $this->setTitle($this->translate('Add a new user'));
@@ -61,10 +61,10 @@ class UserForm extends RepositoryForm
         $this->addElement(
             'password',
             'password',
-            array(
+            [
                 'description'   => $this->translate('Leave empty for not updating the user\'s password'),
                 'label'         => $this->translate('Password'),
-            )
+            ]
         );
 
         $this->setTitle(sprintf($this->translate('Edit user %s'), $this->getIdentifier()));

--- a/application/forms/Config/UserBackend/DbBackendForm.php
+++ b/application/forms/Config/UserBackend/DbBackendForm.php
@@ -50,18 +50,18 @@ class DbBackendForm extends Form
         $this->addElement(
             'text',
             'name',
-            array(
+            [
                 'required'      => true,
                 'label'         => $this->translate('Backend Name'),
                 'description'   => $this->translate(
                     'The name of this authentication provider that is used to differentiate it from others'
                 )
-            )
+            ]
         );
         $this->addElement(
             'select',
             'resource',
-            array(
+            [
                 'required'      => true,
                 'label'         => $this->translate('Database Connection'),
                 'description'   => $this->translate(
@@ -69,16 +69,16 @@ class DbBackendForm extends Form
                 ),
                 'multiOptions'  => !empty($this->resources)
                     ? array_combine($this->resources, $this->resources)
-                    : array()
-            )
+                    : []
+            ]
         );
         $this->addElement(
             'hidden',
             'backend',
-            array(
+            [
                 'disabled'  => true,
                 'value'     => 'db'
-            )
+            ]
         );
     }
 }

--- a/application/forms/Config/UserBackend/ExternalBackendForm.php
+++ b/application/forms/Config/UserBackend/ExternalBackendForm.php
@@ -29,13 +29,13 @@ class ExternalBackendForm extends Form
         $this->addElement(
             'text',
             'name',
-            array(
+            [
                 'required'      => true,
                 'label'         => $this->translate('Backend Name'),
                 'description'   => $this->translate(
                     'The name of this authentication provider that is used to differentiate it from others'
                 )
-            )
+            ]
         );
         $callbackValidator = new Zend_Validate_Callback(function ($value) {
             return @preg_match($value, '') !== false;
@@ -47,23 +47,23 @@ class ExternalBackendForm extends Form
         $this->addElement(
             'text',
             'strip_username_regexp',
-            array(
+            [
                 'label'         => $this->translate('Filter Pattern'),
                 'description'   => $this->translate(
                     'The filter to use to strip specific parts off from usernames.'
                     . ' Leave empty if you do not want to strip off anything.'
                 ),
                 'requirement'   => $this->translate('The filter pattern must be a valid regular expression.'),
-                'validators'    => array($callbackValidator)
-            )
+                'validators'    => [$callbackValidator]
+            ]
         );
         $this->addElement(
             'hidden',
             'backend',
-            array(
+            [
                 'disabled'  => true,
                 'value'     => 'external'
-            )
+            ]
         );
 
         return $this;

--- a/application/forms/Config/UserBackend/LdapBackendForm.php
+++ b/application/forms/Config/UserBackend/LdapBackendForm.php
@@ -29,7 +29,7 @@ class LdapBackendForm extends Form
      *
      * @var string[]
      */
-    protected $suggestions = array();
+    protected $suggestions = [];
 
     /**
      * Cache for {@link getLdapCapabilities()}
@@ -71,19 +71,19 @@ class LdapBackendForm extends Form
         $this->addElement(
             'text',
             'name',
-            array(
+            [
                 'required'      => true,
                 'label'         => $this->translate('Backend Name'),
                 'description'   => $this->translate(
                     'The name of this authentication provider that is used to differentiate it from others.'
                 ),
                 'value'         => $this->getSuggestion('name')
-            )
+            ]
         );
         $this->addElement(
             'select',
             'resource',
-            array(
+            [
                 'required'      => true,
                 'label'         => $this->translate('LDAP Connection'),
                 'description'   => $this->translate(
@@ -91,16 +91,16 @@ class LdapBackendForm extends Form
                 ),
                 'multiOptions'  => !empty($this->resources)
                     ? array_combine($this->resources, $this->resources)
-                    : array(),
+                    : [],
                 'value'         => $this->getSuggestion('resource')
-            )
+            ]
         );
 
         if (! $isAd && !empty($this->resources)) {
             $this->addElement(
                 'button',
                 'discovery_btn',
-                array(
+                [
                     'class'             => 'control-button',
                     'type'              => 'submit',
                     'value'             => 'discovery_btn',
@@ -108,13 +108,13 @@ class LdapBackendForm extends Form
                     'title'             => $this->translate(
                         'Push to fill in the chosen connection\'s default settings.'
                     ),
-                    'decorators'        => array(
-                        array('ViewHelper', array('separator' => '')),
-                        array('Spinner'),
-                        array('HtmlTag', array('tag' => 'div', 'class' => 'control-group form-controls'))
-                    ),
+                    'decorators'        => [
+                        ['ViewHelper', ['separator' => '']],
+                        ['Spinner'],
+                        ['HtmlTag', ['tag' => 'div', 'class' => 'control-group form-controls']]
+                    ],
                     'formnovalidate'    => 'formnovalidate'
-                )
+                ]
             );
         }
 
@@ -133,7 +133,7 @@ class LdapBackendForm extends Form
         $this->addElement(
             'text',
             'user_class',
-            array(
+            [
                 'preserveDefault'   => true,
                 'required'          => ! $isAd,
                 'ignore'            => $isAd,
@@ -141,12 +141,12 @@ class LdapBackendForm extends Form
                 'label'             => $this->translate('LDAP User Object Class'),
                 'description'       => $this->translate('The object class used for storing users on the LDAP server.'),
                 'value'             => $this->getSuggestion('user_class', $userClass)
-            )
+            ]
         );
         $this->addElement(
             'text',
             'filter',
-            array(
+            [
                 'preserveDefault'   => true,
                 'allowEmpty'        => true,
                 'value'             => $this->getSuggestion('filter', $filter),
@@ -159,11 +159,11 @@ class LdapBackendForm extends Form
                     'The filter needs to be expressed as standard LDAP expression.'
                     . ' (e.g. &(foo=bar)(bar=foo) or foo=bar)'
                 ),
-                'validators'        => array(
-                    array(
+                'validators'        => [
+                    [
                         'Callback',
                         false,
-                        array(
+                        [
                             'callback'  => function ($v) {
                                 // This is not meant to be a full syntax check. It will just
                                 // ensure that we can safely strip unnecessary parentheses.
@@ -172,18 +172,18 @@ class LdapBackendForm extends Form
                                     strpos($v, ')(') !== false ? substr($v, -2) === '))' : substr($v, -1) === ')'
                                 );
                             },
-                            'messages'  => array(
+                            'messages'  => [
                                 'callbackValue' => $this->translate('The filter is invalid. Please check your syntax.')
-                            )
-                        )
-                    )
-                )
-            )
+                            ]
+                        ]
+                    ]
+                ]
+            ]
         );
         $this->addElement(
             'text',
             'user_name_attribute',
-            array(
+            [
                 'preserveDefault'   => true,
                 'required'          => ! $isAd,
                 'ignore'            => $isAd,
@@ -193,20 +193,20 @@ class LdapBackendForm extends Form
                     'The attribute name used for storing the user name on the LDAP server.'
                 ),
                 'value'             => $this->getSuggestion('user_name_attribute', $userNameAttribute)
-            )
+            ]
         );
         $this->addElement(
             'hidden',
             'backend',
-            array(
+            [
                 'disabled'  => true,
                 'value'     => $this->getSuggestion('backend', $isAd ? 'msldap' : 'ldap')
-            )
+            ]
         );
         $this->addElement(
             'text',
             'base_dn',
-            array(
+            [
                 'preserveDefault'   => true,
                 'required'          => false,
                 'label'             => $this->translate('LDAP Base DN'),
@@ -215,13 +215,13 @@ class LdapBackendForm extends Form
                     'empty to select all users available using the specified connection.'
                 ),
                 'value'             => $this->getSuggestion('base_dn')
-            )
+            ]
         );
 
         $this->addElement(
             'text',
             'domain',
-            array(
+            [
                 'label'         => $this->translate('Domain'),
                 'description'   => $this->translate(
                     'The domain the LDAP server is responsible for upon authentication.'
@@ -234,13 +234,13 @@ class LdapBackendForm extends Form
                 ),
                 'preserveDefault' => true,
                 'value'         => $this->getSuggestion('domain')
-            )
+            ]
         );
 
         $this->addElement(
             'button',
             'btn_discover_domain',
-            array(
+            [
                 'class'             => 'control-button',
                 'type'              => 'submit',
                 'value'             => 'discovery_btn',
@@ -248,13 +248,13 @@ class LdapBackendForm extends Form
                 'title'             => $this->translate(
                     'Push to disover and fill in the domain of the LDAP server.'
                 ),
-                'decorators'        => array(
-                    array('ViewHelper', array('separator' => '')),
-                    array('Spinner'),
-                    array('HtmlTag', array('tag' => 'div', 'class' => 'control-group form-controls'))
-                ),
+                'decorators'        => [
+                    ['ViewHelper', ['separator' => '']],
+                    ['Spinner'],
+                    ['HtmlTag', ['tag' => 'div', 'class' => 'control-group form-controls']]
+                ],
                 'formnovalidate'    => 'formnovalidate'
-            )
+            ]
         );
     }
 
@@ -368,9 +368,9 @@ class LdapBackendForm extends Form
     {
         $defaultNamingContext = $cap->getDefaultNamingContext();
         if ($defaultNamingContext !== null) {
-            $validationMatches = array();
+            $validationMatches = [];
             if (preg_match('/\bdc=[^,]+(?:,dc=[^,]+)*$/', strtolower($defaultNamingContext), $validationMatches)) {
-                $splitMatches = array();
+                $splitMatches = [];
                 preg_match_all('/dc=([^,]+)/', $validationMatches[0], $splitMatches);
                 return implode('.', $splitMatches[1]);
             }

--- a/application/forms/Config/UserBackendConfigForm.php
+++ b/application/forms/Config/UserBackendConfigForm.php
@@ -68,9 +68,9 @@ class UserBackendConfigForm extends ConfigForm
      */
     public function setResourceConfig(Config $resourceConfig)
     {
-        $resources = array();
+        $resources = [];
         foreach ($resourceConfig as $name => $resource) {
-            if (in_array($resource->type, array('db', 'ldap'))) {
+            if (in_array($resource->type, ['db', 'ldap'])) {
                 $resources[$resource->type][] = $name;
             }
         }
@@ -113,12 +113,12 @@ class UserBackendConfigForm extends ConfigForm
         switch ($type) {
             case 'db':
                 $form = new DbBackendForm();
-                $form->setResources(isset($this->resources['db']) ? $this->resources['db'] : array());
+                $form->setResources(isset($this->resources['db']) ? $this->resources['db'] : []);
                 break;
             case 'ldap':
             case 'msldap':
                 $form = new LdapBackendForm();
-                $form->setResources(isset($this->resources['ldap']) ? $this->resources['ldap'] : array());
+                $form->setResources(isset($this->resources['ldap']) ? $this->resources['ldap'] : []);
                 break;
             case 'external':
                 $form = new ExternalBackendForm();
@@ -250,7 +250,7 @@ class UserBackendConfigForm extends ConfigForm
         array_splice($backendOrder, array_search($name, $backendOrder), 1);
         array_splice($backendOrder, $position, 0, $name);
 
-        $newConfig = array();
+        $newConfig = [];
         foreach ($backendOrder as $backendName) {
             $newConfig[$backendName] = $this->config->getSection($backendName);
         }
@@ -267,7 +267,7 @@ class UserBackendConfigForm extends ConfigForm
      */
     public function createElements(array $formData)
     {
-        $backendTypes = array();
+        $backendTypes = [];
         $backendType = isset($formData['type']) ? $formData['type'] : null;
 
         if (isset($this->resources['db'])) {
@@ -298,7 +298,7 @@ class UserBackendConfigForm extends ConfigForm
         $this->addElement(
             'select',
             'type',
-            array(
+            [
                 'ignore'            => true,
                 'required'          => true,
                 'autosubmit'        => true,
@@ -307,7 +307,7 @@ class UserBackendConfigForm extends ConfigForm
                     'The type of the resource to use for this authenticaton provider'
                 ),
                 'multiOptions'      => $backendTypes
-            )
+            ]
         );
 
         if (isset($formData['skip_validation']) && $formData['skip_validation']) {
@@ -384,14 +384,14 @@ class UserBackendConfigForm extends ConfigForm
         $this->addElement(
             'checkbox',
             'skip_validation',
-            array(
+            [
                 'order'         => 0,
                 'ignore'        => true,
                 'label'         => $this->translate('Skip Validation'),
                 'description'   => $this->translate(
                     'Check this box to enforce changes without validating that authentication is possible.'
                 )
-            )
+            ]
         );
     }
 
@@ -419,15 +419,15 @@ class UserBackendConfigForm extends ConfigForm
                 $this->addElement(
                     'note',
                     'inspection_output',
-                    array(
+                    [
                         'order'         => 0,
                         'value'         => '<strong>' . $this->translate('Validation Log') . "</strong>\n\n"
                             . join("\n", array_map($join, $inspection->toArray())),
-                        'decorators'    => array(
+                        'decorators'    => [
                             'ViewHelper',
-                            array('HtmlTag', array('tag' => 'pre', 'class' => 'log-output')),
-                        )
-                    )
+                            ['HtmlTag', ['tag' => 'pre', 'class' => 'log-output']],
+                        ]
+                    ]
                 );
 
                 if ($inspection->hasError()) {
@@ -456,27 +456,27 @@ class UserBackendConfigForm extends ConfigForm
     {
         parent::addSubmitButton()
             ->getElement('btn_submit')
-            ->setDecorators(array('ViewHelper'));
+            ->setDecorators(['ViewHelper']);
 
         $this->addElement(
             'submit',
             'backend_validation',
-            array(
+            [
                 'ignore'                => true,
                 'label'                 => $this->translate('Validate Configuration'),
                 'data-progress-label'   => $this->translate('Validation In Progress'),
-                'decorators'            => array('ViewHelper')
-            )
+                'decorators'            => ['ViewHelper']
+            ]
         );
         $this->addDisplayGroup(
-            array('btn_submit', 'backend_validation'),
+            ['btn_submit', 'backend_validation'],
             'submit_validation',
-            array(
-                'decorators' => array(
+            [
+                'decorators' => [
                     'FormElements',
-                    array('HtmlTag', array('tag' => 'div', 'class' => 'control-group form-controls'))
-                )
-            )
+                    ['HtmlTag', ['tag' => 'div', 'class' => 'control-group form-controls']]
+                ]
+            ]
         );
 
         return $this;

--- a/application/forms/Config/UserGroup/AddMemberForm.php
+++ b/application/forms/Config/UserGroup/AddMemberForm.php
@@ -91,37 +91,37 @@ class AddMemberForm extends Form
         // not work currently as our ldap protocol stuff is unable to handle our filter implementation..
         $members = $this->backend
             ->select()
-            ->from('group_membership', array('user_name'))
+            ->from('group_membership', ['user_name'])
             ->where('group_name', $this->groupName)
             ->fetchColumn();
         $filter = empty($members) ? Filter::matchAll() : Filter::not(Filter::where('user_name', $members));
 
-        $users = $this->ds->select()->from('user', array('user_name'))->applyFilter($filter)->fetchColumn();
+        $users = $this->ds->select()->from('user', ['user_name'])->applyFilter($filter)->fetchColumn();
         if (! empty($users)) {
             $this->addElement(
                 'multiselect',
                 'user_name',
-                array(
+                [
                     'multiOptions'  => array_combine($users, $users),
                     'label'         => $this->translate('Backend Users'),
                     'description'   => $this->translate(
                         'Select one or more users (fetched from your user backends) to add as group member'
                     ),
                     'class'         => 'grant-permissions'
-                )
+                ]
             );
         }
 
         $this->addElement(
             'textarea',
             'users',
-            array(
+            [
                 'required'      => empty($users),
                 'label'         => $this->translate('Users'),
                 'description'   => $this->translate(
                     'Provide one or more usernames separated by comma to add as group member'
                 )
-            )
+            ]
         );
 
         $this->setTitle(sprintf($this->translate('Add members for group %s'), $this->groupName));
@@ -135,7 +135,7 @@ class AddMemberForm extends Form
      */
     public function onSuccess()
     {
-        $userNames = $this->getValue('user_name') ?: array();
+        $userNames = $this->getValue('user_name') ?: [];
         if (($users = $this->getValue('users'))) {
             $userNames = array_merge($userNames, array_map('trim', explode(',', $users)));
         }
@@ -154,10 +154,10 @@ class AddMemberForm extends Form
             try {
                 $this->backend->insert(
                     'group_membership',
-                    array(
+                    [
                         'group_name'    => $this->groupName,
                         'user_name'     => $userName
-                    )
+                    ]
                 );
             } catch (NotFoundError $e) {
                 throw $e; // Trigger 404, the group name is initially accessed as GET parameter

--- a/application/forms/Config/UserGroup/DbUserGroupBackendForm.php
+++ b/application/forms/Config/UserGroup/DbUserGroupBackendForm.php
@@ -31,34 +31,34 @@ class DbUserGroupBackendForm extends Form
         $this->addElement(
             'text',
             'name',
-            array(
+            [
                 'required'      => true,
                 'label'         => $this->translate('Backend Name'),
                 'description'   => $this->translate(
                     'The name of this user group backend that is used to differentiate it from others'
                 )
-            )
+            ]
         );
 
         $resourceNames = $this->getDatabaseResourceNames();
         $this->addElement(
             'select',
             'resource',
-            array(
+            [
                 'required'      => true,
                 'label'         => $this->translate('Database Connection'),
                 'description'   => $this->translate('The database connection to use for this backend'),
-                'multiOptions'  => empty($resourceNames) ? array() : array_combine($resourceNames, $resourceNames)
-            )
+                'multiOptions'  => empty($resourceNames) ? [] : array_combine($resourceNames, $resourceNames)
+            ]
         );
 
         $this->addElement(
             'hidden',
             'backend',
-            array(
+            [
                 'disabled'  => true, // Prevents the element from being submitted, see #7717
                 'value'     => 'db'
-            )
+            ]
         );
     }
 
@@ -69,7 +69,7 @@ class DbUserGroupBackendForm extends Form
      */
     protected function getDatabaseResourceNames()
     {
-        $names = array();
+        $names = [];
         foreach (ResourceFactory::getResourceConfigs() as $name => $config) {
             if (strtolower($config->type) === 'db') {
                 $names[] = $name;

--- a/application/forms/Config/UserGroup/LdapUserGroupBackendForm.php
+++ b/application/forms/Config/UserGroup/LdapUserGroupBackendForm.php
@@ -36,26 +36,26 @@ class LdapUserGroupBackendForm extends Form
         $this->addElement(
             'text',
             'name',
-            array(
+            [
                 'required'      => true,
                 'label'         => $this->translate('Backend Name'),
                 'description'   => $this->translate(
                     'The name of this user group backend that is used to differentiate it from others'
                 )
-            )
+            ]
         );
 
         $resourceNames = $this->getLdapResourceNames();
         $this->addElement(
             'select',
             'resource',
-            array(
+            [
                 'required'      => true,
                 'autosubmit'    => true,
                 'label'         => $this->translate('LDAP Connection'),
                 'description'   => $this->translate('The LDAP connection to use for this backend.'),
                 'multiOptions'  => array_combine($resourceNames, $resourceNames)
-            )
+            ]
         );
         $resource = ResourceFactory::create(
             isset($formData['resource']) && in_array($formData['resource'], $resourceNames)
@@ -68,18 +68,18 @@ class LdapUserGroupBackendForm extends Form
             $userBackends = array_combine($userBackendNames, $userBackendNames);
             $userBackends['none'] = $this->translate('None', 'usergroupbackend.ldap.user_backend');
         } else {
-            $userBackends = array('none' => $this->translate('None', 'usergroupbackend.ldap.user_backend'));
+            $userBackends = ['none' => $this->translate('None', 'usergroupbackend.ldap.user_backend')];
         }
         $this->addElement(
             'select',
             'user_backend',
-            array(
+            [
                 'required'      => true,
                 'autosubmit'    => true,
                 'label'         => $this->translate('User Backend'),
                 'description'   => $this->translate('The user backend to link with this user group backend.'),
                 'multiOptions'  => $userBackends
-            )
+            ]
         );
 
         $groupBackend = new LdapUserGroupBackend($resource);
@@ -95,16 +95,16 @@ class LdapUserGroupBackendForm extends Form
             $this->addElement(
                 'checkbox',
                 'nested_group_search',
-                array(
+                [
                     'description'   => $this->translate(
                         'Check this box for nested group search in Active Directory based on the user'
                     ),
                     'label'         => $this->translate('Nested Group Search')
-                )
+                ]
             );
         } else {
             // This is required to purge already present options
-            $this->addElement('hidden', 'nested_group_search', array('disabled' => true));
+            $this->addElement('hidden', 'nested_group_search', ['disabled' => true]);
         }
 
         $this->createGroupConfigElements($defaults, $groupConfigDisabled);
@@ -117,10 +117,10 @@ class LdapUserGroupBackendForm extends Form
         $this->addElement(
             'hidden',
             'backend',
-            array(
+            [
                 'disabled'  => true, // Prevents the element from being submitted, see #7717
                 'value'     => $formData['type']
-            )
+            ]
         );
     }
 
@@ -135,19 +135,19 @@ class LdapUserGroupBackendForm extends Form
         $this->addElement(
             'text',
             'group_class',
-            array(
+            [
                 'preserveDefault'   => true,
                 'ignore'            => $disabled,
                 'disabled'          => $disabled,
                 'label'             => $this->translate('LDAP Group Object Class'),
                 'description'       => $this->translate('The object class used for storing groups on the LDAP server.'),
                 'value'             => $defaults->group_class
-            )
+            ]
         );
         $this->addElement(
             'text',
             'group_filter',
-            array(
+            [
                 'preserveDefault'   => true,
                 'allowEmpty'        => true,
                 'label'             => $this->translate('LDAP Group Filter'),
@@ -159,27 +159,27 @@ class LdapUserGroupBackendForm extends Form
                     'The filter needs to be expressed as standard LDAP expression, without'
                     . ' outer parentheses. (e.g. &(foo=bar)(bar=foo) or foo=bar)'
                 ),
-                'validators'        => array(
-                    array(
+                'validators'        => [
+                    [
                         'Callback',
                         false,
-                        array(
+                        [
                             'callback'  => function ($v) {
                                 return strpos($v, '(') !== 0;
                             },
-                            'messages'  => array(
+                            'messages'  => [
                                 'callbackValue' => $this->translate('The filter must not be wrapped in parantheses.')
-                            )
-                        )
-                    )
-                ),
+                            ]
+                        ]
+                    ]
+                ],
                 'value'             => $defaults->group_filter
-            )
+            ]
         );
         $this->addElement(
             'text',
             'group_name_attribute',
-            array(
+            [
                 'preserveDefault'   => true,
                 'ignore'            => $disabled,
                 'disabled'          => $disabled,
@@ -188,24 +188,24 @@ class LdapUserGroupBackendForm extends Form
                     'The attribute name used for storing a group\'s name on the LDAP server.'
                 ),
                 'value'             => $defaults->group_name_attribute
-            )
+            ]
         );
         $this->addElement(
             'text',
             'group_member_attribute',
-            array(
+            [
                 'preserveDefault'   => true,
                 'ignore'            => $disabled,
                 'disabled'          => $disabled,
                 'label'             => $this->translate('LDAP Group Member Attribute'),
                 'description'       => $this->translate('The attribute name used for storing a group\'s members.'),
                 'value'             => $defaults->group_member_attribute
-            )
+            ]
         );
         $this->addElement(
             'text',
             'base_dn',
-            array(
+            [
                 'preserveDefault'   => true,
                 'label'             => $this->translate('LDAP Group Base DN'),
                 'description'       => $this->translate(
@@ -213,7 +213,7 @@ class LdapUserGroupBackendForm extends Form
                     'empty to select all users available using the specified connection.'
                 ),
                 'value'             => $defaults->base_dn
-            )
+            ]
         );
     }
 
@@ -228,19 +228,19 @@ class LdapUserGroupBackendForm extends Form
         $this->addElement(
             'text',
             'user_class',
-            array(
+            [
                 'preserveDefault'   => true,
                 'ignore'            => $disabled,
                 'disabled'          => $disabled,
                 'label'             => $this->translate('LDAP User Object Class'),
                 'description'       => $this->translate('The object class used for storing users on the LDAP server.'),
                 'value'             => $defaults->user_class
-            )
+            ]
         );
         $this->addElement(
             'text',
             'user_filter',
-            array(
+            [
                 'preserveDefault'   => true,
                 'allowEmpty'        => true,
                 'label'             => $this->translate('LDAP User Filter'),
@@ -252,27 +252,27 @@ class LdapUserGroupBackendForm extends Form
                     'The filter needs to be expressed as standard LDAP expression, without'
                     . ' outer parentheses. (e.g. &(foo=bar)(bar=foo) or foo=bar)'
                 ),
-                'validators'        => array(
-                    array(
+                'validators'        => [
+                    [
                         'Callback',
                         false,
-                        array(
+                        [
                             'callback'  => function ($v) {
                                 return strpos($v, '(') !== 0;
                             },
-                            'messages'  => array(
+                            'messages'  => [
                                 'callbackValue' => $this->translate('The filter must not be wrapped in parantheses.')
-                            )
-                        )
-                    )
-                ),
+                            ]
+                        ]
+                    ]
+                ],
                 'value'             => $defaults->user_filter
-            )
+            ]
         );
         $this->addElement(
             'text',
             'user_name_attribute',
-            array(
+            [
                 'preserveDefault'   => true,
                 'ignore'            => $disabled,
                 'disabled'          => $disabled,
@@ -281,12 +281,12 @@ class LdapUserGroupBackendForm extends Form
                     'The attribute name used for storing a user\'s name on the LDAP server.'
                 ),
                 'value'             => $defaults->user_name_attribute
-            )
+            ]
         );
         $this->addElement(
             'text',
             'user_base_dn',
-            array(
+            [
                 'preserveDefault'   => true,
                 'label'             => $this->translate('LDAP User Base DN'),
                 'description'       => $this->translate(
@@ -294,17 +294,17 @@ class LdapUserGroupBackendForm extends Form
                     'empty to select all users available using the specified connection.'
                 ),
                 'value'             => $defaults->user_base_dn
-            )
+            ]
         );
         $this->addElement(
             'text',
             'domain',
-            array(
+            [
                 'label'         => $this->translate('Domain'),
                 'description'   => $this->translate(
                     'The domain the LDAP server is responsible for.'
                 )
-            )
+            ]
         );
     }
 
@@ -315,11 +315,11 @@ class LdapUserGroupBackendForm extends Form
      */
     protected function createHiddenUserConfigElements()
     {
-        $this->addElement('hidden', 'user_class', array('disabled' => true));
-        $this->addElement('hidden', 'user_filter', array('disabled' => true));
-        $this->addElement('hidden', 'user_name_attribute', array('disabled' => true));
-        $this->addElement('hidden', 'user_base_dn', array('disabled' => true));
-        $this->addElement('hidden', 'domain', array('disabled' => true));
+        $this->addElement('hidden', 'user_class', ['disabled' => true]);
+        $this->addElement('hidden', 'user_filter', ['disabled' => true]);
+        $this->addElement('hidden', 'user_name_attribute', ['disabled' => true]);
+        $this->addElement('hidden', 'user_base_dn', ['disabled' => true]);
+        $this->addElement('hidden', 'domain', ['disabled' => true]);
     }
 
     /**
@@ -329,9 +329,9 @@ class LdapUserGroupBackendForm extends Form
      */
     protected function getLdapResourceNames()
     {
-        $names = array();
+        $names = [];
         foreach (ResourceFactory::getResourceConfigs() as $name => $config) {
-            if (in_array(strtolower($config->type), array('ldap', 'msldap'))) {
+            if (in_array(strtolower($config->type), ['ldap', 'msldap'])) {
                 $names[] = $name;
             }
         }
@@ -355,9 +355,9 @@ class LdapUserGroupBackendForm extends Form
      */
     protected function getLdapUserBackendNames(LdapConnection $resource)
     {
-        $names = array();
+        $names = [];
         foreach (UserBackend::getBackendConfigs() as $name => $config) {
-            if (in_array(strtolower($config->backend), array('ldap', 'msldap'))) {
+            if (in_array(strtolower($config->backend), ['ldap', 'msldap'])) {
                 $backendResource = ResourceFactory::create($config->resource);
                 if ($backendResource->getHostname() === $resource->getHostname()
                     && $backendResource->getPort() === $resource->getPort()

--- a/application/forms/Config/UserGroup/UserGroupBackendForm.php
+++ b/application/forms/Config/UserGroup/UserGroupBackendForm.php
@@ -188,11 +188,11 @@ class UserGroupBackendForm extends ConfigForm
      */
     public function createElements(array $formData)
     {
-        $backendTypes = array(
+        $backendTypes = [
             'db'        => $this->translate('Database'),
             'ldap'      => 'LDAP',
             'msldap'    => 'ActiveDirectory'
-        );
+        ];
 
         $customBackendTypes = array_keys($this->customBackends);
         $backendTypes += array_combine($customBackendTypes, $customBackendTypes);
@@ -205,14 +205,14 @@ class UserGroupBackendForm extends ConfigForm
         $this->addElement(
             'select',
             'type',
-            array(
+            [
                 'ignore'            => true,
                 'required'          => true,
                 'autosubmit'        => true,
                 'label'             => $this->translate('Backend Type'),
                 'description'       => $this->translate('The type of this user group backend'),
                 'multiOptions'      => $backendTypes
-            )
+            ]
         );
 
         $this->addSubForm($this->getBackendForm($backendType)->create($formData), 'backend_form');
@@ -251,15 +251,15 @@ class UserGroupBackendForm extends ConfigForm
                 $this->addElement(
                     'note',
                     'inspection_output',
-                    array(
+                    [
                         'order'         => 0,
                         'value'         => '<strong>' . $this->translate('Validation Log') . "</strong>\n\n"
                             . join("\n", array_map($join, $inspection->toArray())),
-                        'decorators'    => array(
+                        'decorators'    => [
                             'ViewHelper',
-                            array('HtmlTag', array('tag' => 'pre', 'class' => 'log-output')),
-                        )
-                    )
+                            ['HtmlTag', ['tag' => 'pre', 'class' => 'log-output']],
+                        ]
+                    ]
                 );
 
                 if ($inspection->hasError()) {
@@ -288,27 +288,27 @@ class UserGroupBackendForm extends ConfigForm
     {
         parent::addSubmitButton()
             ->getElement('btn_submit')
-            ->setDecorators(array('ViewHelper'));
+            ->setDecorators(['ViewHelper']);
 
         $this->addElement(
             'submit',
             'backend_validation',
-            array(
+            [
                 'ignore'                => true,
                 'label'                 => $this->translate('Validate Configuration'),
                 'data-progress-label'   => $this->translate('Validation In Progress'),
-                'decorators'            => array('ViewHelper')
-            )
+                'decorators'            => ['ViewHelper']
+            ]
         );
         $this->addDisplayGroup(
-            array('btn_submit', 'backend_validation'),
+            ['btn_submit', 'backend_validation'],
             'submit_validation',
-            array(
-                'decorators' => array(
+            [
+                'decorators' => [
                     'FormElements',
-                    array('HtmlTag', array('tag' => 'div', 'class' => 'control-group form-controls'))
-                )
-            )
+                    ['HtmlTag', ['tag' => 'div', 'class' => 'control-group form-controls']]
+                ]
+            ]
         );
 
         return $this;

--- a/application/forms/Config/UserGroup/UserGroupForm.php
+++ b/application/forms/Config/UserGroup/UserGroupForm.php
@@ -22,10 +22,10 @@ class UserGroupForm extends RepositoryForm
         $this->addElement(
             'text',
             'group_name',
-            array(
+            [
                 'required'  => true,
                 'label'     => $this->translate('Group Name')
-            )
+            ]
         );
 
         if ($this->shouldInsert()) {

--- a/application/forms/ConfigForm.php
+++ b/application/forms/ConfigForm.php
@@ -72,7 +72,7 @@ class ConfigForm extends Form
 
     public function onSuccess()
     {
-        $sections = array();
+        $sections = [];
         foreach (static::transformEmptyValuesToNull($this->getValues()) as $sectionAndPropertyName => $value) {
             list($section, $property) = explode('_', $sectionAndPropertyName, 2);
             $sections[$section][$property] = $value;
@@ -102,7 +102,7 @@ class ConfigForm extends Form
 
     public function onRequest()
     {
-        $values = array();
+        $values = [];
         foreach ($this->config as $section => $properties) {
             foreach ($properties as $name => $value) {
                 $values[$section . '_' . $name] = $value;
@@ -128,14 +128,14 @@ class ConfigForm extends Form
 
             return false;
         } catch (Exception $e) {
-            $this->addDecorator('ViewScript', array(
+            $this->addDecorator('ViewScript', [
                 'viewModule'    => 'default',
                 'viewScript'    => 'showConfiguration.phtml',
                 'errorMessage'  => $e->getMessage(),
                 'configString'  => $this->config,
                 'filePath'      => $this->config->getConfigFile(),
                 'placement'     => Zend_Form_Decorator_Abstract::PREPEND
-            ));
+            ]);
             return false;
         }
 
@@ -184,7 +184,7 @@ class ConfigForm extends Form
     public static function transformEmptyValuesToNull(array $values)
     {
         array_walk($values, function (&$v) {
-            if ($v === '' || $v === false || $v === array()) {
+            if ($v === '' || $v === false || $v === []) {
                 $v = null;
             }
         });

--- a/application/forms/Control/LimiterControlForm.php
+++ b/application/forms/Control/LimiterControlForm.php
@@ -31,13 +31,13 @@ class LimiterControlForm extends Form
      *
      * @var int[]
      */
-    public static $limits = array(
+    public static $limits = [
         10  => '10',
         25  => '25',
         50  => '50',
         100 => '100',
         500 => '500'
-    );
+    ];
 
     public static $defaultElementDecorators = [
         ['Label', ['tag' => 'span', 'separator' => '']],
@@ -114,13 +114,13 @@ class LimiterControlForm extends Form
         $this->addElement(
             'select',
             'limit',
-            array(
+            [
                 'autosubmit'    => true,
                 'escape'        => false,
                 'label'         => '#',
                 'multiOptions'  => $options,
                 'value'         => $pageSize
-            )
+            ]
         );
     }
 

--- a/application/forms/Dashboard/DashletForm.php
+++ b/application/forms/Dashboard/DashletForm.php
@@ -41,8 +41,8 @@ class DashletForm extends Form
      */
     public function createElements(array $formData)
     {
-        $groupElements  = array();
-        $panes          = array();
+        $groupElements  = [];
+        $panes          = [];
 
         if ($this->dashboard) {
             $panes = $this->dashboard->getPaneKeyTitleArray();
@@ -62,81 +62,81 @@ class DashletForm extends Form
         $this->addElement(
             'hidden',
             'org_pane',
-            array(
+            [
                 'required' => false
-            )
+            ]
         );
 
         $this->addElement(
             'hidden',
             'org_dashlet',
-            array(
+            [
                 'required' => false
-            )
+            ]
         );
 
         $this->addElement(
             'textarea',
             'url',
-            array(
+            [
                 'required'      => true,
                 'label'         => $this->translate('Url'),
                 'description'   => $this->translate(
                     'Enter url to be loaded in the dashlet. You can paste the full URL, including filters.'
                 ),
-                'validators'    => array(new UrlValidator(), new InternalUrlValidator())
-            )
+                'validators'    => [new UrlValidator(), new InternalUrlValidator()]
+            ]
         );
         $this->addElement(
             'text',
             'dashlet',
-            array(
+            [
                 'required'      => true,
                 'label'         => $this->translate('Dashlet Title'),
                 'description'   => $this->translate('Enter a title for the dashlet.'),
                 'validators'    => [$sectionNameValidator]
-            )
+            ]
         );
         $this->addElement(
             'note',
             'note',
-            array(
-                'decorators' => array(
-                    array('HtmlTag', array('tag' => 'hr'))
-                )
-            )
+            [
+                'decorators' => [
+                    ['HtmlTag', ['tag' => 'hr']]
+                ]
+            ]
         );
         $this->addElement(
             'checkbox',
             'create_new_pane',
-            array(
+            [
                 'autosubmit'    => true,
                 'required'      => false,
                 'label'         => $this->translate('New dashboard'),
                 'description'   => $this->translate('Check this box if you want to add the dashlet to a new dashboard')
-            )
+            ]
         );
         if (empty($panes) || ((isset($formData['create_new_pane']) && $formData['create_new_pane'] != false))) {
             $this->addElement(
                 'text',
                 'pane',
-                array(
+                [
                     'required'      => true,
                     'label'         => $this->translate('New Dashboard Title'),
                     'description'   => $this->translate('Enter a title for the new dashboard'),
                     'validators'    => [$sectionNameValidator]
-                )
+                ]
             );
         } else {
             $this->addElement(
                 'select',
                 'pane',
-                array(
+                [
                     'required'      => true,
                     'label'         => $this->translate('Dashboard'),
                     'multiOptions'  => $panes,
                     'description'   => $this->translate('Select a dashboard you want to add the dashlet to')
-                )
+                ]
             );
         }
     }
@@ -162,12 +162,12 @@ class DashletForm extends Form
      */
     public function load(Dashlet $dashlet)
     {
-        $this->populate(array(
+        $this->populate([
             'pane'          => $dashlet->getPane()->getTitle(),
             'org_pane'      => $dashlet->getPane()->getName(),
             'dashlet'       => $dashlet->getTitle(),
             'org_dashlet'   => $dashlet->getName(),
             'url'           => $dashlet->getUrl()->getRelativeUrl()
-        ));
+        ]);
     }
 }

--- a/application/forms/LdapDiscoveryForm.php
+++ b/application/forms/LdapDiscoveryForm.php
@@ -25,10 +25,10 @@ class LdapDiscoveryForm extends Form
         $this->addElement(
             'text',
             'domain',
-            array(
+            [
                 'label'         => $this->translate('Search Domain'),
                 'description'   => $this->translate('Search this domain for records of available servers.'),
-            )
+            ]
         );
 
         return $this;

--- a/application/forms/Navigation/DashletForm.php
+++ b/application/forms/Navigation/DashletForm.php
@@ -15,23 +15,23 @@ class DashletForm extends NavigationItemForm
         $this->addElement(
             'text',
             'pane',
-            array(
+            [
                 'required'      => true,
                 'label'         => $this->translate('Pane'),
                 'description'   => $this->translate('The name of the dashboard pane in which to display this dashlet')
-            )
+            ]
         );
         $this->addElement(
             'text',
             'url',
-            array(
+            [
                 'required'      => true,
                 'label'         => $this->translate('Url'),
                 'description'   => $this->translate(
                     'The url to load in the dashlet. For external urls, make sure to prepend'
                     . ' an appropriate protocol identifier (e.g. http://example.tld)'
                 )
-            )
+            ]
         );
     }
 }

--- a/application/forms/Navigation/NavigationConfigForm.php
+++ b/application/forms/Navigation/NavigationConfigForm.php
@@ -198,7 +198,7 @@ class NavigationConfigForm extends ConfigForm
      */
     public function getItemTypes()
     {
-        return $this->itemTypes ?: array();
+        return $this->itemTypes ?: [];
     }
 
     /**
@@ -211,9 +211,9 @@ class NavigationConfigForm extends ConfigForm
      */
     public function listAvailableParents($type, $owner = null)
     {
-        $children = $this->itemToLoad ? $this->getFlattenedChildren($this->itemToLoad) : array();
+        $children = $this->itemToLoad ? $this->getFlattenedChildren($this->itemToLoad) : [];
 
-        $names = array();
+        $names = [];
         foreach ($this->getShareConfig($type) as $sectionName => $sectionConfig) {
             if ((string) $sectionName !== $this->itemToLoad
                 && $sectionConfig->owner === ($owner ?: $this->getUser()->getUsername())
@@ -245,10 +245,10 @@ class NavigationConfigForm extends ConfigForm
     {
         $config = $this->getConfigForItem($name);
         if ($config === null) {
-            return array();
+            return [];
         }
 
-        $children = array();
+        $children = [];
         foreach ($config->toArray() as $sectionName => $sectionConfig) {
             if (isset($sectionConfig['parent']) && $sectionConfig['parent'] === $name) {
                 $children[] = $sectionName;
@@ -572,13 +572,13 @@ class NavigationConfigForm extends ConfigForm
         $this->addElement(
             'text',
             'name',
-            array(
+            [
                 'required'      => true,
                 'label'         => $this->translate('Name'),
                 'description'   => $this->translate(
                     'The name of this navigation item that is used to differentiate it from others'
                 )
-            )
+            ]
         );
 
         if ((! $itemForm->requiresParentSelection() || ! isset($formData['parent']) || ! $formData['parent'])
@@ -589,13 +589,13 @@ class NavigationConfigForm extends ConfigForm
             $this->addElement(
                 'checkbox',
                 'shared',
-                array(
+                [
                     'autosubmit'    => true,
                     'ignore'        => true,
                     'value'         => $checked,
                     'label'         => $this->translate('Shared'),
                     'description'   => $this->translate('Tick this box to share this item with others')
-                )
+                ]
             );
 
             if ($checked || (isset($formData['shared']) && $formData['shared'])) {
@@ -603,22 +603,22 @@ class NavigationConfigForm extends ConfigForm
                 $this->addElement(
                     'textarea',
                     'users',
-                    array(
+                    [
                         'label'         => $this->translate('Users'),
                         'description'   => $this->translate(
                             'Comma separated list of usernames to share this item with'
                         )
-                    )
+                    ]
                 );
                 $this->addElement(
                     'textarea',
                     'groups',
-                    array(
+                    [
                         'label'         => $this->translate('Groups'),
                         'description'   => $this->translate(
                             'Comma separated list of group names to share this item with'
                         )
-                    )
+                    ]
                 );
             }
         }
@@ -627,21 +627,21 @@ class NavigationConfigForm extends ConfigForm
             $this->addElement(
                 'hidden',
                 'type',
-                array(
+                [
                     'value' => $itemType
-                )
+                ]
             );
         } else {
             $this->addElement(
                 'select',
                 'type',
-                array(
+                [
                     'required'      => true,
                     'autosubmit'    => true,
                     'label'         => $this->translate('Type'),
                     'description'   => $this->translate('The type of this navigation item'),
                     'multiOptions'  => $itemTypes
-                )
+                ]
             );
         }
 
@@ -656,7 +656,7 @@ class NavigationConfigForm extends ConfigForm
             $this->addElement(
                 'select',
                 'parent',
-                array(
+                [
                     'allowEmpty'    => true,
                     'autosubmit'    => true,
                     'label'         => $this->translate('Parent'),
@@ -666,7 +666,7 @@ class NavigationConfigForm extends ConfigForm
                     ),
                     'multiOptions'  => ['' => $this->translate('None', 'No parent for a navigation item')]
                         + (empty($availableParents) ? [] : array_combine($availableParents, $availableParents))
-                )
+                ]
             );
         } else {
             $this->addElement('hidden', 'parent', ['disabled'  => true]);
@@ -694,7 +694,7 @@ class NavigationConfigForm extends ConfigForm
             $data['name'] = $this->itemToLoad;
             $this->populate($data);
         } elseif ($this->defaultUrl !== null) {
-            $this->populate(array('url' => $this->defaultUrl));
+            $this->populate(['url' => $this->defaultUrl]);
         }
     }
 
@@ -709,7 +709,7 @@ class NavigationConfigForm extends ConfigForm
 
         $valid = true;
         if (isset($formData['users']) && $formData['users']) {
-            $parsedUserRestrictions = array();
+            $parsedUserRestrictions = [];
             foreach (Auth::getInstance()->getRestrictions('application/share/users') as $userRestriction) {
                 $parsedUserRestrictions[] = array_map('trim', explode(',', $userRestriction));
             }
@@ -733,7 +733,7 @@ class NavigationConfigForm extends ConfigForm
         }
 
         if (isset($formData['groups']) && $formData['groups']) {
-            $parsedGroupRestrictions = array();
+            $parsedGroupRestrictions = [];
             foreach (Auth::getInstance()->getRestrictions('application/share/groups') as $groupRestriction) {
                 $parsedGroupRestrictions[] = array_map('trim', explode(',', $groupRestriction));
             }

--- a/application/forms/Navigation/NavigationItemForm.php
+++ b/application/forms/Navigation/NavigationItemForm.php
@@ -35,23 +35,23 @@ class NavigationItemForm extends Form
         $this->addElement(
             'select',
             'target',
-            array(
+            [
                 'allowEmpty'    => true,
                 'label'         => $this->translate('Target'),
                 'description'   => $this->translate('The target where to open this navigation item\'s url'),
-                'multiOptions'  => array(
+                'multiOptions'  => [
                     '_blank'    => $this->translate('New Window'),
                     '_next'     => $this->translate('New Column'),
                     '_main'     => $this->translate('Single Column'),
                     '_self'     => $this->translate('Current Column')
-                )
-            )
+                ]
+            ]
         );
 
         $this->addElement(
             'textarea',
             'url',
-            array(
+            [
                 'allowEmpty'    => true,
                 'label'         => $this->translate('Url'),
                 'description'   => $this->translate(
@@ -59,37 +59,37 @@ class NavigationItemForm extends Form
                     . ' For urls with username and password and for all external urls,'
                     . ' make sure to prepend an appropriate protocol identifier (e.g. http://example.tld)'
                 ),
-                'validators'    => array(
-                    array(
+                'validators'    => [
+                    [
                         'Callback',
                         false,
-                        array(
+                        [
                             'callback' => function ($url) {
                                 // Matches if the given url contains obviously
                                 // a username but not any protocol identifier
                                 return !preg_match('#^((?=[^/@]).)+@.*$#', $url);
                             },
-                            'messages' => array(
+                            'messages' => [
                                 'callbackValue' => $this->translate(
                                     'Missing protocol identifier'
                                 )
-                            )
-                        )
-                    )
-                )
-            )
+                            ]
+                        ]
+                    ]
+                ]
+            ]
         );
 
         $this->addElement(
             'text',
             'icon',
-            array(
+            [
                 'allowEmpty'    => true,
                 'label'         => $this->translate('Icon'),
                 'description'   => $this->translate(
                     'The icon of this navigation item. Leave blank if you do not want a icon being displayed'
                 )
-            )
+            ]
         );
     }
 

--- a/application/forms/PreferenceForm.php
+++ b/application/forms/PreferenceForm.php
@@ -101,7 +101,7 @@ class PreferenceForm extends Form
         $oldLocale = $currentPreferences->getValue('icingaweb', 'language');
         $defaultTheme = Config::app()->get('themes', 'default', StyleSheet::DEFAULT_THEME);
 
-        $this->preferences = new Preferences($this->store ? $this->store->load() : array());
+        $this->preferences = new Preferences($this->store ? $this->store->load() : []);
         $webPreferences = $this->preferences->get('icingaweb');
         foreach ($this->getValues() as $key => $value) {
             if ($value === ''
@@ -199,7 +199,7 @@ class PreferenceForm extends Form
                 $this->addElement(
                     'select',
                     'theme',
-                    array(
+                    [
                         'label'         => $this->translate('Theme', 'Form element label'),
                         'multiOptions'  => $themes,
                         'autosubmit'    => true,
@@ -208,7 +208,7 @@ class PreferenceForm extends Form
                             'theme',
                             $defaultTheme
                         )
-                    )
+                    ]
                 );
             }
         }
@@ -257,7 +257,7 @@ class PreferenceForm extends Form
         /** @var GettextTranslator $translator */
         $translator = StaticTranslator::$instance;
 
-        $languages = array();
+        $languages = [];
         $availableLocales = $translator->listLocales();
 
         $locale = $this->getLocale($availableLocales);
@@ -270,7 +270,7 @@ class PreferenceForm extends Form
             $languages[$language] = $language;
         }
 
-        $tzList = array();
+        $tzList = [];
         $tzList['autodetect'] = sprintf(
             $this->translate('Browser (%s)', 'preferences.form'),
             $this->getDefaultTimezone()
@@ -282,31 +282,31 @@ class PreferenceForm extends Form
         $this->addElement(
             'select',
             'language',
-            array(
+            [
                 'required'      => true,
                 'label'         => $this->translate('Your Current Language'),
                 'description'   => $this->translate('Use the following language to display texts and messages'),
                 'multiOptions'  => $languages,
                 'value'         => substr(setlocale(LC_ALL, 0), 0, 5)
-            )
+            ]
         );
 
         $this->addElement(
             'select',
             'timezone',
-            array(
+            [
                 'required'      => true,
                 'label'         => $this->translate('Your Current Timezone'),
                 'description'   => $this->translate('Use the following timezone for dates and times'),
                 'multiOptions'  => $tzList,
                 'value'         => $this->getDefaultTimezone()
-            )
+            ]
         );
 
         $this->addElement(
             'select',
             'show_application_state_messages',
-            array(
+            [
                 'required'      => true,
                 'label'         => $this->translate('Show application state messages'),
                 'description'   => $this->translate('Whether to show application state messages.'),
@@ -317,33 +317,33 @@ class PreferenceForm extends Form
                     1        => $this->translate('Yes'),
                     0        => $this->translate('No')],
                 'value'         => 'system'
-            )
+            ]
         );
 
         if (Auth::getInstance()->hasPermission('user/application/stacktraces')) {
             $this->addElement(
                 'checkbox',
                 'show_stacktraces',
-                array(
+                [
                     'value'         => $this->getDefaultShowStacktraces(),
                     'label'         => $this->translate('Show Stacktraces'),
                     'description'   => $this->translate('Set whether to show an exception\'s stacktrace.')
-                )
+                ]
             );
         }
 
         $this->addElement(
             'checkbox',
             'show_benchmark',
-            array(
+            [
                 'label'     => $this->translate('Use benchmark')
-            )
+            ]
         );
 
         $this->addElement(
             'checkbox',
             'auto_refresh',
-            array(
+            [
                 'required'      => false,
                 'autosubmit'    => true,
                 'label'         => $this->translate('Enable auto refresh'),
@@ -351,7 +351,7 @@ class PreferenceForm extends Form
                     'This option allows you to enable or to disable the global page content auto refresh'
                 ),
                 'value'         => 1
-            )
+            ]
         );
 
         if (isset($formData['auto_refresh']) && $formData['auto_refresh']) {
@@ -378,59 +378,59 @@ class PreferenceForm extends Form
         $this->addElement(
             'number',
             'default_page_size',
-            array(
+            [
                 'label'         => $this->translate('Default page size'),
                 'description'   => $this->translate('Default number of items per page for list views'),
                 'placeholder'   => 25,
                 'min'           => 25,
                 'step'          => 1
-            )
+            ]
         );
 
         if ($this->store) {
             $this->addElement(
                 'submit',
                 'btn_submit',
-                array(
+                [
                     'ignore'        => true,
                     'label'         => $this->translate('Save to the Preferences'),
-                    'decorators'    => array('ViewHelper'),
+                    'decorators'    => ['ViewHelper'],
                     'class'         => 'btn-primary'
-                )
+                ]
             );
         }
 
         $this->addElement(
             'submit',
             'btn_submit_session',
-            array(
+            [
                 'ignore'        => true,
                 'label'         => $this->translate('Save for the current Session'),
-                'decorators'    => array('ViewHelper')
-            )
+                'decorators'    => ['ViewHelper']
+            ]
         );
 
         $this->setAttrib('data-progress-element', 'preferences-progress');
         $this->addElement(
             'note',
             'preferences-progress',
-            array(
-                'decorators'    => array(
+            [
+                'decorators'    => [
                     'ViewHelper',
-                    array('Spinner', array('id' => 'preferences-progress'))
-                )
-            )
+                    ['Spinner', ['id' => 'preferences-progress']]
+                ]
+            ]
         );
 
         $this->addDisplayGroup(
-            array('btn_submit', 'btn_submit_session', 'preferences-progress'),
+            ['btn_submit', 'btn_submit_session', 'preferences-progress'],
             'submit_buttons',
-            array(
-                'decorators' => array(
+            [
+                'decorators' => [
                     'FormElements',
-                    array('HtmlTag', array('tag' => 'div', 'class' => 'control-group form-controls'))
-                )
-            )
+                    ['HtmlTag', ['tag' => 'div', 'class' => 'control-group form-controls']]
+                ]
+            ]
         );
     }
 

--- a/application/forms/Security/RoleForm.php
+++ b/application/forms/Security/RoleForm.php
@@ -62,7 +62,7 @@ class RoleForm extends RepositoryForm
         return parent::filterName($value, $allowBrackets) . '_element';
     }
 
-    public function createInsertElements(array $formData = array())
+    public function createInsertElements(array $formData = [])
     {
         $this->addElement(
             'text',

--- a/application/layouts/scripts/body.phtml
+++ b/application/layouts/scripts/body.phtml
@@ -38,11 +38,11 @@ if ($this->layout()->inlineLayout) {
                 '',
                 Auth::getInstance()->isAuthenticated() ? 'dashboard' : '',
                 null,
-                array(
+                [
                     'aria-hidden'       => 'true',
                     'data-base-target'  => '_main',
                     'id'                => 'header-logo'
-                )
+                ]
             ); ?>
             <div id="mobile-menu-toggle">
                 <button type="button"><?= $this->icon('menu') ?><?= $this->icon('cancel') ?></button>

--- a/application/layouts/scripts/parts/navigation.phtml
+++ b/application/layouts/scripts/parts/navigation.phtml
@@ -24,9 +24,9 @@ if (! $this->auth()->isAuthenticated()) {
     <?= $this->partial(
         'layout/menu.phtml',
         'default',
-        array(
+        [
             'menuRenderer' => (new Menu())->getRenderer()->setUseStandardItemRenderer()
-        )
+        ]
     ) ?>
 </div>
 <button id="toggle-sidebar" title="<?= $this->translate('Toggle Menu') ?>">

--- a/application/views/scripts/about/index.phtml
+++ b/application/views/scripts/about/index.phtml
@@ -12,7 +12,7 @@ use ipl\Web\Widget\StateBadge;
 </div>
 <div id="about" class="content">
 
-    <?= $this->img('img/icinga-logo-big.svg', null, array('class' => 'icinga-logo', 'width' => 194)) ?>
+    <?= $this->img('img/icinga-logo-big.svg', null, ['class' => 'icinga-logo', 'width' => 194]) ?>
 
     <section>
         <table class="name-value-table">
@@ -159,8 +159,8 @@ use ipl\Web\Widget\StateBadge;
                     <?= $this->qlink(
                         $this->translate('Configure'),
                         'config/module/',
-                        array('name' => $module->getName()),
-                        array('title' => sprintf($this->translate('Show the overview of the %s module'), $module->getName()))
+                        ['name' => $module->getName()],
+                        ['title' => sprintf($this->translate('Show the overview of the %s module'), $module->getName())]
                     ) ?>
                 <?php endif ?>
                 </td>
@@ -177,9 +177,9 @@ use ipl\Web\Widget\StateBadge;
                 'Icinga GmbH',
                 'https://icinga.com',
                 null,
-                array(
+                [
                     'target' => '_blank'
-                )
+                ]
             ) ?>
         </div>
         <div class="about-social">
@@ -187,11 +187,11 @@ use ipl\Web\Widget\StateBadge;
                 null,
                 'https://www.facebook.com/icinga',
                 null,
-                array(
+                [
                     'target'    => '_blank',
                     'icon'      => 'facebook-squared',
                     'title'     => $this->translate('Icinga on Facebook')
-                )
+                ]
             ) ?>
         </div>
     </footer>

--- a/application/views/scripts/announcements/index.phtml
+++ b/application/views/scripts/announcements/index.phtml
@@ -15,12 +15,12 @@
         $this->translate('Create a New Announcement') ,
         'announcements/new',
         null,
-        array(
+        [
             'class'             => 'button-link',
             'data-base-target'  => '_next',
             'icon'              => 'plus',
             'title'             => $this->translate('Create a new announcement')
-        )
+        ]
     );
 } ?>
 <?php if (empty($this->announcements)): ?>
@@ -43,7 +43,7 @@
             <td><?= $this->escape($announcement->author) ?></td>
         <?php if ($this->hasPermission('application/announcements')): ?>
             <td>
-                <a href="<?= $this->href('announcements/update', array('id' => $announcement->id)) ?>">
+                <a href="<?= $this->href('announcements/update', ['id' => $announcement->id]) ?>">
                     <?= $this->ellipsis($this->escape($announcement->message), 100) ?>
                 </a>
             </td>
@@ -56,12 +56,12 @@
             <td class="icon-col"><?= $this->qlink(
                 null,
                 'announcements/remove',
-                array('id' => $announcement->id),
-                array(
+                ['id' => $announcement->id],
+                [
                     'class' => 'action-link',
                     'icon'  => 'cancel',
                     'title' => $this->translate('Remove this announcement')
-                )
+                ]
             ) ?></td>
         <?php endif ?>
         </tr>

--- a/application/views/scripts/config/modules.phtml
+++ b/application/views/scripts/config/modules.phtml
@@ -28,11 +28,11 @@
                 echo $this->qlink(
                     $module->name,
                     'config/module',
-                    array('name' => $module->name),
-                    array(
+                    ['name' => $module->name],
+                    [
                         'class' => 'rowaction',
                         'title' => sprintf($this->translate('Show the overview of the %s module'), $module->name)
-                    )
+                    ]
                 ); ?>
             </td>
         </tr>

--- a/application/views/scripts/config/resource.phtml
+++ b/application/views/scripts/config/resource.phtml
@@ -6,12 +6,12 @@
         $this->translate('Create a New Resource') ,
         'config/createresource',
         null,
-        array(
+        [
             'class'             => 'button-link',
             'data-base-target'  => '_next',
             'icon'              => 'plus',
             'title'             => $this->translate('Create a new resource')
-        )
+        ]
     ) ?>
     <table class="table-row-selectable common-table" data-base-target="_next">
     <thead>
@@ -47,23 +47,23 @@
             <?= $this->qlink(
                 $name,
                 'config/editresource',
-                array('resource' => $name),
-                array(
+                ['resource' => $name],
+                [
                     'icon'  => $icon,
                     'title' => sprintf($this->translate('Edit resource %s'), $name)
-                )
+                ]
             ) ?>
         </td>
         <td class="icon-col text-right">
             <?= $this->qlink(
                 '',
                 'config/removeresource',
-                array('resource' => $name),
-                array(
+                ['resource' => $name],
+                [
                     'class'   => 'action-link',
                     'icon'    => 'cancel',
                     'title'   => sprintf($this->translate('Remove resource %s'), $name)
-                )
+                ]
             ) ?>
         </td>
     </tr>

--- a/application/views/scripts/config/userbackend/reorder.phtml
+++ b/application/views/scripts/config/userbackend/reorder.phtml
@@ -8,12 +8,12 @@
         $this->translate('Create a New User Backend') ,
         'config/createuserbackend',
         null,
-        array(
+        [
             'class'             => 'button-link',
             'data-base-target'  => '_next',
             'icon'              => 'plus',
             'title'             => $this->translate('Create a new user backend')
-        )
+        ]
     ) ?>
     <?= $form ?>
   <?php endif ?>
@@ -24,12 +24,12 @@
         $this->translate('Create a New User Group Backend') ,
         'usergroupbackend/create',
         null,
-        array(
+        [
             'class'             => 'button-link',
             'data-base-target'  => '_next',
             'icon'              => 'plus',
             'title'             => $this->translate('Create a new user group backend')
-        )
+        ]
     ) ?>
 <?php if (! count($backendNames)) { return; } ?>
     <table class="table-row-selectable common-table" data-base-target="_next">
@@ -48,23 +48,23 @@
             <?= $this->qlink(
                 $backendName,
                 'usergroupbackend/edit',
-                array('backend' => $backendName),
-                array(
+                ['backend' => $backendName],
+                [
                     'icon'  => $type === 'external' ? 'magic' : ($type === 'ldap' || $type === 'msldap' ? 'sitemap' : 'database'),
                     'title' => sprintf($this->translate('Edit user group backend %s'), $backendName)
-                )
+                ]
             ); ?>
         </td>
         <td class="icon-col text-right">
             <?= $this->qlink(
                 null,
                 'usergroupbackend/remove',
-                array('backend' => $backendName),
-                array(
+                ['backend' => $backendName],
+                [
                     'class' => 'action-link',
                     'icon'  => 'cancel',
                     'title' => sprintf($this->translate('Remove user group backend %s'), $backendName)
-                )
+                ]
             ) ?>
         </td>
     </tr>

--- a/application/views/scripts/dashboard/settings.phtml
+++ b/application/views/scripts/dashboard/settings.phtml
@@ -25,8 +25,8 @@
                         <?= $this->qlink(
                             $pane->getName(),
                             'dashboard/rename-pane',
-                            array('pane' => $pane->getName()),
-                            array('title' => sprintf($this->translate('Edit pane %s'), $pane->getName()))
+                            ['pane' => $pane->getName()],
+                            ['title' => sprintf($this->translate('Edit pane %s'), $pane->getName())]
                         ) ?>
                     <?php else: ?>
                         <?= $this->escape($pane->getName()) ?>
@@ -36,12 +36,12 @@
                         <?= $this->qlink(
                             '',
                             'dashboard/remove-pane',
-                            array('pane' => $pane->getName()),
-                            array(
+                            ['pane' => $pane->getName()],
+                            [
                                 'icon'  => 'cancel',
                                 'class' => 'action-link',
                                 'title' => sprintf($this->translate('Remove pane %s'), $pane->getName())
-                            )
+                            ]
                         ); ?>
                     </th>
                 </tr>
@@ -60,8 +60,8 @@
                                 <?= $this->qlink(
                                     $dashlet->getTitle(),
                                     'dashboard/update-dashlet',
-                                    array('pane' => $pane->getName(), 'dashlet' => $dashlet->getName()),
-                                    array('title' => sprintf($this->translate('Edit dashlet %s'), $dashlet->getTitle()))
+                                    ['pane' => $pane->getName(), 'dashlet' => $dashlet->getName()],
+                                    ['title' => sprintf($this->translate('Edit dashlet %s'), $dashlet->getTitle())]
                                 ); ?>
                             </td>
                             <td>
@@ -69,19 +69,19 @@
                                     $dashlet->getUrl()->getRelativeUrl(),
                                     $dashlet->getUrl()->getRelativeUrl(),
                                     null,
-                                    array('title' => sprintf($this->translate('Show dashlet %s'), $dashlet->getTitle()))
+                                    ['title' => sprintf($this->translate('Show dashlet %s'), $dashlet->getTitle())]
                                 ); ?>
                             </td>
                             <td>
                                 <?= $this->qlink(
                                     '',
                                     'dashboard/remove-dashlet',
-                                    array('pane' => $pane->getName(), 'dashlet' => $dashlet->getName()),
-                                    array(
+                                    ['pane' => $pane->getName(), 'dashlet' => $dashlet->getName()],
+                                    [
                                         'icon'  => 'cancel',
                                         'class' => 'action-link',
                                         'title' => sprintf($this->translate('Remove dashlet %s from pane %s'), $dashlet->getTitle(), $pane->getTitle())
-                                    )
+                                    ]
                                 ); ?>
                             </td>
                         </tr>

--- a/application/views/scripts/form/reorder-authbackend.phtml
+++ b/application/views/scripts/form/reorder-authbackend.phtml
@@ -27,25 +27,25 @@ $this->escape($form->getAction())
           <?= $this->qlink(
             $backendNames[$i],
             'config/edituserbackend',
-            array('backend' => $backendNames[$i]),
-            array(
+            ['backend' => $backendNames[$i]],
+            [
                 'icon'  => $type === 'external' ?
                     'magic' : ($type === 'ldap' || $type === 'msldap' ? 'sitemap' : 'database'),
                 'class' => 'rowaction',
                 'title' => sprintf($this->translate('Edit user backend %s'), $backendNames[$i])
-            )
+            ]
           ) ?>
         </td>
         <td class="icon-col text-right">
           <?= $this->qlink(
             '',
             'config/removeuserbackend',
-            array('backend' => $backendNames[$i]),
-            array(
+            ['backend' => $backendNames[$i]],
+            [
                 'class' => 'action-link',
                 'icon'  => 'cancel',
                 'title' => sprintf($this->translate('Remove user backend %s'), $backendNames[$i])
-            )
+            ]
           ) ?>
         </td>
         <td class="icon-col text-right" data-base-target="_self">

--- a/application/views/scripts/group/list.phtml
+++ b/application/views/scripts/group/list.phtml
@@ -31,12 +31,12 @@ if (! isset($backend)) {
     <?= $this->qlink(
         $this->translate('Add a New User Group'),
         'group/add',
-        array('backend' => $backend->getName()),
-        array(
+        ['backend' => $backend->getName()],
+        [
             'class'             => 'button-link',
             'data-base-target'  => '_next',
             'icon'              => 'plus'
-        )
+        ]
     ) ?>
 <?php endif ?>
 
@@ -60,16 +60,16 @@ if (! isset($backend)) {
                     <?= $this->qlink(
                         $group->group_name,
                         'group/show',
-                        array(
+                        [
                             'backend'   => $backend->getName(),
                             'group'     => $group->group_name
-                        ),
-                        array(
+                        ],
+                        [
                             'title'     => sprintf(
                                 $this->translate('Show detailed information for user group %s'),
                                 $group->group_name
                             )
-                        )
+                        ]
                     ); ?>
                 </td>
             <?php if ($reducible): ?>
@@ -77,15 +77,15 @@ if (! isset($backend)) {
                     <?= $this->qlink(
                         null,
                         'group/remove',
-                        array(
+                        [
                             'backend'   => $backend->getName(),
                             'group'     => $group->group_name
-                        ),
-                        array(
+                        ],
+                        [
                             'class'     => 'action-link',
                             'title'     => sprintf($this->translate('Remove user group %s'), $group->group_name),
                             'icon'      => 'cancel'
-                        )
+                        ]
                     ); ?>
                 </td>
             <?php endif ?>

--- a/application/views/scripts/group/show.phtml
+++ b/application/views/scripts/group/show.phtml
@@ -10,15 +10,15 @@ if ($this->hasPermission('config/access-control/groups') && $backend instanceof 
     $editLink = $this->qlink(
         null,
         'group/edit',
-        array(
+        [
             'backend'   => $backend->getName(),
             'group'     => $group->group_name
-        ),
-        array(
+        ],
+        [
             'title' => sprintf($this->translate('Edit group %s'), $group->group_name),
             'class' => 'group-edit',
             'icon'  => 'edit'
-        )
+        ]
     );
 }
 
@@ -53,14 +53,14 @@ if ($this->hasPermission('config/access-control/groups') && $backend instanceof 
     <?= $this->qlink(
         $this->translate('Add New Member'),
         'group/addmember',
-        array(
+        [
             'backend'   => $backend->getName(),
             'group'     => $group->group_name
-        ),
-        array(
+        ],
+        [
             'icon'  => 'plus',
             'class' => 'button-link'
-        )
+        ]
     ) ?>
 <?php endif ?>
 
@@ -86,12 +86,12 @@ if ($this->hasPermission('config/access-control/groups') && $backend instanceof 
                     $this->hasPermission('config/access-control/users')
                     && ($userBackend = $backend->getUserBackendName($member->user_name)) !== null
                 ): ?>
-                    <?= $this->qlink($member->user_name, 'user/show', array(
+                    <?= $this->qlink($member->user_name, 'user/show', [
                         'backend' => $userBackend,
                         'user'    => $member->user_name
-                    ), array(
+                    ], [
                         'title'   => sprintf($this->translate('Show detailed information about %s'), $member->user_name)
-                    )); ?>
+                    ]); ?>
                 <?php else: ?>
                     <?= $this->escape($member->user_name); ?>
                 <?php endif ?>

--- a/application/views/scripts/joystickPagination.phtml
+++ b/application/views/scripts/joystickPagination.phtml
@@ -40,10 +40,10 @@ $nextXAxisPage = $currentXAxisPage < $totalXAxisPages ? $currentXAxisPage + 1 : 
         <?= $this->qlink(
           '',
           Url::fromRequest(),
-          array(
+          [
             'page' => $currentXAxisPage . ',' . $prevYAxisPage
-          ),
-          array(
+          ],
+          [
             'icon'              => 'up-open',
             'data-base-target'  => '_self',
             'title'             => sprintf(
@@ -54,7 +54,7 @@ $nextXAxisPage = $currentXAxisPage < $totalXAxisPages ? $currentXAxisPage + 1 : 
               $prevYAxisPage * $yAxisPages->itemCountPerPage,
               $yAxisPages->totalItemCount
             )
-          )
+          ]
         ); ?>
       <?php else: ?>
         <?= $this->icon('up-open'); ?>
@@ -68,10 +68,10 @@ $nextXAxisPage = $currentXAxisPage < $totalXAxisPages ? $currentXAxisPage + 1 : 
         <?= $this->qlink(
           '',
           Url::fromRequest(),
-          array(
+          [
             'page' => $prevXAxisPage . ',' . $currentYAxisPage
-          ),
-          array(
+          ],
+          [
             'icon'              => 'left-open',
             'data-base-target'  => '_self',
             'title'             => sprintf(
@@ -82,7 +82,7 @@ $nextXAxisPage = $currentXAxisPage < $totalXAxisPages ? $currentXAxisPage + 1 : 
               $prevXAxisPage * $xAxisPages->itemCountPerPage,
               $xAxisPages->totalItemCount
             )
-          )
+          ]
         ); ?>
       <?php else: ?>
         <?= $this->icon('left-open'); ?>
@@ -93,11 +93,11 @@ $nextXAxisPage = $currentXAxisPage < $totalXAxisPages ? $currentXAxisPage + 1 : 
         '',
         $flipUrl,
         null,
-        array(
+        [
           'icon'                => 'arrows-cw',
           'data-base-target'    => '_self',
           'title'               => $this->translate('Flip grid axes')
-        )
+        ]
       ) ?></td>
       <?php else: ?>
       <td>&nbsp;</td>
@@ -107,10 +107,10 @@ $nextXAxisPage = $currentXAxisPage < $totalXAxisPages ? $currentXAxisPage + 1 : 
         <?= $this->qlink(
           '',
           Url::fromRequest(),
-          array(
+          [
             'page' => $nextXAxisPage . ',' . $currentYAxisPage
-          ),
-          array(
+          ],
+          [
             'icon'              => 'right-open',
             'data-base-target'  => '_self',
             'title'             => sprintf(
@@ -121,7 +121,7 @@ $nextXAxisPage = $currentXAxisPage < $totalXAxisPages ? $currentXAxisPage + 1 : 
               $nextXAxisPage === $xAxisPages->last ? $xAxisPages->totalItemCount : $nextXAxisPage * $xAxisPages->itemCountPerPage,
               $xAxisPages->totalItemCount
             )
-          ),
+          ],
           false
         ); ?>
       <?php else: ?>
@@ -136,10 +136,10 @@ $nextXAxisPage = $currentXAxisPage < $totalXAxisPages ? $currentXAxisPage + 1 : 
         <?= $this->qlink(
           '',
           Url::fromRequest(),
-          array(
+          [
             'page' => $currentXAxisPage . ',' . $nextYAxisPage
-          ),
-          array(
+          ],
+          [
             'icon'              => 'down-open',
             'data-base-target'  => '_self',
             'title'             => sprintf(
@@ -150,7 +150,7 @@ $nextXAxisPage = $currentXAxisPage < $totalXAxisPages ? $currentXAxisPage + 1 : 
               $nextYAxisPage === $yAxisPages->last ? $yAxisPages->totalItemCount : $nextYAxisPage * $yAxisPages->itemCountPerPage,
               $yAxisPages->totalItemCount
             )
-          )
+          ]
         ); ?>
       <?php else: ?>
         <?= $this->icon('down-open'); ?>

--- a/application/views/scripts/mixedPagination.phtml
+++ b/application/views/scripts/mixedPagination.phtml
@@ -10,7 +10,7 @@
             $this->totalItemCount
         ) ?>
         <li class="nav-item">
-            <a  href="<?= $this->escape($this->url()->overwriteParams(array('page' => $this->previous))->getAbsoluteUrl()) ?>"
+            <a  href="<?= $this->escape($this->url()->overwriteParams(['page' => $this->previous])->getAbsoluteUrl()) ?>"
                 title="<?= $label ?>"
                 aria-label="<?= $label ?>"
                 class="previous-page">
@@ -44,7 +44,7 @@
             );
             ?>
             <li<?= $page === $this->current ? ' class="active nav-item"' : ' class="nav-item"' ?>>
-                <a  href="<?= $this->escape($this->url()->overwriteParams(array('page' => $page))->getAbsoluteUrl()) ?>"
+                <a  href="<?= $this->escape($this->url()->overwriteParams(['page' => $page])->getAbsoluteUrl()) ?>"
                     title="<?= $label ?>"
                     aria-label="<?= $label ?>">
                     <?= $page ?>
@@ -60,7 +60,7 @@
             $this->totalItemCount
         ) ?>
         <li class="nav-item">
-            <a  href="<?= $this->escape($this->url()->overwriteParams(array('page' => $this->next))->getAbsoluteUrl()) ?>"
+            <a  href="<?= $this->escape($this->url()->overwriteParams(['page' => $this->next])->getAbsoluteUrl()) ?>"
                 title="<?= $label ?>"
                 aria-label="<?= $label ?>"
                 class="next-page">

--- a/application/views/scripts/navigation/dashboard.phtml
+++ b/application/views/scripts/navigation/dashboard.phtml
@@ -15,7 +15,7 @@ use ipl\Web\Widget\Icon;
             if (Str::startsWith($item->getIcon(), 'fa-') || substr($item->getUrl()->getPath(), 0, 9) === 'icingadb/') {
                 echo new Icon($item->getIcon() ?: 'share', [ 'aria-hidden' => 1]);
             } else {
-                echo $this->icon($item->getIcon() ?: 'forward', null, array('aria-hidden' => true));
+                echo $this->icon($item->getIcon() ?: 'forward', null, ['aria-hidden' => true]);
             }
         ?>
         </div>

--- a/application/views/scripts/navigation/index.phtml
+++ b/application/views/scripts/navigation/index.phtml
@@ -12,12 +12,12 @@
         $this->translate('Create a New Navigation Item') ,
         'navigation/add',
         null,
-        array(
+        [
             'class'             => 'button-link',
             'data-base-target'  => '_next',
             'icon'              => 'plus',
             'title'             => $this->translate('Create a new navigation item')
-        )
+        ]
     ) ?>
 <?php if (count($items) === 0): ?>
     <p><?= $this->translate('You did not create any navigation item yet.') ?></p>
@@ -39,13 +39,13 @@
             <?= $this->qlink(
                 $item->name,
                 'navigation/edit',
-                array(
+                [
                     'name'  => $item->name,
                     'type'  => $item->type
-                ),
-                array(
+                ],
+                [
                     'title' => sprintf($this->translate('Edit navigation item %s'), $item->name)
-                )
+                ]
             ) ?>
         </td>
         <td>
@@ -60,15 +60,15 @@
             <?= $this->qlink(
                 '',
                 'navigation/remove',
-                array(
+                [
                     'name'  => $item->name,
                     'type'  => $item->type
-                ),
-                array(
+                ],
+                [
                     'class' => 'action-link',
                     'icon'  => 'cancel',
                     'title' => sprintf($this->translate('Remove navigation item %s'), $item->name)
-                )
+                ]
             ) ?>
         </td>
     </tr>

--- a/application/views/scripts/navigation/shared.phtml
+++ b/application/views/scripts/navigation/shared.phtml
@@ -27,15 +27,15 @@ if (! $this->compact): ?>
                 <td><?= $this->qlink(
                     $item->name,
                     'navigation/edit',
-                    array(
+                    [
                         'name'      => $item->name,
                         'type'      => $item->type,
                         'owner'     => $item->owner,
                         'referrer'  => 'shared'
-                    ),
-                    array(
+                    ],
+                    [
                         'title' => sprintf($this->translate('Edit shared navigation item %s'), $item->name)
-                    )
+                    ]
                 ); ?></td>
                 <td><?= $item->type && isset($types[$item->type])
                     ? $this->escape($types[$item->type])
@@ -57,7 +57,7 @@ if (! $this->compact): ?>
                     ->setDefault('name', $item->name)
                     ->setAction(Url::fromPath(
                         'navigation/unshare',
-                        array('type' => $item->type, 'owner' => $item->owner)
+                        ['type' => $item->type, 'owner' => $item->owner]
                 )); ?></td>
             <?php endif ?>
             </tr>

--- a/application/views/scripts/pivottablePagination.phtml
+++ b/application/views/scripts/pivottablePagination.phtml
@@ -22,7 +22,7 @@ $yAxisPages = $yAxisPaginator->getPages('all');
                 <td<?= $xAxisPage === $xAxisPages->current && $yAxisPage === $yAxisPages->current ? ' class="active"' : ''; ?>>
 <?php if ($xAxisPage !== $xAxisPages->current || $yAxisPage !== $yAxisPages->current): ?>
                     <a href="<?= Url::fromRequest()->overwriteParams(
-                        array('page' => $xAxisPage . ',' . $yAxisPage)
+                        ['page' => $xAxisPage . ',' . $yAxisPage]
                     )->getAbsoluteUrl(); ?>" title="<?= sprintf(
                         $fromTo,
                         t('Hosts'),

--- a/application/views/scripts/role/list.phtml
+++ b/application/views/scripts/role/list.phtml
@@ -12,12 +12,12 @@
         $this->translate('Create a New Role') ,
         'role/add',
         null,
-        array(
+        [
             'class'             => 'button-link',
             'data-base-target'  => '_next',
             'icon'              => 'plus',
             'title'             => $this->translate('Create a new role')
-        )
+        ]
     ) ?>
 <?php /** @var \Icinga\Application\Config $roles */ if (! $roles->hasResult()): ?>
     <p><?= $this->translate('No roles found.') ?></p>
@@ -39,8 +39,8 @@
             <?= $this->qlink(
                 $name,
                 'role/edit',
-                array('role' => $name),
-                array('title' => sprintf($this->translate('Edit role %s'), $name))
+                ['role' => $name],
+                ['title' => sprintf($this->translate('Edit role %s'), $name)]
             ) ?>
         </td>
         <td><?= $this->escape($role->users) ?></td>
@@ -50,12 +50,12 @@
             <?= $this->qlink(
                 '',
                 'role/remove',
-                array('role' => $name),
-                array(
+                ['role' => $name],
+                [
                     'class' => 'action-link',
                     'icon'  => 'cancel',
                     'title' => sprintf($this->translate('Remove role %s'), $name)
-                )
+                ]
             ) ?>
         </td>
     </tr>

--- a/application/views/scripts/user/list.phtml
+++ b/application/views/scripts/user/list.phtml
@@ -31,12 +31,12 @@ if (! isset($backend)) {
     <?= $this->qlink(
         $this->translate('Add a New User') ,
         'user/add',
-        array('backend' => $backend->getName()),
-        array(
+        ['backend' => $backend->getName()],
+        [
             'class'             => 'button-link',
             'data-base-target'  => '_next',
             'icon'              => 'plus'
-        )
+        ]
     ) ?>
 <?php endif ?>
 
@@ -60,27 +60,27 @@ if (! isset($backend)) {
             <td><?= $this->qlink(
                 $user->user_name,
                 'user/show',
-                array(
+                [
                     'backend'   => $backend->getName(),
                     'user'      => $user->user_name
-                ),
-                array(
+                ],
+                [
                     'title'     => sprintf($this->translate('Show detailed information about %s'), $user->user_name)
-                )
+                ]
             ) ?></td>
         <?php if ($reducible): ?>
             <td class="icon-col"><?= $this->qlink(
                 null,
                 'user/remove',
-                array(
+                [
                     'backend'   => $backend->getName(),
                     'user'      => $user->user_name
-                ),
-                array(
+                ],
+                [
                     'class' => 'action-link',
                     'icon'  => 'cancel',
                     'title' => sprintf($this->translate('Remove user %s'), $user->user_name)
-                )
+                ]
             ) ?></td>
             <?php endif ?>
         </tr>

--- a/application/views/scripts/user/show.phtml
+++ b/application/views/scripts/user/show.phtml
@@ -15,15 +15,15 @@ use Icinga\Data\Selectable;
         echo $this->qlink(
             $this->translate('Edit User'),
             'user/edit',
-            array(
+            [
                 'backend'   => $backend->getName(),
                 'user'      => $user->user_name
-            ),
-            array(
+            ],
+            [
                 'class' => 'button-link',
                 'icon'  => 'edit',
                 'title' => sprintf($this->translate('Edit user %s'), $user->user_name)
-            )
+            ]
         );
     }
     ?>
@@ -83,14 +83,14 @@ use Icinga\Data\Selectable;
     <?= $this->qlink(
         $this->translate('Create New Membership'),
         'user/createmembership',
-        array(
+        [
             'backend'   => $backend->getName(),
             'user'      => $user->user_name
-        ),
-        array(
+        ],
+        [
             'icon'  => 'plus',
             'class' => 'button-link'
-        )
+        ]
     ) ?>
 <?php endif ?>
 
@@ -111,22 +111,22 @@ use Icinga\Data\Selectable;
             <tr>
                 <td>
                 <?php if ($this->hasPermission('config/access-control/groups') && $membership->backend instanceof Selectable): ?>
-                    <?= $this->qlink($membership->group_name, 'group/show', array(
+                    <?= $this->qlink($membership->group_name, 'group/show', [
                         'backend' => $membership->backend->getName(),
                         'group'   => $membership->group_name
-                    ), array(
+                    ], [
                         'title'   => sprintf($this->translate('Show detailed information for group %s'), $membership->group_name)
-                    )); ?>
+                    ]); ?>
                 <?php else: ?>
                     <?= $this->escape($membership->group_name); ?>
                 <?php endif ?>
                 </td>
                 <td class="icon-col" data-base-target="_self">
                 <?php if (isset($removeForm) && $membership->backend instanceof Reducible): ?>
-                    <?= $removeForm->setAction($this->url('group/removemember', array(
+                    <?= $removeForm->setAction($this->url('group/removemember', [
                         'backend'   => $membership->backend->getName(),
                         'group'     => $membership->group_name
-                    ))); ?>
+                    ])); ?>
                 <?php else: ?>
                     -
                 <?php endif ?>

--- a/library/Icinga/Application/ApplicationBootstrap.php
+++ b/library/Icinga/Application/ApplicationBootstrap.php
@@ -536,9 +536,9 @@ abstract class ApplicationBootstrap
     {
         Logger::create(
             new ConfigObject(
-                array(
+                [
                     'log' => 'syslog'
-                )
+                ]
             )
         );
         return $this;

--- a/library/Icinga/Application/Benchmark.php
+++ b/library/Icinga/Application/Benchmark.php
@@ -27,7 +27,7 @@ class Benchmark
 
     protected static $instance;
     protected $start;
-    protected $measures = array();
+    protected $measures = [];
 
     /**
      * Add a measurement to your benchmark
@@ -39,12 +39,12 @@ class Benchmark
      */
     public static function measure($message)
     {
-        self::getInstance()->measures[] = (object) array(
+        self::getInstance()->measures[] = (object) [
             'timestamp'   => microtime(true),
             'memory_real' => memory_get_usage(true),
             'memory'      => memory_get_usage(),
             'message'     => $message
-        );
+        ];
     }
 
     /**
@@ -188,56 +188,56 @@ class Benchmark
             $what = self::TIME | self::MEMORY;
         }
 
-        $columns = array(
-            (object) array(
+        $columns = [
+            (object) [
                 'title'  => 'Time',
                 'align'  => 'left',
                 'maxlen' => 4
-            ),
-            (object) array(
+            ],
+            (object) [
                 'title'  => 'Description',
                 'align'  => 'left',
                 'maxlen' => 11
-            )
-        );
+            ]
+        ];
         if ($what & self::TIME) {
-            $columns[] = (object) array(
+            $columns[] = (object) [
                 'title'  => 'Off (ms)',
                 'align'  => 'right',
                 'maxlen' => 11
-            );
-            $columns[] = (object) array(
+            ];
+            $columns[] = (object) [
                 'title'  => 'Dur (ms)',
                 'align'  => 'right',
                 'maxlen' => 13
-            );
+            ];
         }
         if ($what & self::MEMORY) {
-            $columns[] = (object) array(
+            $columns[] = (object) [
                 'title'  => 'Mem (diff)',
                 'align'  => 'right',
                 'maxlen' => 10
-            );
-            $columns[] = (object) array(
+            ];
+            $columns[] = (object) [
                 'title'  => 'Mem (total)',
                 'align'  => 'right',
                 'maxlen' => 11
-            );
+            ];
         }
 
         $bench = self::getInstance();
         $last = $bench->start;
-        $rows = array();
+        $rows = [];
         $lastmem = 0;
         foreach ($bench->measures as $m) {
             $micro = sprintf(
                 '%03d',
                 round(($m->timestamp - floor($m->timestamp)) * 1000)
             );
-            $vals = array(
+            $vals = [
                 date('H:i:s', (int) $m->timestamp) . '.' . $micro,
                 $m->message
-            );
+            ];
 
             if ($what & self::TIME) {
                 $m->relative = $m->timestamp - $bench->start;
@@ -264,10 +264,10 @@ class Benchmark
             }
         }
 
-        return (object) array(
+        return (object) [
             'columns' => $columns,
             'rows' => $rows
-        );
+        ];
     }
 
     /**

--- a/library/Icinga/Application/ClassLoader.php
+++ b/library/Icinga/Application/ClassLoader.php
@@ -36,11 +36,11 @@ class ClassLoader
      *
      * @var array
      */
-    protected $applicationPrefixes = array(
+    protected $applicationPrefixes = [
         'Clicommands' => 'clicommands',
         'Controllers' => 'controllers',
         'Forms'       => 'forms'
-    );
+    ];
 
     /**
      * Whether we already instantiated the ZF autoloader
@@ -54,14 +54,14 @@ class ClassLoader
      *
      * @var array
      */
-    private $namespaces = array();
+    private $namespaces = [];
 
     /**
      * Application directories
      *
      * @var array
      */
-    private $applicationDirectories = array();
+    private $applicationDirectories = [];
 
     /**
      * Register a base directory for a namespace prefix
@@ -287,7 +287,7 @@ class ClassLoader
      */
     public function register()
     {
-        spl_autoload_register(array($this, 'loadClass'));
+        spl_autoload_register([$this, 'loadClass']);
     }
 
     /**
@@ -295,7 +295,7 @@ class ClassLoader
      */
     public function unregister()
     {
-        spl_autoload_unregister(array($this, 'loadClass'));
+        spl_autoload_unregister([$this, 'loadClass']);
     }
 
     /**

--- a/library/Icinga/Application/Cli.php
+++ b/library/Icinga/Application/Cli.php
@@ -61,9 +61,9 @@ class Cli extends ApplicationBootstrap
     {
         Logger::create(
             new ConfigObject(
-                array(
+                [
                     'log' => 'stderr'
-                )
+                ]
             )
         );
 

--- a/library/Icinga/Application/Config.php
+++ b/library/Icinga/Application/Config.php
@@ -37,21 +37,21 @@ class Config implements Countable, Iterator, Selectable
      *
      * @var array
      */
-    protected static $app = array();
+    protected static $app = [];
 
     /**
      * Module config instances per file
      *
      * @var array
      */
-    protected static $modules = array();
+    protected static $modules = [];
 
     /**
      * Navigation config instances per type
      *
      * @var array
      */
-    protected static $navigation = array();
+    protected static $navigation = [];
 
     /**
      * The internal ConfigObject
@@ -416,7 +416,7 @@ class Config implements Countable, Iterator, Selectable
     public static function module($modulename, $configname = 'config', $fromDisk = false)
     {
         if (! isset(self::$modules[$modulename])) {
-            self::$modules[$modulename] = array();
+            self::$modules[$modulename] = [];
         }
 
         if (! isset(self::$modules[$modulename][$configname]) || $fromDisk) {
@@ -439,7 +439,7 @@ class Config implements Countable, Iterator, Selectable
     public static function navigation($type, $username = null, $fromDisk = false)
     {
         if (! isset(self::$navigation[$type])) {
-            self::$navigation[$type] = array();
+            self::$navigation[$type] = [];
         }
 
         $branch = $username ?: 'shared';
@@ -475,11 +475,11 @@ class Config implements Countable, Iterator, Selectable
         }
 
         if ($username) {
-            $path = static::resolvePath(implode(DIRECTORY_SEPARATOR, array('preferences', $username, $filename)));
+            $path = static::resolvePath(implode(DIRECTORY_SEPARATOR, ['preferences', $username, $filename]));
             if (realpath($path) === false) {
                 $path = static::resolvePath(implode(
                     DIRECTORY_SEPARATOR,
-                    array('preferences', strtolower($username), $filename)
+                    ['preferences', strtolower($username), $filename]
                 ));
             }
         } else {

--- a/library/Icinga/Application/Hook.php
+++ b/library/Icinga/Application/Hook.php
@@ -27,14 +27,14 @@ class Hook
      *
      * @var array
      */
-    protected static $hooks = array();
+    protected static $hooks = [];
 
     /**
      * Hooks that have already been instantiated
      *
      * @var array
      */
-    protected static $instances = array();
+    protected static $instances = [];
 
     /**
      * Namespace prefix
@@ -57,8 +57,8 @@ class Hook
      */
     public static function clean()
     {
-        self::$hooks = array();
-        self::$instances = array();
+        self::$hooks = [];
+        self::$instances = [];
         self::$BASE_NS = 'Icinga\\Application\\Hook\\';
     }
 
@@ -157,12 +157,12 @@ class Hook
     {
         $sep = '\\';
         if (false === $module = strpos($name, $sep)) {
-            return array(null, $name);
+            return [null, $name];
         }
-        return array(
+        return [
             substr($name, 0, $module),
             substr($name, $module + 1)
-        );
+        ];
     }
 
     /**
@@ -328,7 +328,7 @@ class Hook
         $name = self::normalizeHookName($name);
 
         if (!isset(self::$hooks[$name])) {
-            self::$hooks[$name] = array();
+            self::$hooks[$name] = [];
         }
 
         $class = ltrim($class, ClassLoader::NAMESPACE_SEPARATOR);

--- a/library/Icinga/Application/Hook/Ticket/TicketPattern.php
+++ b/library/Icinga/Application/Hook/Ticket/TicketPattern.php
@@ -20,7 +20,7 @@ class TicketPattern implements ArrayAccess
      *
      * @var array
      */
-    protected $match = array();
+    protected $match = [];
 
     /**
      * The name of the TTS integration

--- a/library/Icinga/Application/Hook/TicketHook.php
+++ b/library/Icinga/Application/Hook/TicketHook.php
@@ -101,7 +101,7 @@ abstract class TicketHook
             }
 
             // Remove preg_offset from match for the ticket pattern
-            $carry = array();
+            $carry = [];
             array_walk($match, function ($value, $key) use (&$carry) {
                 $carry[$key] = $value[0];
             }, $carry);
@@ -202,7 +202,7 @@ abstract class TicketHook
             try {
                 $text = preg_replace_callback(
                     $pattern,
-                    array($this, 'createLink'),
+                    [$this, 'createLink'],
                     $text
                 );
             } catch (ErrorException $e) {

--- a/library/Icinga/Application/Logger.php
+++ b/library/Icinga/Application/Logger.php
@@ -43,12 +43,12 @@ class Logger
      *
      * @var array
      */
-    public static $levels = array(
+    public static $levels = [
         Logger::DEBUG   => 'DEBUG',
         Logger::INFO    => 'INFO',
         Logger::WARNING => 'WARNING',
         Logger::ERROR   => 'ERROR'
-    );
+    ];
 
     /**
      * This logger's instance
@@ -76,7 +76,7 @@ class Logger
      *
      * @var array
      */
-    protected $configErrors = array();
+    protected $configErrors = [];
 
     /**
      * Create a new logger object
@@ -237,7 +237,7 @@ class Logger
             $message = $arguments[0];
 
             if ($message instanceof Throwable) {
-                $messages = array();
+                $messages = [];
                 $error = $message;
                 do {
                     $messages[] = IcingaException::describe($error);

--- a/library/Icinga/Application/Logger/Writer/SyslogWriter.php
+++ b/library/Icinga/Application/Logger/Writer/SyslogWriter.php
@@ -34,7 +34,7 @@ class SyslogWriter extends LogWriter
      *
      * @var array
      */
-    public static $facilities = array(
+    public static $facilities = [
         'user'      => LOG_USER,
         'local0'    => LOG_LOCAL0,
         'local1'    => LOG_LOCAL1,
@@ -44,19 +44,19 @@ class SyslogWriter extends LogWriter
         'local5'    => LOG_LOCAL5,
         'local6'    => LOG_LOCAL6,
         'local7'    => LOG_LOCAL7
-    );
+    ];
 
     /**
      * Log level to syslog severity map
      *
      * @var array
      */
-    public static $severityMap = array(
+    public static $severityMap = [
         Logger::ERROR   => LOG_ERR,
         Logger::WARNING => LOG_WARNING,
         Logger::INFO    => LOG_INFO,
         Logger::DEBUG   => LOG_DEBUG
-    );
+    ];
 
     /**
      * Create a new syslog log writer

--- a/library/Icinga/Application/Modules/DashboardContainer.php
+++ b/library/Icinga/Application/Modules/DashboardContainer.php
@@ -37,7 +37,7 @@ class DashboardContainer extends NavigationItemContainer
      */
     public function getDashlets()
     {
-        return $this->dashlets ?: array();
+        return $this->dashlets ?: [];
     }
 
     /**

--- a/library/Icinga/Application/Modules/Manager.php
+++ b/library/Icinga/Application/Modules/Manager.php
@@ -39,21 +39,21 @@ class Manager
      *
      * @var array
      */
-    private $installedBaseDirs = array();
+    private $installedBaseDirs = [];
 
     /**
      * Array of all enabled modules base dirs
      *
      * @var array
      */
-    private $enabledDirs       = array();
+    private $enabledDirs       = [];
 
     /**
      * Array of all module names that have been loaded
      *
      * @var array
      */
-    private $loadedModules     = array();
+    private $loadedModules     = [];
 
     /**
      * Reference to Icinga::app
@@ -74,7 +74,7 @@ class Manager
      *
      * @var array
      */
-    private $modulePaths        = array();
+    private $modulePaths        = [];
 
     /**
      * Whether we loaded all enabled modules
@@ -145,7 +145,7 @@ class Manager
         }
         if (($dh = opendir($this->enableDir)) !== false) {
             $isPhar = substr($this->enableDir, 0, 8) === 'phar:///';
-            $this->enabledDirs = array();
+            $this->enabledDirs = [];
             while (($file = readdir($dh)) !== false) {
                 if ($file[0] === '.' || $file === 'README') {
                     continue;
@@ -546,28 +546,28 @@ class Manager
      */
     public function getModuleInfo()
     {
-        $info = array();
+        $info = [];
 
         $installed = $this->listInstalledModules();
         foreach ($installed as $name) {
-            $info[$name] = (object) array(
+            $info[$name] = (object) [
                 'name'      => $name,
                 'path'      => $this->installedBaseDirs[$name],
                 'installed' => true,
                 'enabled'   => $this->hasEnabled($name),
                 'loaded'    => $this->hasLoaded($name)
-            );
+            ];
         }
 
         $enabled = $this->listEnabledModules();
         foreach ($enabled as $name) {
-            $info[$name] = (object) array(
+            $info[$name] = (object) [
                 'name'      => $name,
                 'path'      => $this->enabledDirs[$name],
                 'installed' => $this->enabledDirs[$name] !== null,
                 'enabled'   => true,
                 'loaded'    => $this->hasLoaded($name)
-            );
+            ];
         }
 
         return $info;
@@ -657,7 +657,7 @@ class Manager
             return array_keys($this->installedBaseDirs);
         }
 
-        return array();
+        return [];
     }
 
     /**

--- a/library/Icinga/Application/Modules/MenuItemContainer.php
+++ b/library/Icinga/Application/Modules/MenuItemContainer.php
@@ -37,7 +37,7 @@ class MenuItemContainer extends NavigationItemContainer
      */
     public function getChildren()
     {
-        return $this->children ?: array();
+        return $this->children ?: [];
     }
 
     /**
@@ -48,7 +48,7 @@ class MenuItemContainer extends NavigationItemContainer
      *
      * @return  MenuItemContainer   The newly added sub menu
      */
-    public function add($name, array $properties = array())
+    public function add($name, array $properties = [])
     {
         $child = new MenuItemContainer($name, $properties);
         $this->children[] = $child;

--- a/library/Icinga/Application/Modules/Module.php
+++ b/library/Icinga/Application/Modules/Module.php
@@ -160,21 +160,21 @@ class Module
      *
      * @var array
      */
-    private $permissionList = array();
+    private $permissionList = [];
 
     /**
      * Provided restrictions
      *
      * @var array
      */
-    private $restrictionList = array();
+    private $restrictionList = [];
 
     /**
      * Provided config tabs
      *
      * @var array
      */
-    private $configTabs = array();
+    private $configTabs = [];
 
     /**
      * Provided setup wizard
@@ -195,14 +195,14 @@ class Module
      *
      * @var array
      */
-    protected $cssFiles = array();
+    protected $cssFiles = [];
 
     /**
      * The Javascript files this module provides
      *
      * @var array
      */
-    protected $jsFiles = array();
+    protected $jsFiles = [];
 
     /**
      * Routes to add to the route chain
@@ -211,49 +211,49 @@ class Module
      *
      * @see addRoute()
      */
-    protected $routes = array();
+    protected $routes = [];
 
     /**
      * A set of menu elements
      *
      * @var MenuItemContainer[]
      */
-    protected $menuItems = array();
+    protected $menuItems = [];
 
     /**
      * A set of Pane elements
      *
      * @var array
      */
-    protected $paneItems = array();
+    protected $paneItems = [];
 
     /**
      * A set of objects representing a searchUrl configuration
      *
      * @var array
      */
-    protected $searchUrls = array();
+    protected $searchUrls = [];
 
     /**
      * This module's user backends providing several authentication mechanisms
      *
      * @var array
      */
-    protected $userBackends = array();
+    protected $userBackends = [];
 
     /**
      * This module's user group backends
      *
      * @var array
      */
-    protected $userGroupBackends = array();
+    protected $userGroupBackends = [];
 
     /**
      * This module's configurable navigation items
      *
      * @var array
      */
-    protected $navigationItems = array();
+    protected $navigationItems = [];
 
     /**
      * Create a new module object
@@ -293,11 +293,11 @@ class Module
      */
     public function provideSearchUrl($title, $url, $priority = 0)
     {
-        $this->searchUrls[] = (object) array(
+        $this->searchUrls[] = (object) [
             'title'     => (string) $title,
             'url'       => (string) $url,
             'priority'  => (int) $priority
-        );
+        ];
 
         return $this;
     }
@@ -349,11 +349,11 @@ class Module
                 $pane->getName(),
                 array_merge(
                     $pane->getProperties(),
-                    array(
+                    [
                         'label'     => $this->translate($pane->getName()),
                         'type'      => 'dashboard-pane',
                         'children'  => $dashlets
-                    )
+                    ]
                 )
             );
         }
@@ -369,7 +369,7 @@ class Module
      *
      * @return  DashboardContainer
      */
-    protected function dashboard($name, array $properties = array())
+    protected function dashboard($name, array $properties = [])
     {
         if (array_key_exists($name, $this->paneItems)) {
             $this->paneItems[$name]->setProperties($properties);
@@ -400,7 +400,7 @@ class Module
      */
     private function createMenu(array $items)
     {
-        $navigation = array();
+        $navigation = [];
         foreach ($items as $item) {
             /** @var MenuItemContainer $item */
             $properties = $item->getProperties();
@@ -423,7 +423,7 @@ class Module
      *
      * @return  MenuItemContainer
      */
-    protected function menuSection($name, array $properties = array())
+    protected function menuSection($name, array $properties = [])
     {
         if (array_key_exists($name, $this->menuItems)) {
             $this->menuItems[$name]->setProperties($properties);
@@ -1037,11 +1037,11 @@ class Module
         $this->launchConfigScript();
         $tabs = Widget::create('tabs');
         /** @var \Icinga\Web\Widget\Tabs $tabs */
-        $tabs->add('info', array(
+        $tabs->add('info', [
             'url'       => 'config/module',
-            'urlParams' => array('name' => $this->getName()),
+            'urlParams' => ['name' => $this->getName()],
             'label'     => 'Module: ' . $this->getName()
-        ));
+        ]);
 
         if ($this->app->getModuleManager()->hasEnabled($this->name)) {
             foreach ($this->configTabs as $name => $config) {
@@ -1157,10 +1157,10 @@ class Module
                 $name
             );
         }
-        $this->permissionList[$name] = (object) array(
+        $this->permissionList[$name] = (object) [
             'name'        => $name,
             'description' => $description
-        );
+        ];
     }
 
     /**
@@ -1179,10 +1179,10 @@ class Module
                 $name
             );
         }
-        $this->restrictionList[$name] = (object) array(
+        $this->restrictionList[$name] = (object) [
             'name'        => $name,
             'description' => $description
-        );
+        ];
     }
 
     /**
@@ -1194,7 +1194,7 @@ class Module
      * @return  $this
      * @throws  ProgrammingError    If $config lacks the key 'url'
      */
-    protected function provideConfigTab($name, $config = array())
+    protected function provideConfigTab($name, $config = [])
     {
         if (! array_key_exists('url', $config)) {
             throw new ProgrammingError('A module config tab MUST provide a "url"');
@@ -1286,10 +1286,10 @@ class Module
      */
     protected function provideNavigationItem($type, $label = null, $config = null)
     {
-        $this->navigationItems[$type] = array(
+        $this->navigationItems[$type] = [
             'label'     => $label,
             'config'    => $config
-        );
+        ];
 
         return $this;
     }
@@ -1347,7 +1347,7 @@ class Module
      */
     public function listLocales()
     {
-        $locales = array();
+        $locales = [];
         if (! $this->hasLocales()) {
             return $locales;
         }
@@ -1405,15 +1405,15 @@ class Module
             $this->name . '_img',
             new Zend_Controller_Router_Route_Regex(
                 'img/' . $this->name . '/(.+)',
-                array(
+                [
                     'action'        => 'img',
                     'controller'    => 'static',
                     'module'        => 'default',
                     'module_name'   => $this->name
-                ),
-                array(
+                ],
+                [
                     1 => 'file'
-                )
+                ]
             )
         );
         return $this;

--- a/library/Icinga/Application/Modules/NavigationItemContainer.php
+++ b/library/Icinga/Application/Modules/NavigationItemContainer.php
@@ -32,7 +32,7 @@ abstract class NavigationItemContainer
      * @param   string  $name
      * @param   array   $properties
      */
-    public function __construct($name, array $properties = array())
+    public function __construct($name, array $properties = [])
     {
         $this->name = $name;
         $this->properties = $properties;
@@ -81,7 +81,7 @@ abstract class NavigationItemContainer
      */
     public function getProperties()
     {
-        return $this->properties ?: array();
+        return $this->properties ?: [];
     }
 
     /**
@@ -97,7 +97,7 @@ abstract class NavigationItemContainer
     public function __call($name, $arguments)
     {
         if (method_exists($this, $name)) {
-            return call_user_func(array($this, $name), $this, $arguments);
+            return call_user_func([$this, $name], $this, $arguments);
         }
 
         $type = substr($name, 0, 3);

--- a/library/Icinga/Application/Platform.php
+++ b/library/Icinga/Application/Platform.php
@@ -86,7 +86,7 @@ class Platform
             return false;
         }
 
-        foreach (array('/etc/os-release', '/usr/lib/os-release') as $osReleaseFile) {
+        foreach (['/etc/os-release', '/usr/lib/os-release'] as $osReleaseFile) {
             if (false === ($osRelease = @file(
                 $osReleaseFile,
                 FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES
@@ -102,7 +102,7 @@ class Platform
                     continue;
                 }
 
-                $matches = array();
+                $matches = [];
                 if (false === ($res = @preg_match(
                     '/(?<!.)[ \t]*ID[ \t]*=[ \t]*(\'|"|)(.*?)(?:\1)[ \t]*(?!.)/msi',
                     $osInfo,
@@ -120,10 +120,10 @@ class Platform
             return 'linux';
         }
 
-        foreach (array(
+        foreach ([
             'fedora' => '/etc/fedora-release',
             'centos' => '/etc/centos-release'
-        ) as $distro => $releaseFile) {
+        ] as $distro => $releaseFile) {
             if (! (false === (
                 $release = @file_get_contents($releaseFile)
             ) || false === strpos(strtolower($release), $distro))) {
@@ -136,7 +136,7 @@ class Platform
             if (false !== strpos($release, 'red hat enterprise linux')) {
                 return 'rhel';
             }
-            foreach (array('fedora', 'centos') as $distro) {
+            foreach (['fedora', 'centos'] as $distro) {
                 if (false !== strpos($release, $distro)) {
                     return $distro;
                 }
@@ -146,11 +146,11 @@ class Platform
 
         if (false !== ($release = @file_get_contents('/etc/SuSE-release'))) {
             $release = strtolower($release);
-            foreach (array(
+            foreach ([
                 'opensuse'  => 'opensuse',
                 'sles'      => 'suse linux enterprise server',
                 'sled'      => 'suse linux enterprise desktop'
-            ) as $distro => $name) {
+            ] as $distro => $name) {
                 if (false !== strpos($release, $name)) {
                     return $distro;
                 }
@@ -163,12 +163,12 @@ class Platform
                 return false;
             }
             $procVersion = strtolower($procVersion);
-            foreach (array(
+            foreach ([
                 'redhat'    => 'red hat',
                 'suse'      => 'suse linux',
                 'ubuntu'    => 'ubuntu',
                 'debian'    => 'debian'
-            ) as $distro => $name) {
+            ] as $distro => $name) {
                 if (false !== strpos($procVersion, $name)) {
                     return $distro;
                 }

--- a/library/Icinga/Application/Version.php
+++ b/library/Icinga/Application/Version.php
@@ -19,12 +19,12 @@ class Version
      */
     public static function get()
     {
-        $version = array('appVersion' => self::VERSION);
+        $version = ['appVersion' => self::VERSION];
         preg_match('/2.(\d+)\./', self::VERSION, $matches);
         $version['docVersion'] = isset($matches[1]) ? '2.' . $matches[1] : null;
 
         if (false !== ($appVersion = @file_get_contents(Icinga::app()->getApplicationDir('VERSION')))) {
-            $matches = array();
+            $matches = [];
             if (@preg_match('/^(?P<gitCommitID>\w+) (?P<gitCommitDate>\S+)/', $appVersion, $matches)) {
                 return array_merge($version, $matches);
             }

--- a/library/Icinga/Application/Web.php
+++ b/library/Icinga/Application/Web.php
@@ -97,7 +97,7 @@ class Web extends EmbeddedWeb
      */
     public function getThemes()
     {
-        $themes = array(StyleSheet::DEFAULT_THEME);
+        $themes = [StyleSheet::DEFAULT_THEME];
         $applicationThemePath = $this->getBaseDir('public/css/themes');
         if (DirectoryIterator::isReadable($applicationThemePath)) {
             foreach (new DirectoryIterator($applicationThemePath, 'less') as $name => $theme) {
@@ -206,7 +206,7 @@ class Web extends EmbeddedWeb
         $config = Config::navigation($type === 'dashboard-pane' ? 'dashlet' : $type);
 
         if ($type === 'dashboard-pane') {
-            $panes = array();
+            $panes = [];
             foreach ($config as $dashletName => $dashletConfig) {
                 if ($this->hasAccessToSharedNavigationItem($dashletConfig, $config)) {
                     // TODO: Throw ConfigurationError if pane or url is missing
@@ -218,14 +218,14 @@ class Web extends EmbeddedWeb
             foreach ($panes as $paneName => $dashlets) {
                 $navigation->addItem(
                     $paneName,
-                    array(
+                    [
                         'type'      => 'dashboard-pane',
                         'dashlets'  => $dashlets
-                    )
+                    ]
                 );
             }
         } else {
-            $items = array();
+            $items = [];
             foreach ($config as $name => $typeConfig) {
                 if (isset($this->accessibleMenuItems[$name])) {
                     if ($this->accessibleMenuItems[$name]) {
@@ -263,10 +263,10 @@ class Web extends EmbeddedWeb
     private function setupZendMvc()
     {
         Zend_Layout::startMvc(
-            array(
+            [
                 'layout'     => 'layout',
                 'layoutPath' => $this->getApplicationDir('/layouts/scripts')
-            )
+            ]
         );
 
         $this->setupFrontController();
@@ -322,9 +322,9 @@ class Web extends EmbeddedWeb
         $displayExceptions = $this->config->get('global', 'show_stacktraces', true);
 
         $this->frontController->setParams(
-            array(
+            [
                 'displayExceptions' => $displayExceptions
-            )
+            ]
         );
         return $this;
     }
@@ -367,7 +367,7 @@ class Web extends EmbeddedWeb
 
         Zend_Paginator::setDefaultScrollingStyle('SlidingWithBorder');
         Zend_View_Helper_PaginationControl::setDefaultViewPartial(
-            array('mixedPagination.phtml', 'default')
+            ['mixedPagination.phtml', 'default']
         );
         return $this;
     }

--- a/library/Icinga/Application/webrouter.php
+++ b/library/Icinga/Application/webrouter.php
@@ -45,12 +45,12 @@ if (strpos($ruri, '?') === false) {
     list($path, $params) = preg_split('/\?/', $ruri, 2);
 }
 
-$special = array(
+$special = [
     'css/icinga.css',
     'css/icinga.min.css',
     'js/icinga.dev.js',
     'js/icinga.min.js'
-);
+];
 
 if (in_array($path, $special)) {
     include_once __DIR__ . '/EmbeddedWeb.php';

--- a/library/Icinga/Authentication/Auth.php
+++ b/library/Icinga/Authentication/Auth.php
@@ -213,7 +213,7 @@ class Auth
     public function getRestrictions($restriction)
     {
         if (! $this->isAuthenticated()) {
-            return array();
+            return [];
         }
         return $this->user->getRestrictions($restriction);
     }

--- a/library/Icinga/Authentication/User/DbUserBackend.php
+++ b/library/Icinga/Authentication/User/DbUserBackend.php
@@ -22,67 +22,67 @@ class DbUserBackend extends DbRepository implements UserBackendInterface, Inspec
      *
      * @var array
      */
-    protected $queryColumns = array(
-        'user' => array(
+    protected $queryColumns = [
+        'user' => [
             'user'          => 'name COLLATE utf8mb4_general_ci',
             'user_name'     => 'name',
             'is_active'     => 'active',
             'created_at'    => 'UNIX_TIMESTAMP(ctime)',
             'last_modified' => 'UNIX_TIMESTAMP(mtime)'
-        )
-    );
+        ]
+    ];
 
     /**
      * The statement columns being provided
      *
      * @var array
      */
-    protected $statementColumns = array(
-        'user' => array(
+    protected $statementColumns = [
+        'user' => [
             'password'      => 'password_hash',
             'created_at'    => 'ctime',
             'last_modified' => 'mtime'
-        )
-    );
+        ]
+    ];
 
     /**
      * The columns which are not permitted to be queried
      *
      * @var array
      */
-    protected $blacklistedQueryColumns = array('user');
+    protected $blacklistedQueryColumns = ['user'];
 
     /**
      * The search columns being provided
      *
      * @var array
      */
-    protected $searchColumns = array('user');
+    protected $searchColumns = ['user'];
 
     /**
      * The default sort rules to be applied on a query
      *
      * @var array
      */
-    protected $sortRules = array(
-        'user_name' => array(
-            'columns'   => array(
+    protected $sortRules = [
+        'user_name' => [
+            'columns'   => [
                 'is_active desc',
                 'user_name'
-            )
-        )
-    );
+            ]
+        ]
+    ];
 
     /**
      * The value conversion rules to apply on a query or statement
      *
      * @var array
      */
-    protected $conversionRules = array(
-        'user' => array(
+    protected $conversionRules = [
+        'user' => [
             'password'
-        )
-    );
+        ]
+    ];
 
     /**
      * Initialize this database user backend
@@ -102,13 +102,13 @@ class DbUserBackend extends DbRepository implements UserBackendInterface, Inspec
     protected function initializeFilterColumns()
     {
         $userLabel = t('Username') . ' ' . t('(Case insensitive)');
-        return array(
+        return [
             $userLabel          => 'user',
             t('Username')       => 'user_name',
             t('Active')         => 'is_active',
             t('Created at')     => 'created_at',
             t('Last modified')  => 'last_modified'
-        );
+        ];
     }
 
     /**
@@ -119,17 +119,17 @@ class DbUserBackend extends DbRepository implements UserBackendInterface, Inspec
      *
      * @return void
      */
-    public function insert($table, array $bind, array $types = array())
+    public function insert($table, array $bind, array $types = [])
     {
         $this->requireTable($table);
         $bind['created_at'] = date('Y-m-d H:i:s');
         $this->ds->insert(
             $this->prependTablePrefix($table),
             $this->requireStatementColumns($table, $bind),
-            array(
+            [
                 'active'        => PDO::PARAM_INT,
                 'password_hash' => PDO::PARAM_LOB
-            )
+            ]
         );
     }
 
@@ -140,7 +140,7 @@ class DbUserBackend extends DbRepository implements UserBackendInterface, Inspec
      * @param array $bind
      * @param ?Filter $filter
      */
-    public function update($table, array $bind, ?Filter $filter = null, array $types = array())
+    public function update($table, array $bind, ?Filter $filter = null, array $types = [])
     {
         $this->requireTable($table);
         $bind['last_modified'] = date('Y-m-d H:i:s');
@@ -152,10 +152,10 @@ class DbUserBackend extends DbRepository implements UserBackendInterface, Inspec
             $this->prependTablePrefix($table),
             $this->requireStatementColumns($table, $bind),
             $filter,
-            array(
+            [
                 'active'        => PDO::PARAM_INT,
                 'password_hash' => PDO::PARAM_LOB
-            )
+            ]
         );
     }
 

--- a/library/Icinga/Authentication/User/ExternalBackend.php
+++ b/library/Icinga/Authentication/User/ExternalBackend.php
@@ -19,7 +19,7 @@ class ExternalBackend implements UserBackendInterface
      *
      * @var string[]
      */
-    public static $remoteUserEnvvars = array('REMOTE_USER', 'REDIRECT_REMOTE_USER');
+    public static $remoteUserEnvvars = ['REMOTE_USER', 'REDIRECT_REMOTE_USER'];
 
     /**
      * The name of this backend
@@ -91,11 +91,11 @@ class ExternalBackend implements UserBackendInterface
         foreach (static::$remoteUserEnvvars as $envVar) {
             $username = static::getRemoteUser($envVar);
             if ($username !== null) {
-                return array($username, $envVar);
+                return [$username, $envVar];
             }
         }
 
-        return array(null, null);
+        return [null, null];
     }
 
     /**

--- a/library/Icinga/Authentication/User/LdapUserBackend.php
+++ b/library/Icinga/Authentication/User/LdapUserBackend.php
@@ -60,28 +60,28 @@ class LdapUserBackend extends LdapRepository implements UserBackendInterface, Do
      *
      * @var array
      */
-    protected $blacklistedQueryColumns = array('user');
+    protected $blacklistedQueryColumns = ['user'];
 
     /**
      * The search columns being provided
      *
      * @var array
      */
-    protected $searchColumns = array('user');
+    protected $searchColumns = ['user'];
 
     /**
      * The default sort rules to be applied on a query
      *
      * @var array
      */
-    protected $sortRules = array(
-        'user_name' => array(
-            'columns'   => array(
+    protected $sortRules = [
+        'user_name' => [
+            'columns'   => [
                 'is_active desc',
                 'user_name'
-            )
-        )
-    );
+            ]
+        ]
+    ];
 
     /**
      * Set the base DN to use for a query
@@ -219,9 +219,9 @@ class LdapUserBackend extends LdapRepository implements UserBackendInterface, Do
             throw new ProgrammingError('It is required to set the object class where to find users first');
         }
 
-        return array(
+        return [
             'user' => $this->userClass
-        );
+        ];
     }
 
     /**
@@ -249,15 +249,15 @@ class LdapUserBackend extends LdapRepository implements UserBackendInterface, Do
             $lastModifiedAttribute = 'modifyTimestamp';
         }
 
-        return array(
-            'user' => array(
+        return [
+            'user' => [
                 'user'          => $this->userNameAttribute,
                 'user_name'     => $this->userNameAttribute,
                 'is_active'     => $isActiveAttribute,
                 'created_at'    => $createdAtAttribute,
                 'last_modified' => $lastModifiedAttribute
-            )
-        );
+            ]
+        ];
     }
 
     /**
@@ -267,12 +267,12 @@ class LdapUserBackend extends LdapRepository implements UserBackendInterface, Do
      */
     protected function initializeFilterColumns()
     {
-        return array(
+        return [
             t('Username')       => 'user_name',
             t('Active')         => 'is_active',
             t('Created At')     => 'created_at',
             t('Last modified')  => 'last_modified'
-        );
+        ];
     }
 
     /**
@@ -288,13 +288,13 @@ class LdapUserBackend extends LdapRepository implements UserBackendInterface, Do
             $stateConverter = 'shadow_expire';
         }
 
-        return array(
-            'user' => array(
+        return [
+            'user' => [
                 'is_active'     => $stateConverter,
                 'created_at'    => 'generalized_time',
                 'last_modified' => 'generalized_time'
-            )
-        );
+            ]
+        ];
     }
 
     /**

--- a/library/Icinga/Authentication/User/UserBackend.php
+++ b/library/Icinga/Authentication/User/UserBackend.php
@@ -23,12 +23,12 @@ class UserBackend implements ConfigAwareFactory
      *
      * @var array
      */
-    protected static $defaultBackends = array(
+    protected static $defaultBackends = [
         'external',
         'db',
         'ldap',
         'msldap'
-    );
+    ];
 
     /**
      * The registered custom user backends with their identifier as key and class name as value
@@ -88,8 +88,8 @@ class UserBackend implements ConfigAwareFactory
             return;
         }
 
-        static::$customBackends = array();
-        $providedBy = array();
+        static::$customBackends = [];
+        $providedBy = [];
         foreach (Icinga::app()->getModuleManager()->getLoadedModules() as $module) {
             foreach ($module->getUserBackends() as $identifier => $className) {
                 if (array_key_exists($identifier, $providedBy)) {

--- a/library/Icinga/Authentication/UserGroup/DbUserGroupBackend.php
+++ b/library/Icinga/Authentication/UserGroup/DbUserGroupBackend.php
@@ -21,83 +21,83 @@ class DbUserGroupBackend extends DbRepository implements Inspectable, UserGroupB
      *
      * @var array
      */
-    protected $queryColumns = array(
-        'group' => array(
+    protected $queryColumns = [
+        'group' => [
             'group_id'      => 'g.id',
             'group'         => 'g.name COLLATE utf8mb4_general_ci',
             'group_name'    => 'g.name',
             'parent'        => 'g.parent',
             'created_at'    => 'UNIX_TIMESTAMP(g.ctime)',
             'last_modified' => 'UNIX_TIMESTAMP(g.mtime)'
-        ),
-        'group_membership' => array(
+        ],
+        'group_membership' => [
             'group_id'      => 'gm.group_id',
             'user'          => 'gm.username COLLATE utf8mb4_general_ci',
             'user_name'     => 'gm.username',
             'created_at'    => 'UNIX_TIMESTAMP(gm.ctime)',
             'last_modified' => 'UNIX_TIMESTAMP(gm.mtime)'
-        )
-    );
+        ]
+    ];
 
     /**
      * The table aliases being applied
      *
      * @var array
      */
-    protected $tableAliases = array(
+    protected $tableAliases = [
         'group'             => 'g',
         'group_membership'  => 'gm'
-    );
+    ];
 
     /**
      * The statement columns being provided
      *
      * @var array
      */
-    protected $statementColumns = array(
-        'group' => array(
+    protected $statementColumns = [
+        'group' => [
             'group_id'      => 'id',
             'group_name'    => 'name',
             'parent'        => 'parent',
             'created_at'    => 'ctime',
             'last_modified' => 'mtime'
-        ),
-        'group_membership' => array(
+        ],
+        'group_membership' => [
             'group_id'      => 'group_id',
             'group_name'    => 'group_id',
             'user_name'     => 'username',
             'created_at'    => 'ctime',
             'last_modified' => 'mtime'
-        )
-    );
+        ]
+    ];
 
     /**
      * The columns which are not permitted to be queried
      *
      * @var array
      */
-    protected $blacklistedQueryColumns = array('group', 'user');
+    protected $blacklistedQueryColumns = ['group', 'user'];
 
     /**
      * The search columns being provided
      *
      * @var array
      */
-    protected $searchColumns = array('group', 'user');
+    protected $searchColumns = ['group', 'user'];
 
     /**
      * The value conversion rules to apply on a query or statement
      *
      * @var array
      */
-    protected $conversionRules = array(
-        'group'             => array(
+    protected $conversionRules = [
+        'group'             => [
             'parent'        => 'group_id'
-        ),
-        'group_membership'  => array(
+        ],
+        'group_membership'  => [
             'group_name'    => 'group_id'
-        )
-    );
+        ]
+    ];
 
     /**
      * Initialize this database user group backend
@@ -118,7 +118,7 @@ class DbUserGroupBackend extends DbRepository implements Inspectable, UserGroupB
     {
         $userLabel = t('Username') . ' ' . t('(Case insensitive)');
         $groupLabel = t('User Group') . ' ' . t('(Case insensitive)');
-        return array(
+        return [
             $userLabel          => 'user',
             t('Username')       => 'user_name',
             $groupLabel         => 'group',
@@ -126,7 +126,7 @@ class DbUserGroupBackend extends DbRepository implements Inspectable, UserGroupB
             t('Parent')         => 'parent',
             t('Created At')     => 'created_at',
             t('Last modified')  => 'last_modified'
-        );
+        ];
     }
 
     /**
@@ -135,7 +135,7 @@ class DbUserGroupBackend extends DbRepository implements Inspectable, UserGroupB
      * @param   string  $table
      * @param   array   $bind
      */
-    public function insert($table, array $bind, array $types = array())
+    public function insert($table, array $bind, array $types = [])
     {
         $bind['created_at'] = date('Y-m-d H:i:s');
         parent::insert($table, $bind);
@@ -148,7 +148,7 @@ class DbUserGroupBackend extends DbRepository implements Inspectable, UserGroupB
      * @param array $bind
      * @param ?Filter $filter
      */
-    public function update($table, array $bind, ?Filter $filter = null, array $types = array())
+    public function update($table, array $bind, ?Filter $filter = null, array $types = [])
     {
         $bind['last_modified'] = date('Y-m-d H:i:s');
         parent::update($table, $bind, $filter);
@@ -164,12 +164,12 @@ class DbUserGroupBackend extends DbRepository implements Inspectable, UserGroupB
     {
         if ($table === 'group') {
             parent::delete('group_membership', $filter);
-            $idQuery = $this->select(array('group_id'));
+            $idQuery = $this->select(['group_id']);
             if ($filter !== null) {
                 $idQuery->applyFilter($filter);
             }
 
-            $this->update('group', array('parent' => null), Filter::where('parent', $idQuery->fetchColumn()));
+            $this->update('group', ['parent' => null], Filter::where('parent', $idQuery->fetchColumn()));
         }
 
         parent::delete($table, $filter);
@@ -187,28 +187,28 @@ class DbUserGroupBackend extends DbRepository implements Inspectable, UserGroupB
         $groupQuery = $this->ds
             ->select()
             ->from(
-                array('g' => $this->prependTablePrefix('group')),
-                array(
+                ['g' => $this->prependTablePrefix('group')],
+                [
                     'group_name'    => 'g.name',
                     'parent_name'   => 'gg.name'
-                )
+                ]
             )->joinLeft(
-                array('gg' => $this->prependTablePrefix('group')),
+                ['gg' => $this->prependTablePrefix('group')],
                 'g.parent = gg.id',
-                array()
+                []
             );
 
-        $groups = array();
+        $groups = [];
         foreach ($groupQuery as $group) {
             $groups[$group->group_name] = $group->parent_name;
         }
 
         $membershipQuery = $this
             ->select()
-            ->from('group_membership', array('group_name'))
+            ->from('group_membership', ['group_name'])
             ->where('user', $user->getUsername());
 
-        $memberships = array();
+        $memberships = [];
         foreach ($membershipQuery as $membership) {
             $memberships[] = $membership->group_name;
             $parent = $groups[$membership->group_name];
@@ -244,7 +244,7 @@ class DbUserGroupBackend extends DbRepository implements Inspectable, UserGroupB
         $query->getQuery()->join(
             $this->requireTable('group'),
             'gm.group_id = g.id',
-            array()
+            []
         );
     }
 
@@ -258,7 +258,7 @@ class DbUserGroupBackend extends DbRepository implements Inspectable, UserGroupB
         $query->getQuery()->joinLeft(
             $this->requireTable('group_membership'),
             'g.id = gm.group_id',
-            array()
+            []
         )->group('g.id');
     }
 
@@ -284,7 +284,7 @@ class DbUserGroupBackend extends DbRepository implements Inspectable, UserGroupB
 
             $groupIds = $this->ds
                 ->select()
-                ->from($this->prependTablePrefix('group'), array('id'))
+                ->from($this->prependTablePrefix('group'), ['id'])
                 ->where('name', $groupName)
                 ->fetchColumn();
             if (empty($groupIds)) {
@@ -296,7 +296,7 @@ class DbUserGroupBackend extends DbRepository implements Inspectable, UserGroupB
 
         $groupId = $this->ds
             ->select()
-            ->from($this->prependTablePrefix('group'), array('id'))
+            ->from($this->prependTablePrefix('group'), ['id'])
             ->where('name', $groupName)
             ->fetchOne();
         if ($groupId === false) {

--- a/library/Icinga/Authentication/UserGroup/LdapUserGroupBackend.php
+++ b/library/Icinga/Authentication/UserGroup/LdapUserGroupBackend.php
@@ -120,25 +120,25 @@ class LdapUserGroupBackend extends LdapRepository implements Inspectable, UserGr
      *
      * @var array
      */
-    protected $blacklistedQueryColumns = array('group', 'user');
+    protected $blacklistedQueryColumns = ['group', 'user'];
 
     /**
      * The search columns being provided
      *
      * @var array
      */
-    protected $searchColumns = array('group', 'user');
+    protected $searchColumns = ['group', 'user'];
 
     /**
      * The default sort rules to be applied on a query
      *
      * @var array
      */
-    protected $sortRules = array(
-        'group_name' => array(
+    protected $sortRules = [
+        'group_name' => [
             'order' => 'asc'
-        )
-    );
+        ]
+    ];
 
     /**
      * Set the user backend to be associated with this user group backend
@@ -469,7 +469,7 @@ class LdapUserGroupBackend extends LdapRepository implements Inspectable, UserGr
 
             $sampleValues = $this->ds
                 ->select()
-                ->from($this->groupClass, array($this->groupMemberAttribute))
+                ->from($this->groupClass, [$this->groupMemberAttribute])
                 ->where($this->groupMemberAttribute, '*')
                 ->limit(Logger::getInstance()->getLevel() === Logger::DEBUG ? 3 : 1)
                 ->setUnfoldAttribute($this->groupMemberAttribute)
@@ -520,10 +520,10 @@ class LdapUserGroupBackend extends LdapRepository implements Inspectable, UserGr
             throw new ProgrammingError('It is required to set the object class where to find groups first');
         }
 
-        return array(
+        return [
             'group'             => $this->groupClass,
             'group_membership'  => $this->groupClass
-        );
+        ];
     }
 
     /**
@@ -551,15 +551,15 @@ class LdapUserGroupBackend extends LdapRepository implements Inspectable, UserGr
             $lastModifiedAttribute = 'modifyTimestamp';
         }
 
-        $columns = array(
+        $columns = [
             'group'         => $this->groupNameAttribute,
             'group_name'    => $this->groupNameAttribute,
             'user'          => $this->groupMemberAttribute,
             'user_name'     => $this->groupMemberAttribute,
             'created_at'    => $createdAtAttribute,
             'last_modified' => $lastModifiedAttribute
-        );
-        return array('group' => $columns, 'group_membership' => $columns);
+        ];
+        return ['group' => $columns, 'group_membership' => $columns];
     }
 
     /**
@@ -569,12 +569,12 @@ class LdapUserGroupBackend extends LdapRepository implements Inspectable, UserGr
      */
     protected function initializeFilterColumns()
     {
-        return array(
+        return [
             t('Username')       => 'user_name',
             t('User Group')     => 'group_name',
             t('Created At')     => 'created_at',
             t('Last modified')  => 'last_modified'
-        );
+        ];
     }
 
     /**
@@ -584,16 +584,16 @@ class LdapUserGroupBackend extends LdapRepository implements Inspectable, UserGr
      */
     protected function initializeConversionRules()
     {
-        $rules = array(
-            'group' => array(
+        $rules = [
+            'group' => [
                 'created_at'    => 'generalized_time',
                 'last_modified' => 'generalized_time'
-            ),
-            'group_membership' => array(
+            ],
+            'group_membership' => [
                 'created_at'    => 'generalized_time',
                 'last_modified' => 'generalized_time'
-            )
-        );
+            ]
+        ];
         if (! $this->isMemberAttributeAmbiguous()) {
             $rules['group_membership']['user_name'] = 'user_name';
             $rules['group_membership']['user'] = 'user_name';
@@ -616,7 +616,7 @@ class LdapUserGroupBackend extends LdapRepository implements Inspectable, UserGr
         try {
             $userDn = $this->ds
                 ->select()
-                ->from($this->userClass, array())
+                ->from($this->userClass, [])
                 ->where($this->userNameAttribute, $name)
                 ->setBase($this->userBaseDn)
                 ->setUsePagedResults(false)
@@ -627,7 +627,7 @@ class LdapUserGroupBackend extends LdapRepository implements Inspectable, UserGr
 
             $groupDn = $this->ds
                 ->select()
-                ->from($this->groupClass, array())
+                ->from($this->groupClass, [])
                 ->where($this->groupNameAttribute, $name)
                 ->setBase($this->groupBaseDn)
                 ->setUsePagedResults(false)
@@ -654,7 +654,7 @@ class LdapUserGroupBackend extends LdapRepository implements Inspectable, UserGr
     {
         return $this->ds
             ->select()
-            ->from('*', array($this->userNameAttribute))
+            ->from('*', [$this->userNameAttribute])
             ->setUnfoldAttribute($this->userNameAttribute)
             ->setBase($dn)
             ->fetchOne();
@@ -716,7 +716,7 @@ class LdapUserGroupBackend extends LdapRepository implements Inspectable, UserGr
 
         if ($domain !== null) {
             if (! $user->hasDomain() || strtolower($user->getDomain()) !== strtolower($domain)) {
-                return array();
+                return [];
             }
 
             $username = $user->getLocalUsername();
@@ -738,7 +738,7 @@ class LdapUserGroupBackend extends LdapRepository implements Inspectable, UserGr
             }
 
             if (($queryValue = $userQuery->fetchDn()) === null) {
-                return array();
+                return [];
             }
         }
 
@@ -750,7 +750,7 @@ class LdapUserGroupBackend extends LdapRepository implements Inspectable, UserGr
 
         $groupQuery = $this->ds
             ->select()
-            ->from($this->groupClass, array($this->groupNameAttribute))
+            ->from($this->groupClass, [$this->groupNameAttribute])
             ->setUnfoldAttribute($this->groupNameAttribute)
             ->where($groupMemberAttribute, $queryValue)
             ->setBase($this->groupBaseDn);
@@ -758,7 +758,7 @@ class LdapUserGroupBackend extends LdapRepository implements Inspectable, UserGr
             $groupQuery->setNativeFilter($this->groupFilter);
         }
 
-        $groups = array();
+        $groups = [];
         foreach ($groupQuery as $row) {
             $groups[] = $row->{$this->groupNameAttribute};
             if ($domain !== null) {
@@ -820,13 +820,13 @@ class LdapUserGroupBackend extends LdapRepository implements Inspectable, UserGr
             }
 
             $this->setUserBackend($userBackend);
-            $defaults->merge(array(
+            $defaults->merge([
                 'user_base_dn'          => $userBackend->getBaseDn(),
                 'user_class'            => $userBackend->getUserClass(),
                 'user_name_attribute'   => $userBackend->getUserNameAttribute(),
                 'user_filter'           => $userBackend->getFilter(),
                 'domain'                => $userBackend->getDomain()
-            ));
+            ]);
         }
 
         return $this
@@ -850,14 +850,14 @@ class LdapUserGroupBackend extends LdapRepository implements Inspectable, UserGr
      */
     public function getOpenLdapDefaults()
     {
-        return new ConfigObject(array(
+        return new ConfigObject([
             'group_class'               => 'group',
             'user_class'                => 'inetOrgPerson',
             'group_name_attribute'      => 'gid',
             'user_name_attribute'       => 'uid',
             'group_member_attribute'    => 'member',
             'nested_group_search'       => '0'
-        ));
+        ]);
     }
 
     /**
@@ -867,14 +867,14 @@ class LdapUserGroupBackend extends LdapRepository implements Inspectable, UserGr
      */
     public function getActiveDirectoryDefaults()
     {
-        return new ConfigObject(array(
+        return new ConfigObject([
             'group_class'               => 'group',
             'user_class'                => 'user',
             'group_name_attribute'      => 'sAMAccountName',
             'user_name_attribute'       => 'sAMAccountName',
             'group_member_attribute'    => 'member',
             'nested_group_search'       => '0'
-        ));
+        ]);
     }
 
     /**
@@ -900,7 +900,7 @@ class LdapUserGroupBackend extends LdapRepository implements Inspectable, UserGr
             try {
                 $groupQuery = $this->ds
                     ->select()
-                    ->from($this->groupClass, array($this->groupNameAttribute))
+                    ->from($this->groupClass, [$this->groupNameAttribute])
                     ->setBase($this->groupBaseDn);
 
                 if ($this->groupFilter) {

--- a/library/Icinga/Authentication/UserGroup/UserGroupBackend.php
+++ b/library/Icinga/Authentication/UserGroup/UserGroupBackend.php
@@ -21,11 +21,11 @@ class UserGroupBackend
      *
      * @var array
      */
-    protected static $defaultBackends = array(
+    protected static $defaultBackends = [
         'db',
         'ldap',
         'msldap'
-    );
+    ];
 
     /**
      * The registered custom user group backends with their identifier as key and class name as value
@@ -43,8 +43,8 @@ class UserGroupBackend
             return;
         }
 
-        static::$customBackends = array();
-        $providedBy = array();
+        static::$customBackends = [];
+        $providedBy = [];
         foreach (Icinga::app()->getModuleManager()->getLoadedModules() as $module) {
             foreach ($module->getUserGroupBackends() as $identifier => $className) {
                 if (array_key_exists($identifier, $providedBy)) {

--- a/library/Icinga/Chart/Axis.php
+++ b/library/Icinga/Chart/Axis.php
@@ -149,7 +149,7 @@ class Axis implements Drawable
      */
     public function getRequiredPadding()
     {
-        return array(10, 5, 15, 10);
+        return [10, 5, 15, 10];
     }
 
     /**
@@ -409,12 +409,12 @@ class Axis implements Drawable
      */
     public function transform(array &$dataSet)
     {
-        $result = array();
+        $result = [];
         foreach ($dataSet as &$points) {
-            $result[] = array(
+            $result[] = [
                 $this->xUnit->transform($points[0]),
                 100 - $this->yUnit->transform($points[1])
-            );
+            ];
         }
         return $result;
     }

--- a/library/Icinga/Chart/Donut.php
+++ b/library/Icinga/Chart/Donut.php
@@ -68,7 +68,7 @@ class Donut
      *
      * @var array
      */
-    protected $slices = array();
+    protected $slices = [];
 
     /**
      * The total amount of data units
@@ -85,9 +85,9 @@ class Donut
      *
      * @return  $this
      */
-    public function addSlice($data, $attributes = array())
+    public function addSlice($data, $attributes = [])
     {
-        $this->slices[] = array($data, $attributes);
+        $this->slices[] = [$data, $attributes];
 
         $this->count += $data;
 
@@ -269,31 +269,31 @@ class Donut
     protected function assemble()
     {
         // svg tag containing the ring
-        $svg = array(
+        $svg = [
             'tag'        => 'svg',
-            'attributes' => array(
+            'attributes' => [
                 'xmlns'         => 'http://www.w3.org/2000/svg',
                 'viewbox'       => '0 0 40 40',
                 'class'         => 'donut-graph'
-            ),
-            'content' => array()
-        );
+            ],
+            'content' => []
+        ];
 
         // Donut hole
-        $svg['content'][] = array(
+        $svg['content'][] = [
             'tag'        => 'circle',
-            'attributes' => array(
+            'attributes' => [
                 'cx'   => 20,
                 'cy'   => 20,
                 'r'    => sprintf('%F', $this->radius),
                 'fill' => $this->getCenterColor()
-            )
-        );
+            ]
+        ];
 
         // When there is no data show gray circle
-        $svg['content'][] = array(
+        $svg['content'][] = [
             'tag'        => 'circle',
-            'attributes' => array(
+            'attributes' => [
                 'aria-hidden' => true,
                 'cx'           => 20,
                 'cy'           => 20,
@@ -301,8 +301,8 @@ class Donut
                 'fill'         => $this->getCenterColor(),
                 'stroke-width' => $this->getThickness(),
                 'class'        => 'slice-state-not-checked'
-            )
-        );
+            ]
+        ];
 
         $slices = $this->slices;
 
@@ -316,9 +316,9 @@ class Donut
         $offset = 25;
 
         foreach ($slices as $slice) {
-            $svg['content'][] = array(
+            $svg['content'][] = [
                 'tag'        => 'circle',
-                'attributes' => $slice[1] + array(
+                'attributes' => $slice[1] + [
                     'cx'                => 20,
                     'cy'                => 20,
                     'r'                 => sprintf('%F', $this->radius),
@@ -328,54 +328,54 @@ class Donut
                         . ' '
                         . sprintf('%F', (99.9 - $slice[0])), // 99.9 prevents gaps (slight overlap)
                     'stroke-dashoffset' => sprintf('%F', $offset)
-                )
-            );
+                ]
+            ];
             // negative values shift in the clockwise direction
             $offset -= $slice[0];
         }
 
-        $result = array(
+        $result = [
             'tag'     => 'div',
-            'content' => array($svg)
-        );
+            'content' => [$svg]
+        ];
 
         $labelBig = (string) $this->getLabelBig();
         $labelSmall = (string) $this->getLabelSmall();
 
         if ($labelBig !== '' || $labelSmall !== '') {
-            $labels = array(
+            $labels = [
                 'tag' => 'div',
-                'attributes' => array(
+                'attributes' => [
                     'class' => 'donut-label'
-                ),
-                'content' => array()
-            );
+                ],
+                'content' => []
+            ];
 
             if ($labelBig !== '') {
                 $labels['content'][] =
-                    array(
+                    [
                         'tag' => 'a',
-                        'attributes' => array(
+                        'attributes' => [
                             'aria-label' => $labelBig . ' ' . $labelSmall,
                             'href' => $this->getLabelBigUrl() ? $this->getLabelBigUrl()->getAbsoluteUrl() : null,
                             'class' => $this->labelBigState === null
                                 ? 'donut-label-big'
                                 : 'donut-label-big state-' . $this->labelBigState
-                        ),
+                        ],
                         'content' => $this->shortenLabel($labelBig)
-                    );
+                    ];
             }
 
             if ($labelSmall !== '') {
-                $labels['content'][] = array(
+                $labels['content'][] = [
                     'tag' => 'p',
-                    'attributes' => array(
+                    'attributes' => [
                         'class' => 'donut-label-small',
                         'x' => '50%',
                         'y' => '50%'
-                    ),
+                    ],
                     'content' => $labelSmall
-                );
+                ];
             }
 
             $result['content'][] = $labels;
@@ -409,7 +409,7 @@ class Donut
 
     protected function renderAttributes(array $attributes)
     {
-        $html = array();
+        $html = [];
 
         foreach ($attributes as $name => $value) {
             if ($value === null) {
@@ -434,14 +434,14 @@ class Donut
     protected function renderContent(array $element)
     {
         $tag = $element['tag'];
-        $attributes = isset($element['attributes']) ? $element['attributes'] : array();
+        $attributes = isset($element['attributes']) ? $element['attributes'] : [];
         $content = isset($element['content']) ? $element['content'] : null;
 
-        $html = array(
+        $html = [
             // rtrim because attributes may be empty
             rtrim("<$tag " . $this->renderAttributes($attributes))
             . ">"
-        );
+        ];
 
         if ($content !== null) {
             if (is_array($content)) {

--- a/library/Icinga/Chart/Graph/BarGraph.php
+++ b/library/Icinga/Chart/Graph/BarGraph.php
@@ -146,12 +146,12 @@ class BarGraph extends Styleable implements Drawable
             // draw actual bar
             $bar = $this->drawSingleBar($point, $this->fill, $this->strokeWidth)->toSvg($ctx);
             if (isset($this->tooltips[$x])) {
-                $data = array(
+                $data = [
                     'label' => isset($this->graphs[$this->order]['label']) ?
                             strtolower($this->graphs[$this->order]['label']) : '',
                     'color' => isset($this->graphs[$this->order]['color']) ?
                             strtolower($this->graphs[$this->order]['color']) : '#fff'
-                );
+                ];
                 $format = isset($this->graphs[$this->order]['tooltip'])
                     ? $this->graphs[$this->order]['tooltip'] : null;
                 $title = $ctx->getDocument()->createElement('title');

--- a/library/Icinga/Chart/Graph/LineGraph.php
+++ b/library/Icinga/Chart/Graph/LineGraph.php
@@ -76,7 +76,7 @@ class LineGraph extends Styleable implements Drawable
         $order,
         ?array $tooltips = null
     ) {
-        usort($dataset, array($this, 'sortByX'));
+        usort($dataset, [$this, 'sortByX']);
         $this->dataset = $dataset;
         $this->graphs = $graphs;
 
@@ -161,8 +161,8 @@ class LineGraph extends Styleable implements Drawable
         if ($this->fill !== 'none') {
             $firstX = $this->dataset[0][0];
             $lastX = $this->dataset[count($this->dataset)-1][0];
-            $path->prepend(array($firstX, 100))
-                ->append(array($lastX, 100));
+            $path->prepend([$firstX, 100])
+                ->append([$lastX, 100]);
             $path->setFill($this->fill);
         }
 
@@ -182,12 +182,12 @@ class LineGraph extends Styleable implements Drawable
                 $invisible = new Circle($point[0], $point[1], 20);
                 $invisible->setFill($this->strokeColor);
                 $invisible->setAdditionalStyle(['opacity' => '0.0']);
-                $data = array(
+                $data = [
                     'label' => isset($this->graphs[$this->order]['label']) ?
                             strtolower($this->graphs[$this->order]['label']) : '',
                     'color' => isset($this->graphs[$this->order]['color']) ?
                             strtolower($this->graphs[$this->order]['color']) : '#fff'
-                );
+                ];
                 $format = isset($this->graphs[$this->order]['tooltip'])
                     ? $this->graphs[$this->order]['tooltip'] : null;
                 $title = $ctx->getDocument()->createElement('title');

--- a/library/Icinga/Chart/Graph/StackedGraph.php
+++ b/library/Icinga/Chart/Graph/StackedGraph.php
@@ -19,14 +19,14 @@ class StackedGraph implements Drawable
      *
      * @var array
      */
-    private $stack = array();
+    private $stack = [];
 
     /**
      * An associative array containing x points as the key and an array of y values as the value
      *
      * @var array
      */
-    private $points = array();
+    private $points = [];
 
     /**
      * Add a graph to this stack and aggregate the values on the fly

--- a/library/Icinga/Chart/Graph/Tooltip.php
+++ b/library/Icinga/Chart/Graph/Tooltip.php
@@ -39,16 +39,16 @@ class Tooltip
      *
      * @var array
      */
-    private $points = array();
+    private $points = [];
 
     /**
      * Contains all static replacements
      *
      * @var array
      */
-    private $data = array(
+    private $data = [
         'sum' => 0
-    );
+    ];
 
     /**
      * Used to format the displayed tooltip.
@@ -67,7 +67,7 @@ class Tooltip
      * @param string    $format The default format string
      */
     public function __construct(
-        $data = array(),
+        $data = [],
         $format = '<b>{title}</b>: {value} {label}'
     ) {
         $this->data = array_merge($this->data, $data);
@@ -112,7 +112,7 @@ class Tooltip
      *
      * @return mixed|string The tooltip value
      */
-    public function render($order, $data = array(), $format = null)
+    public function render($order, $data = [], $format = null)
     {
         if (isset($format)) {
             $str = $format;

--- a/library/Icinga/Chart/GridChart.php
+++ b/library/Icinga/Chart/GridChart.php
@@ -56,7 +56,7 @@ class GridChart extends Chart
      *
      * @var array
      */
-    private $graphs = array();
+    private $graphs = [];
 
     /**
      * An associative array containing all axis of this Chart in the  "name" => Axis() form.
@@ -65,7 +65,7 @@ class GridChart extends Chart
      *
      * @var array
      */
-    private $axis = array();
+    private $axis = [];
 
     /**
      * An associative array containing all StackedGraph objects used for cumulative graphs
@@ -74,7 +74,7 @@ class GridChart extends Chart
      *
      * @var array
      */
-    private $stacks = array();
+    private $stacks = [];
 
     /**
      * An associative array containing all Tooltips used to render the titles
@@ -84,7 +84,7 @@ class GridChart extends Chart
      *
      * @var Tooltip
      */
-    private $tooltips = array();
+    private $tooltips = [];
 
     public function __construct()
     {
@@ -198,10 +198,10 @@ class GridChart extends Chart
             foreach ($graph['data'] as $x => $point) {
                 if (!array_key_exists($x, $this->tooltips)) {
                     $this->tooltips[$x] = new Tooltip(
-                        array(
+                        [
                             'color' => $graph['color'],
 
-                        )
+                        ]
                     );
                 }
                 $this->tooltips[$x]->addDataPoint($point);
@@ -281,7 +281,7 @@ class GridChart extends Chart
      */
     public function setAxis(Axis $axis, $name = 'default')
     {
-        $this->axis = array($name => $axis);
+        $this->axis = [$name => $axis];
         return $this;
     }
 
@@ -345,7 +345,7 @@ class GridChart extends Chart
         $outerBox = new Canvas('outerGraph', new LayoutBox(0, 0, 100, 100));
         $innerBox = new Canvas('graph', new LayoutBox(0, 0, 95, 90));
 
-        $maxPadding = array(0,0,0,0);
+        $maxPadding = [0,0,0,0];
         foreach ($this->axis as $axis) {
             $padding = $axis->getRequiredPadding();
             for ($i=0; $i < count($padding); $i++) {

--- a/library/Icinga/Chart/GridChart.php
+++ b/library/Icinga/Chart/GridChart.php
@@ -30,12 +30,14 @@ use Icinga\Chart\Unit\AxisUnit;
  * $this->chart = new GridChart();
  * $this->chart->setAxisLabel("X axis label", "Y axis label");
  * $this->chart->setXAxis(Axis::CalendarUnit());
- * $this->chart->drawLines(
- * array(
- *      'data'  => array(
- *          array(time()-7200, 10),array(time()-3620, 30), array(time()-1800, 15), array(time(), 92))
- *      )
- * );
+ * $this->chart->drawLines([
+ *     'data' => [
+ *         [time()-7200, 10],
+ *         [time()-3620, 30],
+ *         [time()-1800, 15],
+ *         [time(), 92]
+ *     ]
+ * ]);
  * </code>
  * </pre>
  */

--- a/library/Icinga/Chart/Inline/Inline.php
+++ b/library/Icinga/Chart/Inline/Inline.php
@@ -31,19 +31,19 @@ class Inline
      *
      * @var array
      */
-    protected $colors = array(
+    protected $colors = [
         '#00FF00', // OK
         '#FFFF00', // Warning
         '#FF0000', // Critical
         '#E066FF'  // Unreachable
-    );
+    ];
 
     /**
      * The labels displayed on this chart
      *
      * @var array
      */
-    protected $labels = array();
+    protected $labels = [];
 
     /**
      * The height in percent
@@ -61,7 +61,7 @@ class Inline
 
     protected function sanitizeStringArray(array $arr)
     {
-        $sanitized = array();
+        $sanitized = [];
         foreach ($arr as $key => $value) {
             $sanitized[$key] = htmlspecialchars($value);
         }

--- a/library/Icinga/Chart/Inline/PieChart.php
+++ b/library/Icinga/Chart/Inline/PieChart.php
@@ -17,9 +17,9 @@ class PieChart extends Inline
         $pie = new PieChartRenderer();
         $pie->alignTopLeft();
         $pie->disableLegend();
-        $pie->drawPie(array(
+        $pie->drawPie([
             'data' => $this->data, 'colors' => $this->colors, 'labels' => $this->labels
-        ));
+        ]);
         return $pie;
     }
 

--- a/library/Icinga/Chart/Legend.php
+++ b/library/Icinga/Chart/Legend.php
@@ -35,7 +35,7 @@ class Legend implements Drawable
      *
      * @var array
      */
-    private $dataset = array();
+    private $dataset = [];
 
 
     /**

--- a/library/Icinga/Chart/Palette.php
+++ b/library/Icinga/Chart/Palette.php
@@ -35,12 +35,12 @@ class Palette
      *
      * @var array
      */
-    public $colorSets = array(
-        self::OK      => array('#00FF00'),
-        self::PROBLEM => array('#FF0000'),
-        self::WARNING => array('#FFFF00'),
-        self::NEUTRAL => array('#f3f3f3')
-    );
+    public $colorSets = [
+        self::OK      => ['#00FF00'],
+        self::PROBLEM => ['#FF0000'],
+        self::WARNING => ['#FFFF00'],
+        self::NEUTRAL => ['#f3f3f3']
+    ];
 
     /**
      * Return the next available color as an hex string for the given type

--- a/library/Icinga/Chart/PieChart.php
+++ b/library/Icinga/Chart/PieChart.php
@@ -36,7 +36,7 @@ class PieChart extends Chart
      *
      * @var array
      */
-    private $pies = array();
+    private $pies = [];
 
     /**
      * The composition type currently used

--- a/library/Icinga/Chart/Primitive/Canvas.php
+++ b/library/Icinga/Chart/Primitive/Canvas.php
@@ -28,7 +28,7 @@ class Canvas implements Drawable
      *
      * @var array
      */
-    private $children = array();
+    private $children = [];
 
     /**
      * When true, this canvas is encapsulated in a clipPath tag and not drawn

--- a/library/Icinga/Chart/Primitive/Path.php
+++ b/library/Icinga/Chart/Primitive/Path.php
@@ -55,7 +55,7 @@ class Path extends Styleable implements Drawable
      *
      * @var array
      */
-    protected $points = array();
+    protected $points = [];
 
     /**
      * True to draw the path discrete, i.e. make hard steps between points
@@ -87,7 +87,7 @@ class Path extends Styleable implements Drawable
             return $this;
         }
         if (!is_array($points[0])) {
-            $points = array($points);
+            $points = [$points];
         }
         $this->points = array_merge($this->points, $points);
         return $this;
@@ -106,7 +106,7 @@ class Path extends Styleable implements Drawable
             return $this;
         }
         if (!is_array($points[0])) {
-            $points = array($points);
+            $points = [$points];
         }
         $this->points = array_merge($points, $this->points);
         return $this;

--- a/library/Icinga/Chart/Primitive/PieSlice.php
+++ b/library/Icinga/Chart/Primitive/PieSlice.php
@@ -159,10 +159,10 @@ class PieSlice extends Animatable implements Drawable
         $midY = $y - intval(($offsetY + $r)/2 * cos($midRadius));
 
         // Draw the handle
-        $path = new Path(array($midX, $midY));
+        $path = new Path([$midX, $midY]);
 
         $midX += ($addOffset + $r/3) * ($midRadius > M_PI ? -1 : 1);
-        $path->append(array($midX, $midY))->toAbsolute();
+        $path->append([$midX, $midY])->toAbsolute();
 
         $midX += intval($r/2 * sin(M_PI/9)) * ($midRadius > M_PI ? -1 : 1);
         $midY -= intval($r/2 * cos(M_PI/3)) * ($midRadius < M_PI*1.4 && $midRadius > M_PI/3 ? -1 : 1);
@@ -173,7 +173,7 @@ class PieSlice extends Animatable implements Drawable
             $midY = $ctx->yToAbsolute($ctx->yToRelative(100+$midY));
         }
 
-        $path->append(array($midX , $midY));
+        $path->append([$midX , $midY]);
         $rel = $ctx->toRelative($midX, $midY);
 
         // Draw the text box

--- a/library/Icinga/Chart/Primitive/Styleable.php
+++ b/library/Icinga/Chart/Primitive/Styleable.php
@@ -55,7 +55,7 @@ class Styleable
      *
      * @var array
      */
-    public $attributes = array();
+    public $attributes = [];
 
     /**
      * Set the stroke width for this drawable

--- a/library/Icinga/Chart/Render/LayoutBox.php
+++ b/library/Icinga/Chart/Render/LayoutBox.php
@@ -65,7 +65,7 @@ class LayoutBox
      *
      * @var array
      */
-    private $padding = array(0, 0, 0, 0);
+    private $padding = [0, 0, 0, 0];
 
     /**
      * Create this layout box
@@ -92,7 +92,7 @@ class LayoutBox
      */
     public function setUniformPadding($padding)
     {
-        $this->padding = array($padding, $padding, $padding, $padding);
+        $this->padding = [$padding, $padding, $padding, $padding];
     }
 
     /**
@@ -105,7 +105,7 @@ class LayoutBox
      */
     public function setPadding($top, $right, $bottom, $left)
     {
-        $this->padding = array($top, $right, $bottom, $left);
+        $this->padding = [$top, $right, $bottom, $left];
     }
 
     /**

--- a/library/Icinga/Chart/Render/RenderContext.php
+++ b/library/Icinga/Chart/Render/RenderContext.php
@@ -21,7 +21,7 @@ class RenderContext
      *
      * @var array
      */
-    private $viewBoxSize = array(1000, 1000);
+    private $viewBoxSize = [1000, 1000];
 
 
     /**
@@ -137,7 +137,7 @@ class RenderContext
      */
     public function toAbsolute($x, $y)
     {
-        return array($this->xToAbsolute($x), $this->yToAbsolute($y));
+        return [$this->xToAbsolute($x), $this->yToAbsolute($y)];
     }
 
     /**
@@ -153,7 +153,7 @@ class RenderContext
      */
     public function toRelative($x, $y)
     {
-        return array($this->xToRelative($x), $this->yToRelative($y));
+        return [$this->xToRelative($x), $this->yToRelative($y)];
     }
 
     /**
@@ -170,10 +170,10 @@ class RenderContext
             $padding[LayoutBox::PADDING_TOP] + $padding[LayoutBox::PADDING_BOTTOM]
         );
 
-        return array(
+        return [
             ($this->getNrOfUnitsX() - $horizontalPadding) / $this->getNrOfUnitsX(),
             ($this->getNrOfUnitsY() - $verticalPadding) / $this->getNrOfUnitsY()
-        );
+        ];
     }
 
     /**

--- a/library/Icinga/Chart/SVGRenderer.php
+++ b/library/Icinga/Chart/SVGRenderer.php
@@ -207,7 +207,7 @@ class SVGRenderer
             $svg->appendChild($desc);
         }
 
-        $svg->setAttribute('aria-labelledby', join(' ', array($titleId, $descId)));
+        $svg->setAttribute('aria-labelledby', join(' ', [$titleId, $descId]));
     }
 
     /**

--- a/library/Icinga/Chart/Unit/CalendarUnit.php
+++ b/library/Icinga/Chart/Unit/CalendarUnit.php
@@ -39,7 +39,7 @@ class CalendarUnit extends LinearUnit
      *
      * @var array
      */
-    private $labels = array();
+    private $labels = [];
 
     /**
      * The date format to use
@@ -60,7 +60,7 @@ class CalendarUnit extends LinearUnit
      */
     private function createLabels()
     {
-        $this->labels = array();
+        $this->labels = [];
         $duration = $this->getMax() - $this->getMin();
 
         if ($duration <= self::HOUR) {

--- a/library/Icinga/Chart/Unit/LinearUnit.php
+++ b/library/Icinga/Chart/Unit/LinearUnit.php
@@ -80,7 +80,7 @@ class LinearUnit implements AxisUnit
      */
     public function addValues(array $dataset, $idx = 0)
     {
-        $datapoints = array();
+        $datapoints = [];
 
         foreach ($dataset['data'] as $points) {
             $datapoints[] = $points[$idx];

--- a/library/Icinga/Chart/Unit/LogarithmicUnit.php
+++ b/library/Icinga/Chart/Unit/LogarithmicUnit.php
@@ -71,7 +71,7 @@ class LogarithmicUnit implements AxisUnit
      */
     public function addValues(array $dataset, $idx = 0)
     {
-        $datapoints = array();
+        $datapoints = [];
 
         foreach ($dataset['data'] as $points) {
             $datapoints[] = $points[$idx];

--- a/library/Icinga/Chart/Unit/StaticAxis.php
+++ b/library/Icinga/Chart/Unit/StaticAxis.php
@@ -7,7 +7,7 @@ namespace Icinga\Chart\Unit;
 
 class StaticAxis implements AxisUnit
 {
-    private $items = array();
+    private $items = [];
 
     /**
      * Add a dataset to this AxisUnit, required for dynamic min and max values
@@ -19,7 +19,7 @@ class StaticAxis implements AxisUnit
      */
     public function addValues(array $dataset, $idx = 0)
     {
-        $datapoints = array();
+        $datapoints = [];
         foreach ($dataset['data'] as $points) {
             $this->items[] = $points[$idx];
         }

--- a/library/Icinga/Cli/AnsiScreen.php
+++ b/library/Icinga/Cli/AnsiScreen.php
@@ -12,7 +12,7 @@ use Icinga\Exception\IcingaException;
 
 class AnsiScreen extends Screen
 {
-    protected $fgColors = array(
+    protected $fgColors = [
         'black'       => '30',
         'darkgray'    => '1;30',
         'red'         => '31',
@@ -29,9 +29,9 @@ class AnsiScreen extends Screen
         'lightcyan'   => '1;36',
         'lightgray'   => '37',
         'white'       => '1;37',
-    );
+    ];
 
-    protected $bgColors = array(
+    protected $bgColors = [
         'black'     => '40',
         'red'       => '41',
         'green'     => '42',
@@ -40,7 +40,7 @@ class AnsiScreen extends Screen
         'purple'    => '45',
         'cyan'      => '46',
         'lightgray' => '47',
-    );
+    ];
 
     public function strlen($string)
     {
@@ -98,7 +98,7 @@ class AnsiScreen extends Screen
     protected function startColor($fgColor = null, $bgColor = null)
     {
         $escape = "ESC[";
-        $parts = array();
+        $parts = [];
         if ($fgColor !== null
             && $bgColor !== null
             && ! array_key_exists($bgColor, $this->bgColors)

--- a/library/Icinga/Cli/Command.php
+++ b/library/Icinga/Cli/Command.php
@@ -181,7 +181,7 @@ abstract class Command
 
     public function listActions()
     {
-        $actions = array();
+        $actions = [];
         foreach (get_class_methods($this) as $method) {
             if (preg_match('~^([A-Za-z0-9]+)Action$~', $method, $m)) {
                 $actions[] = $m[1];

--- a/library/Icinga/Cli/Documentation/CommentParser.php
+++ b/library/Icinga/Cli/Documentation/CommentParser.php
@@ -13,7 +13,7 @@ class CommentParser
     protected $plain;
     protected $title;
     /** @var array $paragraphs */
-    protected $paragraphs = array();
+    protected $paragraphs = [];
 
     public function __construct($raw)
     {

--- a/library/Icinga/Cli/Loader.php
+++ b/library/Icinga/Cli/Loader.php
@@ -28,7 +28,7 @@ class Loader
 
     protected $modules;
 
-    protected $moduleCommands = array();
+    protected $moduleCommands = [];
 
     protected $coreAppDir;
 
@@ -43,28 +43,28 @@ class Loader
     /**
      * [$command] = $class;
      */
-    protected $commandClassMap = array();
+    protected $commandClassMap = [];
 
     /**
      * [$command] = $file;
      */
-    protected $commandFileMap = array();
+    protected $commandFileMap = [];
 
     /**
      * [$module][$command] = $class;
      */
-    protected $moduleClassMap = array();
+    protected $moduleClassMap = [];
 
     /**
      * [$module][$command] = $file;
      */
-    protected $moduleFileMap = array();
+    protected $moduleFileMap = [];
 
-    protected $commandInstances = array();
+    protected $commandInstances = [];
 
-    protected $moduleInstances = array();
+    protected $moduleInstances = [];
 
-    protected $lastSuggestions = array();
+    protected $lastSuggestions = [];
 
     public function __construct(App $app)
     {
@@ -358,7 +358,7 @@ class Loader
 
     protected function formatTrace($trace)
     {
-        $output = array();
+        $output = [];
         foreach ($trace as $i => $step) {
             $object = '';
             if (isset($step['object']) && is_object($step['object'])) {
@@ -386,7 +386,7 @@ class Loader
                     }
                 }
             } else {
-                $step['args'] = array();
+                $step['args'] = [];
             }
             $args = $step['args'];
             foreach ($args as & $v) {
@@ -431,7 +431,7 @@ class Loader
     public function listModules()
     {
         if ($this->modules === null) {
-            $this->modules = array();
+            $this->modules = [];
             try {
                 $this->modules = array_unique(array_merge(
                     $this->app->getModuleManager()->listEnabledModules(),
@@ -446,7 +446,7 @@ class Loader
 
     protected function retrieveCommandsFromDir($dirname)
     {
-        $commands = array();
+        $commands = [];
         if (! @file_exists($dirname) || ! is_readable($dirname)) {
             return $commands;
         }
@@ -472,7 +472,7 @@ class Loader
     public function listCommands()
     {
         if ($this->commands === null) {
-            $this->commands = array();
+            $this->commands = [];
             $ns = 'Icinga\\Clicommands\\';
             $this->commands = $this->retrieveCommandsFromDir($this->coreAppDir);
             foreach ($this->commands as $cmd) {
@@ -492,7 +492,7 @@ class Loader
             $manager->loadModule($module);
             $dir = $manager->getModuleDir($module) . '/application/clicommands';
             $this->moduleCommands[$module] = $this->retrieveCommandsFromDir($dir);
-            $this->moduleInstances[$module] = array();
+            $this->moduleInstances[$module] = [];
             foreach ($this->moduleCommands[$module] as $cmd) {
                 $this->moduleClassMap[$module][$cmd] = $ns . ucfirst($cmd) . 'Command';
                 $this->moduleFileMap[$module][$cmd] = $dir . '/' . ucfirst($cmd) . 'Command.php';

--- a/library/Icinga/Cli/Params.php
+++ b/library/Icinga/Cli/Params.php
@@ -26,14 +26,14 @@ class Params
      *
      * @var array
      */
-    protected $standalone = array();
+    protected $standalone = [];
 
     /**
      * The options
      *
      * @var array
      */
-    protected $params = array();
+    protected $params = [];
 
     /**
      * Parse the given commandline and create a new Params object
@@ -49,7 +49,7 @@ class Params
                 $noOptionFlag = true;
             } elseif (!$noOptionFlag && substr($argv[$i], 0, 2) === '--') {
                 $key = substr($argv[$i], 2);
-                $matches = array();
+                $matches = [];
                 if (1 === preg_match(
                     '/(?<!.)([^=]+)=(.*)(?!.)/ms',
                     $key,
@@ -60,7 +60,7 @@ class Params
                     $this->params[$key] = true;
                 } elseif (array_key_exists($key, $this->params)) {
                     if (!is_array($this->params[$key])) {
-                        $this->params[$key] = array($this->params[$key]);
+                        $this->params[$key] = [$this->params[$key]];
                     }
                     $this->params[$key][] = $argv[++$i];
                 } else {
@@ -210,10 +210,10 @@ class Params
      *
      * @return  $this
      */
-    public function remove($keys = array())
+    public function remove($keys = [])
     {
         if (! is_array($keys)) {
-            $keys = array($keys);
+            $keys = [$keys];
         }
         foreach ($keys as $key) {
             if (array_key_exists($key, $this->params)) {
@@ -230,7 +230,7 @@ class Params
      *
      * @return  Params
      */
-    public function without($keys = array())
+    public function without($keys = [])
     {
         $params = clone($this);
         return $params->remove($keys);

--- a/library/Icinga/Cli/Screen.php
+++ b/library/Icinga/Cli/Screen.php
@@ -63,7 +63,7 @@ class Screen
             $current = setlocale(LC_ALL, 0);
 
             $parts = preg_split('/;/', $current);
-            $lc_parts = array();
+            $lc_parts = [];
             foreach ($parts as $part) {
                 if (strpos($part, '=') === false) {
                     continue;

--- a/library/Icinga/Data/ConfigObject.php
+++ b/library/Icinga/Data/ConfigObject.php
@@ -24,7 +24,7 @@ class ConfigObject extends ArrayDatasource implements Iterator, ArrayAccess
      *
      * @param   array   $data   The data to initialize the new config with
      */
-    public function __construct(array $data = array())
+    public function __construct(array $data = [])
     {
         // Convert all embedded arrays to ConfigObjects as well
         foreach ($data as & $value) {
@@ -41,7 +41,7 @@ class ConfigObject extends ArrayDatasource implements Iterator, ArrayAccess
      */
     public function __clone()
     {
-        $array = array();
+        $array = [];
         foreach ($this->data as $key => $value) {
             if ($value instanceof self) {
                 $array[$key] = clone $value;
@@ -249,7 +249,7 @@ class ConfigObject extends ArrayDatasource implements Iterator, ArrayAccess
      */
     public function toArray()
     {
-        $array = array();
+        $array = [];
         foreach ($this->data as $key => $value) {
             if ($value instanceof self) {
                 $array[$key] = $value->toArray();

--- a/library/Icinga/Data/DataArray/ArrayDatasource.php
+++ b/library/Icinga/Data/DataArray/ArrayDatasource.php
@@ -106,7 +106,7 @@ class ArrayDatasource implements Selectable
      */
     public function fetchColumn(SimpleQuery $query)
     {
-        $result = array();
+        $result = [];
         foreach ($this->getResult($query) as $row) {
             $arr = (array) $row;
             $result[] = array_shift($arr);
@@ -124,7 +124,7 @@ class ArrayDatasource implements Selectable
      */
     public function fetchPairs(SimpleQuery $query)
     {
-        $result = array();
+        $result = [];
         $keys = null;
         foreach ($this->getResult($query) as $row) {
             if ($keys === null) {
@@ -226,7 +226,7 @@ class ArrayDatasource implements Selectable
 
             // Get only desired columns if asked so
             if (! empty($columns)) {
-                $filteredRow = (object) array();
+                $filteredRow = (object) [];
                 foreach ($columns as $alias => $name) {
                     if (! is_string($alias)) {
                         $alias = $name;

--- a/library/Icinga/Data/Db/DbConnection.php
+++ b/library/Icinga/Data/Db/DbConnection.php
@@ -61,16 +61,16 @@ class DbConnection implements Selectable, Extensible, Updatable, Reducible, Insp
      */
     private $tablePrefix = '';
 
-    private static $genericAdapterOptions = array(
+    private static $genericAdapterOptions = [
         Zend_Db::AUTO_QUOTE_IDENTIFIERS => false,
         Zend_Db::CASE_FOLDING           => Zend_Db::CASE_LOWER
-    );
+    ];
 
-    private static $driverOptions = array(
+    private static $driverOptions = [
         PDO::ATTR_TIMEOUT    => 10,
         PDO::ATTR_CASE       => PDO::CASE_LOWER,
         PDO::ATTR_ERRMODE    => PDO::ERRMODE_EXCEPTION
-    );
+    ];
 
     /**
      * Create a new connection object
@@ -142,7 +142,7 @@ class DbConnection implements Selectable, Extensible, Updatable, Reducible, Insp
     {
         $genericAdapterOptions  = self::$genericAdapterOptions;
         $driverOptions          = self::$driverOptions;
-        $adapterParamaters      = array(
+        $adapterParamaters      = [
             'host'              => $this->config->host,
             'username'          => $this->config->username,
             'password'          => $this->config->password,
@@ -150,7 +150,7 @@ class DbConnection implements Selectable, Extensible, Updatable, Reducible, Insp
             'charset'           => $this->config->charset ?: null,
             'options'           => & $genericAdapterOptions,
             'driver_options'    => & $driverOptions
-        );
+        ];
         $this->dbType = strtolower($this->config->get('db', 'mysql'));
         switch ($this->dbType) {
             case 'mssql':
@@ -227,9 +227,9 @@ class DbConnection implements Selectable, Extensible, Updatable, Reducible, Insp
                 $adapter = 'Oracle';
                 unset($adapterParamaters['options']);
                 unset($adapterParamaters['driver_options']);
-                $adapterParamaters['driver_options'] = array(
+                $adapterParamaters['driver_options'] = [
                     'lob_as_string' => true
-                );
+                ];
                 $defaultPort = 1521;
                 break;
             case 'oracle':
@@ -397,9 +397,9 @@ class DbConnection implements Selectable, Extensible, Updatable, Reducible, Insp
      *
      * @return  int             The number of affected rows
      */
-    public function insert($table, array $bind, array $types = array())
+    public function insert($table, array $bind, array $types = [])
     {
-        $columns = $values = array();
+        $columns = $values = [];
         foreach ($bind as $column => $value) {
             $columns[] = $column;
             if ($value instanceof Zend_Db_Expr) {
@@ -438,9 +438,9 @@ class DbConnection implements Selectable, Extensible, Updatable, Reducible, Insp
      *
      * @return int The number of affected rows
      */
-    public function update($table, array $bind, ?Filter $filter = null, array $types = array())
+    public function update($table, array $bind, ?Filter $filter = null, array $types = [])
     {
-        $set = array();
+        $set = [];
         foreach ($bind as $column => $value) {
             if ($value instanceof Zend_Db_Expr) {
                 $set[] = $column . ' = ' . $value;
@@ -501,7 +501,7 @@ class DbConnection implements Selectable, Extensible, Updatable, Reducible, Insp
             }
 
             if (! $filter->isEmpty()) {
-                $parts = array();
+                $parts = [];
                 foreach ($filter->filters() as $filterPart) {
                     $part = $this->renderFilter($filterPart, $level + 1);
                     if ($part) {

--- a/library/Icinga/Data/Db/DbQuery.php
+++ b/library/Icinga/Data/Db/DbQuery.php
@@ -106,7 +106,7 @@ class DbQuery extends SimpleQuery
     public function from($target, ?array $fields = null)
     {
         parent::from($target, $fields);
-        $this->select->from($this->target, array());
+        $this->select->from($this->target, []);
         return $this;
     }
 
@@ -206,7 +206,7 @@ class DbQuery extends SimpleQuery
     {
         // bindParam? bindValue?
         if (is_array($value)) {
-            $ret = array();
+            $ret = [];
             foreach ($value as $val) {
                 $ret[] = $this->escapeForSql($val);
             }
@@ -310,11 +310,11 @@ class DbQuery extends SimpleQuery
             if ($group) {
                 $count->group($group);
             }
-            $columns = array('cnt' => 'COUNT(*)');
+            $columns = ['cnt' => 'COUNT(*)'];
             return $this->db->select()->from($count, $columns);
         }
 
-        $count->columns(array('cnt' => 'COUNT(*)'));
+        $count->columns(['cnt' => 'COUNT(*)']);
         return $count;
     }
 
@@ -559,7 +559,7 @@ class DbQuery extends SimpleQuery
      *
      * @return  $this
      */
-    public function union($select = array(), $type = Zend_Db_Select::SQL_UNION)
+    public function union($select = [], $type = Zend_Db_Select::SQL_UNION)
     {
         $this->select->union($select, $type);
         return $this;

--- a/library/Icinga/Data/Filter/Filter.php
+++ b/library/Icinga/Data/Filter/Filter.php
@@ -76,13 +76,13 @@ abstract class Filter
     public function applyChanges($changes)
     {
         $filter = $this;
-        $pairs = array();
+        $pairs = [];
         foreach ($changes as $k => $v) {
             if (preg_match('/^(column|value|sign|operator)_([\d-]+)$/', $k, $m)) {
                 $pairs[$m[2]][$m[1]] = $v;
             }
         }
-        $operators = array();
+        $operators = [];
         foreach ($pairs as $id => $fs) {
             if (array_key_exists('operator', $fs)) {
                 $operators[$id] = $fs['operator'];
@@ -221,13 +221,13 @@ abstract class Filter
             }
         }
         if (count($args) > 1) {
-            return new FilterNot(array(new FilterAnd($args)));
+            return new FilterNot([new FilterAnd($args)]);
         } else {
             return new FilterNot($args);
         }
     }
 
-    public static function chain($operator, $filters = array())
+    public static function chain($operator, $filters = [])
     {
         switch ($operator) {
             case 'AND':

--- a/library/Icinga/Data/Filter/FilterChain.php
+++ b/library/Icinga/Data/Filter/FilterChain.php
@@ -15,7 +15,7 @@ use Icinga\Exception\QueryException;
  */
 abstract class FilterChain extends Filter
 {
-    protected $filters = array();
+    protected $filters = [];
 
     protected $operatorName;
 
@@ -62,7 +62,7 @@ abstract class FilterChain extends Filter
     public function removeId($id)
     {
         if ($id === $this->getId()) {
-            $this->filters = array();
+            $this->filters = [];
             return $this;
         }
         $remove = null;
@@ -150,7 +150,7 @@ abstract class FilterChain extends Filter
      *
      * @return  array
      */
-    public function listFilteredColumns(array $columns = array())
+    public function listFilteredColumns(array $columns = [])
     {
         foreach ($this->filters as $filter) {
             if ($filter instanceof FilterExpression) {
@@ -168,7 +168,7 @@ abstract class FilterChain extends Filter
 
     public function toQueryString()
     {
-        $parts = array();
+        $parts = [];
         if (empty($this->filters)) {
             return '';
         }
@@ -198,7 +198,7 @@ abstract class FilterChain extends Filter
         if (empty($this->filters)) {
             return '';
         }
-        $parts = array();
+        $parts = [];
         foreach ($this->filters as $filter) {
             if ($filter instanceof FilterChain) {
                 $parts[] = '(' . $filter . ')';
@@ -210,7 +210,7 @@ abstract class FilterChain extends Filter
         return implode($op, $parts);
     }
 
-    public function __construct($filters = array())
+    public function __construct($filters = [])
     {
         foreach ($filters as $filter) {
             $this->addFilter($filter);

--- a/library/Icinga/Data/Filter/FilterExpression.php
+++ b/library/Icinga/Data/Filter/FilterExpression.php
@@ -104,7 +104,7 @@ class FilterExpression extends Filter
 
     public function listFilteredColumns()
     {
-        return array($this->getColumn());
+        return [$this->getColumn()];
     }
 
     public function __toString()
@@ -161,7 +161,7 @@ class FilterExpression extends Filter
             return strtolower($var);
         }
         if (is_array($var)) {
-            return array_map(array($this, 'strtolowerRecursive'), $var);
+            return array_map([$this, 'strtolowerRecursive'], $var);
         }
         return $var;
     }
@@ -195,7 +195,7 @@ class FilterExpression extends Filter
             return (string) $rowValue === $expression;
         }
 
-        $parts = array();
+        $parts = [];
         foreach (preg_split('~\*~', $expression) as $part) {
             $parts[] = preg_quote($part, '/');
         }

--- a/library/Icinga/Data/Filter/FilterNot.php
+++ b/library/Icinga/Data/Filter/FilterNot.php
@@ -35,7 +35,7 @@ class FilterNot extends FilterChain
 
     public function toQueryString()
     {
-        $parts = array();
+        $parts = [];
         if (empty($this->filters)) {
             return '';
         }

--- a/library/Icinga/Data/Filter/FilterQueryString.php
+++ b/library/Icinga/Data/Filter/FilterQueryString.php
@@ -11,7 +11,7 @@ class FilterQueryString
 
     protected $pos;
 
-    protected $debug = array();
+    protected $debug = [];
 
     protected $reportDebug = false;
 
@@ -61,7 +61,7 @@ class FilterQueryString
                 $this->parseError(null, 'Expected ")"');
             }
         } else {
-            $var = rawurldecode($this->readUnless(array(')', '&', '|', '>', '<')));
+            $var = rawurldecode($this->readUnless([')', '&', '|', '>', '<']));
         }
         return $var;
     }
@@ -72,7 +72,7 @@ class FilterQueryString
             return false;
         }
 
-        foreach (array('<', '>') as $sign) {
+        foreach (['<', '>'] as $sign) {
             if (false !== ($pos = strpos($key, $sign))) {
                 if ($this->nextChar() === '=') {
                     break;
@@ -87,7 +87,7 @@ class FilterQueryString
                 return Filter::expression($key, $sign, $var);
             }
         }
-        if (in_array($this->nextChar(), array('=', '>', '<', '!'))) {
+        if (in_array($this->nextChar(), ['=', '>', '<', '!'])) {
             $sign = $this->readChar();
         } else {
             $sign = false;
@@ -145,7 +145,7 @@ class FilterQueryString
 
     protected function readFilters($nestingLevel = 0, $op = null)
     {
-        $filters = array();
+        $filters = [];
         while ($this->pos < $this->length) {
             if ($op === '!' && count($filters) === 1) {
                 break;
@@ -159,7 +159,7 @@ class FilterQueryString
                 if ($next === '!') {
                     $not = $this->readFilters($nestingLevel + 1, '!');
                     $filters[] = $not;
-                    if (in_array($this->nextChar(), array('|', '&', ')'))) {
+                    if (in_array($this->nextChar(), ['|', '&', ')'])) {
                         $next = $this->readChar();
                         $this->debug('Got NOT, next is now: ' . $next, $nestingLevel, $op);
                     } else {
@@ -220,7 +220,7 @@ class FilterQueryString
                     }
                     $this->parseError($next);
                 }
-                if ($op === null && in_array($next, array('&', '|'))) {
+                if ($op === null && in_array($next, ['&', '|'])) {
                     $this->debug('Setting op to ' . $next, $nestingLevel, $op);
                     $op = $next;
                     continue;
@@ -296,12 +296,12 @@ class FilterQueryString
 
     protected function readUnlessSpecialChar()
     {
-        return $this->readUnless(array('=', '(', ')', '&', '|', '>', '<', '!'));
+        return $this->readUnless(['=', '(', ')', '&', '|', '>', '<', '!']);
     }
 
     protected function readExpressionOperator()
     {
-        return $this->readUnless(array('=', '>', '<', '!'));
+        return $this->readUnless(['=', '>', '<', '!']);
     }
 
     protected function readChar()

--- a/library/Icinga/Data/Inspection.php
+++ b/library/Icinga/Data/Inspection.php
@@ -16,7 +16,7 @@ class Inspection
     /**
      * @var array
      */
-    protected $log = array();
+    protected $log = [];
 
     /**
      * @var string

--- a/library/Icinga/Data/PivotTable.php
+++ b/library/Icinga/Data/PivotTable.php
@@ -38,7 +38,7 @@ class PivotTable implements Sortable
      *
      * @var array
      */
-    protected $order = array();
+    protected $order = [];
 
     /**
      * The filter being applied on the query for the x-axis
@@ -230,7 +230,7 @@ class PivotTable implements Sortable
             $this->xAxisQuery = clone $this->baseQuery;
             $this->xAxisQuery->clearGroupingRules();
             $xAxisHeader = $this->getXAxisHeader();
-            $columns = array($this->xAxisColumn, $xAxisHeader);
+            $columns = [$this->xAxisColumn, $xAxisHeader];
             $this->xAxisQuery->group(array_unique($columns)); // xAxisColumn and header may be the same column
             $this->xAxisQuery->columns($columns);
 
@@ -258,7 +258,7 @@ class PivotTable implements Sortable
             $this->yAxisQuery = clone $this->baseQuery;
             $this->yAxisQuery->clearGroupingRules();
             $yAxisHeader = $this->getYAxisHeader();
-            $columns = array($this->yAxisColumn, $yAxisHeader);
+            $columns = [$this->yAxisColumn, $yAxisHeader];
             $this->yAxisQuery->group(array_unique($columns)); // yAxisColumn and header may be the same column
             $this->yAxisQuery->columns($columns);
 
@@ -363,11 +363,11 @@ class PivotTable implements Sortable
                 $xAxisKeys = array_keys($xAxis);
             }
         }
-        $pivotData = array();
-        $pivotHeader = array(
+        $pivotData = [];
+        $pivotHeader = [
             'cols'  => $xAxis,
             'rows'  => $yAxis
-        );
+        ];
         if (! empty($xAxis) && ! empty($yAxis)) {
             $this->baseQuery
                 ->where($this->xAxisColumn, array_map(
@@ -393,6 +393,6 @@ class PivotTable implements Sortable
                 $pivotData[$row->{$this->yAxisColumn}][$row->{$this->xAxisColumn}] = $row;
             }
         }
-        return array($pivotData, $pivotHeader);
+        return [$pivotData, $pivotHeader];
     }
 }

--- a/library/Icinga/Data/ResourceFactory.php
+++ b/library/Icinga/Data/ResourceFactory.php
@@ -69,7 +69,7 @@ class ResourceFactory implements ConfigAwareFactory
         if ($type === null) {
             return self::$resources;
         }
-        $resources = array();
+        $resources = [];
         foreach (self::$resources as $name => $resource) {
             if ($resource->get('type') === $type) {
                 $resources[$name] = $resource;

--- a/library/Icinga/Data/SimpleQuery.php
+++ b/library/Icinga/Data/SimpleQuery.php
@@ -56,7 +56,7 @@ class SimpleQuery implements QueryInterface, Queryable, Iterator
      *
      * @var array
      */
-    protected $desiredColumns = array();
+    protected $desiredColumns = [];
 
     /**
      * The columns you are interested in
@@ -65,7 +65,7 @@ class SimpleQuery implements QueryInterface, Queryable, Iterator
      *
      * @var array
      */
-    protected $columns = array();
+    protected $columns = [];
 
     /**
      * The columns and their aliases flipped in order to handle aliased sort columns
@@ -81,7 +81,7 @@ class SimpleQuery implements QueryInterface, Queryable, Iterator
      *
      * @var array
      */
-    protected $order = array();
+    protected $order = [];
 
     /**
      * Number of rows to return
@@ -316,7 +316,7 @@ class SimpleQuery implements QueryInterface, Queryable, Iterator
             $direction = (strtoupper(trim($fieldAndDirection[1])) === 'DESC') ?
                 Sortable::SORT_DESC : Sortable::SORT_ASC;
         }
-        return array($field, $direction);
+        return [$field, $direction];
     }
 
     /**
@@ -349,7 +349,7 @@ class SimpleQuery implements QueryInterface, Queryable, Iterator
                     break;
             }
         }
-        $this->order[] = array($field, $direction);
+        $this->order[] = [$field, $direction];
         return $this;
     }
 
@@ -397,7 +397,7 @@ class SimpleQuery implements QueryInterface, Queryable, Iterator
      */
     public function clearOrder()
     {
-        $this->order = array();
+        $this->order = [];
         return $this;
     }
 

--- a/library/Icinga/Data/Tree/SimpleTree.php
+++ b/library/Icinga/Data/Tree/SimpleTree.php
@@ -26,7 +26,7 @@ class SimpleTree implements IteratorAggregate
      *
      * @var array
      */
-    protected $nodes = array();
+    protected $nodes = [];
 
     /**
      * Create a new simple tree

--- a/library/Icinga/Data/Tree/TreeNode.php
+++ b/library/Icinga/Data/Tree/TreeNode.php
@@ -28,7 +28,7 @@ class TreeNode implements Identifiable
      *
      * @var array
      */
-    protected $children = array();
+    protected $children = [];
 
     /**
      * Set the node's ID

--- a/library/Icinga/Date/DateFormatter.php
+++ b/library/Icinga/Date/DateFormatter.php
@@ -84,7 +84,7 @@ class DateFormatter
                 }
             }
         }
-        return array($type, $formatted, $invert);
+        return [$type, $formatted, $invert];
     }
 
     /**

--- a/library/Icinga/Exception/Http/BaseHttpException.php
+++ b/library/Icinga/Exception/Http/BaseHttpException.php
@@ -70,6 +70,6 @@ class BaseHttpException extends IcingaException implements HttpExceptionInterfac
      */
     public function getHeaders()
     {
-        return $this->headers ?: array();
+        return $this->headers ?: [];
     }
 }

--- a/library/Icinga/Exception/IcingaException.php
+++ b/library/Icinga/Exception/IcingaException.php
@@ -79,7 +79,7 @@ class IcingaException extends Exception
      */
     public static function getConfidentialTraceAsString(Throwable $exception)
     {
-        $trace = array();
+        $trace = [];
 
         $index = 0;
         foreach ($exception->getTrace() as $index => $frame) {
@@ -98,7 +98,7 @@ class IcingaException extends Exception
             $trace[] = "{$frame['function']}(";
 
             if (isset($frame['args'])) {
-                $args = array();
+                $args = [];
                 foreach ($frame['args'] as $arg) {
                     $type = gettype($arg);
                     $args[] = $type === 'object' ? 'Object(' . get_class($arg) . ')' : ucfirst($type);

--- a/library/Icinga/File/Csv.php
+++ b/library/Icinga/File/Csv.php
@@ -37,7 +37,7 @@ class Csv
                 $csv .= implode(',', array_keys((array) $row)) . "\r\n";
                 $first = false;
             }
-            $out = array();
+            $out = [];
             foreach ($row as & $val) {
                 $out[] = '"' . ($val == '0' ? '0' : ($val ? str_replace('"', '""', $val) : '')) . '"';
             }

--- a/library/Icinga/File/Ini/Dom/Directive.php
+++ b/library/Icinga/File/Ini/Dom/Directive.php
@@ -122,7 +122,7 @@ class Directive
     {
         $str = '';
         if (! empty($this->commentsPre)) {
-            $comments = array();
+            $comments = [];
             foreach ($this->commentsPre as $comment) {
                 $comments[] = $comment->render();
             }

--- a/library/Icinga/File/Ini/Dom/Document.php
+++ b/library/Icinga/File/Ini/Dom/Document.php
@@ -12,7 +12,7 @@ class Document
      *
      * @var Section[]
      */
-    protected $sections = array();
+    protected $sections = [];
 
     /**
      * The comemnts at file end that belong to no particular section
@@ -105,7 +105,7 @@ class Document
      */
     public function render()
     {
-        $sections = array();
+        $sections = [];
         foreach ($this->sections as $section) {
             $sections []=  $section->render();
         }
@@ -125,7 +125,7 @@ class Document
      */
     public function toArray()
     {
-        $a = array();
+        $a = [];
         foreach ($this->sections as $section) {
             $a[$section->getName()] = $section->toArray();
         }

--- a/library/Icinga/File/Ini/Dom/Section.php
+++ b/library/Icinga/File/Ini/Dom/Section.php
@@ -24,7 +24,7 @@ class Section
      *
      * @var Directive[]
      */
-    protected $directives = array();
+    protected $directives = [];
 
     /**
      * Comments added one line before this section
@@ -183,7 +183,7 @@ class Section
      */
     public function toArray()
     {
-        $a = array();
+        $a = [];
         foreach ($this->directives as $directive) {
             $a[$directive->getKey()] = $directive->getValue();
         }

--- a/library/Icinga/File/Ini/IniParser.php
+++ b/library/Icinga/File/Ini/IniParser.php
@@ -55,7 +55,7 @@ class IniParser
         $doc = new Document();
         $sec = null;
         $dir = null;
-        $coms = array();
+        $coms = [];
         $state = self::LINE_START;
         $escaping = null;
         $token = '';
@@ -101,7 +101,7 @@ class IniParser
                         $sec->setCommentsPre($coms);
                         $doc->addSection($sec);
                         $dir = null;
-                        $coms = array();
+                        $coms = [];
 
                         $state = self::LINE_END;
                         $token = '';
@@ -124,7 +124,7 @@ class IniParser
                             ));
                         }
 
-                        $coms = array();
+                        $coms = [];
                         $state = self::DIRECTIVE_VALUE_START;
                         $token = '';
                     }
@@ -269,7 +269,7 @@ class IniParser
             throw new ConfigurationError('Couldn\'t parse the INI file `%s\'', $path, $e);
         }
 
-        $unescaped = array();
+        $unescaped = [];
         foreach ($configArray as $section => $options) {
             $unescaped[self::unescapeSectionName($section)] = array_map([__CLASS__, 'unescapeOptionValue'], $options);
         }

--- a/library/Icinga/File/Ini/IniWriter.php
+++ b/library/Icinga/File/Ini/IniWriter.php
@@ -56,7 +56,7 @@ class IniWriter
      *
      * @link http://framework.zend.com/apidoc/1.12/files/Config.Writer.html#\Zend_Config_Writer
      */
-    public function __construct(Config $config, $filename, $filemode = 0660, $options = array())
+    public function __construct(Config $config, $filename, $filemode = 0660, $options = [])
     {
         $this->config = $config;
         $this->filename = $filename;
@@ -75,7 +75,7 @@ class IniWriter
             $oldconfig = Config::fromIni($this->filename);
             $content = trim(file_get_contents($this->filename));
         } else {
-            $oldconfig = Config::fromArray(array());
+            $oldconfig = Config::fromArray([]);
             $content = '';
         }
         $doc = IniParser::parseIni($content);

--- a/library/Icinga/Legacy/DashboardConfig.php
+++ b/library/Icinga/Legacy/DashboardConfig.php
@@ -60,7 +60,7 @@ class DashboardConfig extends Config
      */
     public static function listConfigFilesForUser(User $user)
     {
-        $files = array();
+        $files = [];
         $dashboards = static::resolvePath('dashboards');
         if ($handle = @opendir($dashboards)) {
             while (false !== ($entry = readdir($handle))) {

--- a/library/Icinga/Protocol/Dns.php
+++ b/library/Icinga/Protocol/Dns.php
@@ -22,7 +22,7 @@ class Dns
     public static function getSrvRecords($domain, $service, $protocol = 'tcp')
     {
         $records = dns_get_record('_' . $service . '._' . $protocol . '.' . $domain, DNS_SRV);
-        return $records === false ? array() : $records;
+        return $records === false ? [] : $records;
     }
 
     /**

--- a/library/Icinga/Protocol/File/FileIterator.php
+++ b/library/Icinga/Protocol/File/FileIterator.php
@@ -60,7 +60,7 @@ class FileIterator extends EnumeratingFilterIterator
      */
     public function accept(): bool
     {
-        $data = array();
+        $data = [];
         $matched = preg_match(
             $this->fields,
             $this->getInnerIterator()->current(),

--- a/library/Icinga/Protocol/File/FileQuery.php
+++ b/library/Icinga/Protocol/File/FileQuery.php
@@ -29,7 +29,7 @@ class FileQuery extends SimpleQuery
      *
      * @var array
      */
-    private $filters = array();
+    private $filters = [];
 
     /**
      * Nothing to do here

--- a/library/Icinga/Protocol/File/FileReader.php
+++ b/library/Icinga/Protocol/File/FileReader.php
@@ -45,7 +45,7 @@ class FileReader implements Selectable, Countable
      */
     public function __construct(ConfigObject $config)
     {
-        foreach (array('filename', 'fields') as $key) {
+        foreach (['filename', 'fields'] as $key) {
             if (isset($config->{$key})) {
                 $this->{$key} = $config->{$key};
             } else {
@@ -108,7 +108,7 @@ class FileReader implements Selectable, Countable
      */
     public function fetchAll(FileQuery $query)
     {
-        $all = array();
+        $all = [];
         foreach ($this->fetchPairs($query) as $index => $value) {
             $all[$index] = (object) $value;
         }
@@ -129,7 +129,7 @@ class FileReader implements Selectable, Countable
         if ($skip === null) {
             $skip = 0;
         }
-        $lines = array();
+        $lines = [];
         if ($query->sortDesc()) {
             $count = $this->count();
             if ($count <= $skip) {
@@ -180,7 +180,7 @@ class FileReader implements Selectable, Countable
      */
     public function fetchColumn(FileQuery $query)
     {
-        $column = array();
+        $column = [];
         foreach ($this->fetchPairs($query) as $pair) {
             foreach ($pair as $value) {
                 $column[] = $value;

--- a/library/Icinga/Protocol/File/LogFileIterator.php
+++ b/library/Icinga/Protocol/File/LogFileIterator.php
@@ -101,7 +101,7 @@ class LogFileIterator implements Iterator
 
     protected function nextMessage()
     {
-        $message = $this->next === null ? array() : array($this->next);
+        $message = $this->next === null ? [] : [$this->next];
         $this->valid = null;
         while ($this->file->valid()) {
             if (false === ($res = preg_match(
@@ -131,7 +131,7 @@ class LogFileIterator implements Iterator
 
         if ($this->valid) {
             while (! empty($message)) {
-                $matches = array();
+                $matches = [];
                 if (false === ($res = preg_match(
                     $this->fields,
                     implode(PHP_EOL, $message),

--- a/library/Icinga/Protocol/Ldap/Discovery.php
+++ b/library/Icinga/Protocol/Ldap/Discovery.php
@@ -31,11 +31,11 @@ class Discovery
      */
     public function suggestResourceSettings()
     {
-        return array(
+        return [
             'hostname' => $this->connection->getHostname(),
             'port' => $this->connection->getPort(),
             'root_dn' => $this->connection->getCapabilities()->getDefaultNamingContext()
-        );
+        ];
     }
 
     /**
@@ -47,19 +47,19 @@ class Discovery
     public function suggestBackendSettings()
     {
         if ($this->isAd()) {
-            return array(
+            return [
                 'backend' => 'msldap',
                 'base_dn' => $this->connection->getCapabilities()->getDefaultNamingContext(),
                 'user_class' => 'user',
                 'user_name_attribute' => 'sAMAccountName'
-            );
+            ];
         } else {
-            return array(
+            return [
                 'backend' => 'ldap',
                 'base_dn' => $this->connection->getCapabilities()->getDefaultNamingContext(),
                 'user_class' => 'inetOrgPerson',
                 'user_name_attribute' => 'uid'
-            );
+            ];
         }
     }
 
@@ -136,10 +136,10 @@ class Discovery
      */
     public static function discover($host, $port)
     {
-        $conn = new LdapConnection(new ConfigObject(array(
+        $conn = new LdapConnection(new ConfigObject([
             'hostname' => $host,
             'port'     => $port
-        )));
+        ]));
         return new Discovery($conn);
     }
 }

--- a/library/Icinga/Protocol/Ldap/LdapCapabilities.php
+++ b/library/Icinga/Protocol/Ldap/LdapCapabilities.php
@@ -115,9 +115,9 @@ class LdapCapabilities
     protected function setAttributes($attributes)
     {
         $this->attributes = $attributes;
-        $this->oids = array();
+        $this->oids = [];
 
-        $keys = array('supportedControl', 'supportedExtension', 'supportedFeatures', 'supportedCapabilities');
+        $keys = ['supportedControl', 'supportedExtension', 'supportedFeatures', 'supportedCapabilities'];
         foreach ($keys as $key) {
             if (isset($attributes->$key)) {
                 if (is_array($attributes->$key)) {
@@ -251,10 +251,10 @@ class LdapCapabilities
     public function namingContexts()
     {
         if (!isset($this->attributes->namingContexts)) {
-            return array();
+            return [];
         }
         if (!is_array($this->attributes->namingContexts)) {
-            return array($this->attributes->namingContexts);
+            return [$this->attributes->namingContexts];
         }
         return$this->attributes->namingContexts;
     }
@@ -312,7 +312,7 @@ class LdapCapabilities
     {
         $ds = $connection->getConnection();
 
-        $fields = array(
+        $fields = [
             'configurationNamingContext',
             'defaultNamingContext',
             'namingContexts',
@@ -327,7 +327,7 @@ class LdapCapabilities
             'supportedExtension',
             'objectVersion',
             '+'
-        );
+        ];
 
         $result = @ldap_read($ds, '', (string) $connection->select()->from('*', $fields), $fields);
         if (! $result) {
@@ -380,7 +380,7 @@ class LdapCapabilities
             $defaultNamingContext = $this->getDefaultNamingContext();
             if (!($configurationNamingContext === null || $defaultNamingContext === null)) {
                 $ds = $connection->bind()->getConnection();
-                $adFields = array('nETBIOSName');
+                $adFields = ['nETBIOSName'];
                 $partitions = 'CN=Partitions,' . $configurationNamingContext;
 
                 $result = @ldap_list(

--- a/library/Icinga/Protocol/Ldap/LdapCapabilities.php
+++ b/library/Icinga/Protocol/Ldap/LdapCapabilities.php
@@ -321,7 +321,7 @@ class LdapCapabilities
             'supportedSaslMechanisms',
             'dnsHostName',
             'schemaNamingContext',
-            'supportedLDAPVersion', // => array(3, 2)
+            'supportedLDAPVersion', // => [3, 2]
             'supportedCapabilities',
             'supportedControl',
             'supportedExtension',

--- a/library/Icinga/Protocol/Ldap/LdapConnection.php
+++ b/library/Icinga/Protocol/Ldap/LdapConnection.php
@@ -385,9 +385,9 @@ class LdapConnection implements Selectable, Inspectable
         if (($unfoldAttribute = $query->getUnfoldAttribute()) !== null) {
             $desiredColumns = $query->getColumns();
             if (isset($desiredColumns[$unfoldAttribute])) {
-                $fields = array($unfoldAttribute => $desiredColumns[$unfoldAttribute]);
+                $fields = [$unfoldAttribute => $desiredColumns[$unfoldAttribute]];
             } elseif (in_array($unfoldAttribute, $desiredColumns, true)) {
-                $fields = array($unfoldAttribute);
+                $fields = [$unfoldAttribute];
             } else {
                 throw new ProgrammingError(
                     'The attribute used to unfold a query\'s result must be selected'
@@ -399,7 +399,7 @@ class LdapConnection implements Selectable, Inspectable
         }
 
         $ds = $this->getConnection();
-        $results = $this->ldapSearch($query, array('dn'));
+        $results = $this->ldapSearch($query, ['dn']);
 
         if ($results === false) {
             if (ldap_errno($ds) !== self::LDAP_NO_SUCH_OBJECT) {
@@ -472,9 +472,9 @@ class LdapConnection implements Selectable, Inspectable
         }
 
         $alias = key($fields);
-        $results = $this->fetchAll($query, array($alias => current($fields)));
+        $results = $this->fetchAll($query, [$alias => current($fields)]);
         $column = is_int($alias) ? current($fields) : $alias;
-        $values = array();
+        $values = [];
         foreach ($results as $row) {
             if (isset($row->$column)) {
                 $values[] = $row->$column;
@@ -540,7 +540,7 @@ class LdapConnection implements Selectable, Inspectable
             throw new ProgrammingError('You are required to request at least two attributes');
         }
 
-        $columns = $desiredColumnNames = array();
+        $columns = $desiredColumnNames = [];
         foreach ($fields as $alias => $column) {
             if (is_int($alias)) {
                 $columns[] = $column;
@@ -556,7 +556,7 @@ class LdapConnection implements Selectable, Inspectable
         }
 
         $results = $this->fetchAll($query, $columns);
-        $pairs = array();
+        $pairs = [];
         foreach ($results as $row) {
             $colOne = $desiredColumnNames[0];
             $colTwo = $desiredColumnNames[1];
@@ -628,7 +628,7 @@ class LdapConnection implements Selectable, Inspectable
         $ds = $this->getConnection();
         $this->bind();
 
-        $result = ldap_read($ds, $dn, '(objectClass=*)', array('objectClass'));
+        $result = ldap_read($ds, $dn, '(objectClass=*)', ['objectClass']);
         if ($result === false) {
             return false;
         }
@@ -650,7 +650,7 @@ class LdapConnection implements Selectable, Inspectable
         $ds = $this->getConnection();
         $this->bind();
 
-        $result = @ldap_list($ds, $dn, '(objectClass=*)', array('objectClass'));
+        $result = @ldap_list($ds, $dn, '(objectClass=*)', ['objectClass']);
         if ($result === false) {
             if (ldap_errno($ds) === self::LDAP_NO_SUCH_OBJECT) {
                 return false;
@@ -712,7 +712,7 @@ class LdapConnection implements Selectable, Inspectable
      */
     public function fetchDn(LdapQuery $query)
     {
-        $rows = $this->fetchAll($query, array());
+        $rows = $this->fetchAll($query, []);
         if (count($rows) > 1) {
             throw new LdapException('Cannot fetch single DN for %s', $query);
         }
@@ -746,12 +746,12 @@ class LdapConnection implements Selectable, Inspectable
 
         if ($query->hasOrder()) {
             if ($serverSorting) {
-                ldap_set_option($ds, LDAP_OPT_SERVER_CONTROLS, array(
-                    array(
+                ldap_set_option($ds, LDAP_OPT_SERVER_CONTROLS, [
+                    [
                         'oid'   => LdapCapabilities::LDAP_SERVER_SORT_OID,
                         'value' => $this->encodeSortRules($query->getOrder())
-                    )
-                ));
+                    ]
+                ]);
             } elseif (! empty($fields)) {
                 foreach ($query->getOrder() as $rule) {
                     if (! in_array($rule[0], $fields, true)) {
@@ -779,7 +779,7 @@ class LdapConnection implements Selectable, Inspectable
         );
         if ($results === false) {
             if (ldap_errno($ds) === self::LDAP_NO_SUCH_OBJECT) {
-                return array();
+                return [];
             }
 
             throw new LdapException(
@@ -789,11 +789,11 @@ class LdapConnection implements Selectable, Inspectable
                 ldap_error($ds)
             );
         } elseif (ldap_count_entries($ds, $results) === 0) {
-            return array();
+            return [];
         }
 
         $count = 0;
-        $entries = array();
+        $entries = [];
         $entry = ldap_first_entry($ds, $results);
         if ($entry === false) {
             return [];
@@ -837,7 +837,7 @@ class LdapConnection implements Selectable, Inspectable
 
         if (! $serverSorting) {
             if ($query->hasOrder()) {
-                uasort($entries, array($query, 'compare'));
+                uasort($entries, [$query, 'compare']);
             }
 
             if ($limit && $count > $limit) {
@@ -912,7 +912,7 @@ class LdapConnection implements Selectable, Inspectable
 
         $count = 0;
         $cookie = '';
-        $entries = array();
+        $entries = [];
         do {
             if ($legacyControlHandling) {
                 // Do not request the pagination control as a critical extension, as we want the
@@ -952,7 +952,7 @@ class LdapConnection implements Selectable, Inspectable
             } elseif (ldap_count_entries($ds, $results) === 0) {
                 if (in_array(
                     ldap_errno($ds),
-                    array(static::LDAP_SIZELIMIT_EXCEEDED, static::LDAP_ADMINLIMIT_EXCEEDED),
+                    [static::LDAP_SIZELIMIT_EXCEEDED, static::LDAP_ADMINLIMIT_EXCEEDED],
                     true
                 )) {
                     Logger::warning(
@@ -1041,7 +1041,7 @@ class LdapConnection implements Selectable, Inspectable
 
         if (! $serverSorting) {
             if ($query->hasOrder()) {
-                uasort($entries, array($query, 'compare'));
+                uasort($entries, [$query, 'compare']);
             }
 
             if ($limit && $count > $limit) {
@@ -1069,12 +1069,12 @@ class LdapConnection implements Selectable, Inspectable
         // In case the result contains attributes with a differing case than the requested fields, it is
         // necessary to create another array to map attributes case insensitively to their requested counterparts.
         // This does also apply the virtual alias handling. (Since an LDAP server does not handle such)
-        $loweredFieldMap = array();
+        $loweredFieldMap = [];
         foreach ($requestedFields as $alias => $name) {
             $loweredName = strtolower($name);
             if (isset($loweredFieldMap[$loweredName])) {
                 if (! is_array($loweredFieldMap[$loweredName])) {
-                    $loweredFieldMap[$loweredName] = array($loweredFieldMap[$loweredName]);
+                    $loweredFieldMap[$loweredName] = [$loweredFieldMap[$loweredName]];
                 }
 
                 $loweredFieldMap[$loweredName][] = is_string($alias) ? $alias : $name;
@@ -1083,13 +1083,13 @@ class LdapConnection implements Selectable, Inspectable
             }
         }
 
-        $cleanedAttributes = array();
+        $cleanedAttributes = [];
         for ($i = 0; $i < $attributes['count']; $i++) {
             $attribute_name = $attributes[$i];
             if ($attributes[$attribute_name]['count'] === 1) {
                 $attribute_value = $attributes[$attribute_name][0];
             } else {
-                $attribute_value = array();
+                $attribute_value = [];
                 for ($j = 0; $j < $attributes[$attribute_name]['count']; $j++) {
                     $attribute_value[] = $attributes[$attribute_name][$j];
                 }
@@ -1124,10 +1124,10 @@ class LdapConnection implements Selectable, Inspectable
             && isset($cleanedAttributes[$unfoldAttribute])
             && is_array($cleanedAttributes[$unfoldAttribute])
         ) {
-            $siblings = array();
+            $siblings = [];
             foreach ($loweredFieldMap as $loweredName => $requestedNames) {
                 if (is_array($requestedNames) && in_array($unfoldAttribute, $requestedNames, true)) {
-                    $siblings = array_diff($requestedNames, array($unfoldAttribute));
+                    $siblings = array_diff($requestedNames, [$unfoldAttribute]);
                     break;
                 }
             }
@@ -1135,7 +1135,7 @@ class LdapConnection implements Selectable, Inspectable
             $values = $cleanedAttributes[$unfoldAttribute];
             unset($cleanedAttributes[$unfoldAttribute]);
             $baseRow = (object) $cleanedAttributes;
-            $rows = array();
+            $rows = [];
             foreach ($values as $value) {
                 $row = clone $baseRow;
                 $row->{$unfoldAttribute} = $value;
@@ -1434,7 +1434,7 @@ class LdapConnection implements Selectable, Inspectable
         }
 
         /** @var $filter FilterChain */
-        $parts = array();
+        $parts = [];
         foreach ($filter->filters() as $filterPart) {
             $part = $this->renderFilter($filterPart, $level + 1);
             if ($part) {
@@ -1480,7 +1480,7 @@ class LdapConnection implements Selectable, Inspectable
                 $sign = '=';
             }
 
-            $seqParts = array();
+            $seqParts = [];
             foreach ($expression as $expressionValue) {
                 $seqParts[] = sprintf(
                     $format,

--- a/library/Icinga/Protocol/Ldap/LdapQuery.php
+++ b/library/Icinga/Protocol/Ldap/LdapQuery.php
@@ -62,11 +62,11 @@ class LdapQuery extends SimpleQuery
      *
      * @var array
      */
-    public static $scopes = array(
+    public static $scopes = [
         LdapQuery::SCOPE_BASE,
         LdapQuery::SCOPE_ONE,
         LdapQuery::SCOPE_SUB
-    );
+    ];
 
     /**
      * LDAP search scope (default: SCOPE_SUB)
@@ -263,7 +263,7 @@ class LdapQuery extends SimpleQuery
     public function fetchTree()
     {
         $result = $this->fetchAll();
-        $sorted = array();
+        $sorted = [];
         $quotedDn = preg_quote($this->ds->getDn(), '/');
         foreach ($result as $key => & $item) {
             $new_key = LdapUtils::implodeDN(

--- a/library/Icinga/Protocol/Ldap/LdapUtils.php
+++ b/library/Icinga/Protocol/Ldap/LdapUtils.php
@@ -93,7 +93,7 @@ class LdapUtils
     {
         return self::quoteChars(
             $str,
-            array(
+            [
                 ',',
                 '=',
                 '+',
@@ -103,7 +103,7 @@ class LdapUtils
                 '\\',
                 '"',
                 '#'
-            )
+            ]
         );
     }
 
@@ -119,9 +119,9 @@ class LdapUtils
     public static function quoteForSearch($str, $allow_wildcard = false)
     {
         if ($allow_wildcard) {
-            return self::quoteChars($str, array('(', ')', '\\', chr(0)));
+            return self::quoteChars($str, ['(', ')', '\\', chr(0)]);
         }
-        return self::quoteChars($str, array('*', '(', ')', '\\', chr(0)));
+        return self::quoteChars($str, ['*', '(', ')', '\\', chr(0)]);
     }
 
     /**
@@ -136,7 +136,7 @@ class LdapUtils
      */
     protected static function quoteChars($str, $chars)
     {
-        $quotedChars = array();
+        $quotedChars = [];
         foreach ($chars as $k => $v) {
             // Temporarily prefixing with illegal '('
             $quotedChars[$k] = '(' . str_pad(dechex(ord($v)), 2, '0');

--- a/library/Icinga/Protocol/Ldap/Node.php
+++ b/library/Icinga/Protocol/Ldap/Node.php
@@ -45,7 +45,7 @@ class Node extends Root
      * @param array $props
      * @return Node
      */
-    public static function createWithRDN($parent, $rdn, $props = array())
+    public static function createWithRDN($parent, $rdn, $props = [])
     {
         $node = new Node($parent);
         $node->rdn = $rdn;

--- a/library/Icinga/Protocol/Ldap/Root.php
+++ b/library/Icinga/Protocol/Ldap/Root.php
@@ -31,12 +31,12 @@ class Root
     /**
      * @var array
      */
-    protected $children = array();
+    protected $children = [];
 
     /**
      * @var array
      */
-    protected $props = array();
+    protected $props = [];
 
     /**
      * @param LdapConnection $connection
@@ -69,7 +69,7 @@ class Root
      * @param array $props
      * @return Node
      */
-    public function createChildByDN($dn, $props = array())
+    public function createChildByDN($dn, $props = [])
     {
         $dn = $this->stripMyDN($dn);
         $parts = array_reverse(LdapUtils::explodeDN($dn));

--- a/library/Icinga/Repository/DbRepository.php
+++ b/library/Icinga/Repository/DbRepository.php
@@ -187,7 +187,7 @@ abstract class DbRepository extends Repository implements Extensible, Updatable,
      */
     protected function initializeTableAliases()
     {
-        return array();
+        return [];
     }
 
     /**
@@ -213,7 +213,7 @@ abstract class DbRepository extends Repository implements Extensible, Updatable,
      */
     protected function initializeJoinProbabilities()
     {
-        return array();
+        return [];
     }
 
     /**
@@ -352,11 +352,11 @@ abstract class DbRepository extends Repository implements Extensible, Updatable,
         if (! is_array($table)) {
             $tableAliases = $this->getTableAliases();
             if ($virtualTable !== null && isset($tableAliases[$virtualTable])) {
-                return array($tableAliases[$virtualTable] => $table);
+                return [$tableAliases[$virtualTable] => $table];
             }
 
             if (isset($tableAliases[($nonPrefixedTable = $this->removeTablePrefix($table))])) {
-                return array($tableAliases[$nonPrefixedTable] => $table);
+                return [$tableAliases[$nonPrefixedTable] => $table];
             }
         }
 
@@ -398,7 +398,7 @@ abstract class DbRepository extends Repository implements Extensible, Updatable,
      *
      * @return  int             The number of affected rows
      */
-    public function insert($table, array $bind, array $types = array())
+    public function insert($table, array $bind, array $types = [])
     {
         $realTable = $this->clearTableAlias($this->requireTable($table));
 
@@ -424,7 +424,7 @@ abstract class DbRepository extends Repository implements Extensible, Updatable,
      *
      * @return int The number of affected rows
      */
-    public function update($table, array $bind, ?Filter $filter = null, array $types = array())
+    public function update($table, array $bind, ?Filter $filter = null, array $types = [])
     {
         $realTable = $this->clearTableAlias($this->requireTable($table));
 
@@ -482,7 +482,7 @@ abstract class DbRepository extends Repository implements Extensible, Updatable,
      */
     protected function initializeStatementColumns()
     {
-        return array();
+        return [];
     }
 
     /**
@@ -546,10 +546,10 @@ abstract class DbRepository extends Repository implements Extensible, Updatable,
      */
     protected function initializeStatementMaps()
     {
-        $this->statementAliasTableMap = array();
-        $this->statementAliasColumnMap = array();
-        $this->statementColumnTableMap = array();
-        $this->statementColumnAliasMap = array();
+        $this->statementAliasTableMap = [];
+        $this->statementAliasColumnMap = [];
+        $this->statementColumnTableMap = [];
+        $this->statementColumnAliasMap = [];
         foreach ($this->getStatementColumns() as $table => $columns) {
             foreach ($columns as $alias => $column) {
                 $key = is_string($alias) ? $alias : $column;

--- a/library/Icinga/Repository/DbRepository.php
+++ b/library/Icinga/Repository/DbRepository.php
@@ -60,9 +60,9 @@ abstract class DbRepository extends Repository implements Extensible, Updatable,
      * To define a rule use the name of a base table as key and another array of table names as probable join
      * targets ordered by priority. (Ascending: Lower means higher priority)
      * <code>
-     *  array(
-     *      'table_name' => array('target1', 'target2', 'target3')
-     *  )
+     *  [
+     *      'table_name' => ['target1', 'target2', 'target3']
+     *  ]
      * </code>
      *
      * @todo    Support for tree-ish rules
@@ -77,13 +77,13 @@ abstract class DbRepository extends Repository implements Extensible, Updatable,
      * This may be initialized by repositories which are going to make use of table aliases. It allows to provide
      * alias-less column names to be used for a statement. The array needs to be in the following format:
      * <code>
-     *  array(
-     *      'table_name' => array(
+     *  [
+     *      'table_name' => [
      *          'column1',
      *          'alias1' => 'column2',
      *          'alias2' => 'column3'
-     *      )
-     *  )
+     *      ]
+     *  ]
      * </code>
      *
      * @var array

--- a/library/Icinga/Repository/IniRepository.php
+++ b/library/Icinga/Repository/IniRepository.php
@@ -125,7 +125,7 @@ abstract class IniRepository extends Repository implements Extensible, Updatable
      */
     protected function initializeConfigs()
     {
-        return array();
+        return [];
     }
 
     /**
@@ -151,7 +151,7 @@ abstract class IniRepository extends Repository implements Extensible, Updatable
      */
     protected function initializeTriggers()
     {
-        return array();
+        return [];
     }
 
     /**

--- a/library/Icinga/Repository/IniRepository.php
+++ b/library/Icinga/Repository/IniRepository.php
@@ -32,13 +32,13 @@ abstract class IniRepository extends Repository implements Extensible, Updatable
      *
      * This must be initialized by concrete repository implementations, in the following format
      * <code>
-     * array(
-     *   'table_name' => array(
+     * [
+     *   'table_name' => [
      *     'name'      => 'name_of_the_ini_file_without_extension',
      *     'keyColumn' => 'the_name_of_the_column_to_use_as_key_column',
-     *    ['module'    => 'the_name_of_the_module_if_any']
-     *   )
-     * )
+     *    ('module'    => 'the_name_of_the_module_if_any')
+     *   ]
+     * ]
      * </code>
      *
      * @var array

--- a/library/Icinga/Repository/LdapRepository.php
+++ b/library/Icinga/Repository/LdapRepository.php
@@ -29,7 +29,7 @@ abstract class LdapRepository extends Repository
      *
      * @var array
      */
-    protected $normedAttributes = array(
+    protected $normedAttributes = [
         'uid'                   => 'uid',
         'gid'                   => 'gid',
         'user'                  => 'user',
@@ -42,7 +42,7 @@ abstract class LdapRepository extends Repository
         'inetorgperson'         => 'inetOrgPerson',
         'samaccountname'        => 'sAMAccountName',
         'groupofuniquenames'    => 'groupOfUniqueNames'
-    );
+    ];
 
     /**
      * Create a new LDAP repository object

--- a/library/Icinga/Repository/Repository.php
+++ b/library/Icinga/Repository/Repository.php
@@ -224,10 +224,10 @@ abstract class Repository implements Selectable
     public function __construct(?Selectable $ds = null)
     {
         $this->ds = $ds;
-        $this->aliasTableMap = array();
-        $this->aliasColumnMap = array();
-        $this->columnTableMap = array();
-        $this->columnAliasMap = array();
+        $this->aliasTableMap = [];
+        $this->aliasColumnMap = [];
+        $this->columnTableMap = [];
+        $this->columnAliasMap = [];
 
         $this->init();
     }
@@ -332,7 +332,7 @@ abstract class Repository implements Selectable
      */
     protected function initializeVirtualTables()
     {
-        return array();
+        return [];
     }
 
     /**
@@ -358,7 +358,7 @@ abstract class Repository implements Selectable
      */
     protected function initializeQueryColumns()
     {
-        return array();
+        return [];
     }
 
     /**
@@ -405,7 +405,7 @@ abstract class Repository implements Selectable
     protected function initializeBlacklistedQueryColumns()
     {
         // $table is not part of the signature due to PHP strict standards
-        return array();
+        return [];
     }
 
     /**
@@ -454,7 +454,7 @@ abstract class Repository implements Selectable
     protected function initializeFilterColumns()
     {
         // $table is not part of the signature due to PHP strict standards
-        return array();
+        return [];
     }
 
     /**
@@ -501,7 +501,7 @@ abstract class Repository implements Selectable
     protected function initializeSearchColumns()
     {
         // $table is not part of the signature due to PHP strict standards
-        return array();
+        return [];
     }
 
     /**
@@ -550,7 +550,7 @@ abstract class Repository implements Selectable
     protected function initializeSortRules()
     {
         // $table is not part of the signature due to PHP strict standards
-        return array();
+        return [];
     }
 
     /**
@@ -576,7 +576,7 @@ abstract class Repository implements Selectable
      */
     protected function initializeConversionRules()
     {
-        return array();
+        return [];
     }
 
     /**
@@ -1022,7 +1022,7 @@ abstract class Repository implements Selectable
         }
 
         $blacklist = $this->getBlacklistedQueryColumns($table);
-        $columns = array();
+        $columns = [];
         foreach ($queryColumns[$table] as $alias => $column) {
             $name = is_string($alias) ? $alias : $column;
             if (! in_array($name, $blacklist)) {
@@ -1253,7 +1253,7 @@ abstract class Repository implements Selectable
      */
     public function requireStatementColumns($table, array $data)
     {
-        $resolved = array();
+        $resolved = [];
         foreach ($data as $alias => $value) {
             $resolved[$this->requireStatementColumn($table, $alias)] = $this->persistColumn($table, $alias, $value);
         }

--- a/library/Icinga/Repository/Repository.php
+++ b/library/Icinga/Repository/Repository.php
@@ -72,13 +72,13 @@ abstract class Repository implements Selectable
      *
      * This must be initialized by concrete repository implementations, in the following format
      * <code>
-     *  array(
-     *      'baseTable' => array(
+     *  [
+     *      'baseTable' => [
      *          'column1',
      *          'alias1' => 'column2',
      *          'alias2' => 'column3'
-     *      )
-     *  )
+     *      ]
+     *  ]
      * </code>
      *
      * @var array
@@ -106,10 +106,10 @@ abstract class Repository implements Selectable
      *
      * This may be intialized by concrete repository implementations, in the following format
      * <code>
-     *  array(
+     *  [
      *      'alias_or_column_name',
      *      'label_to_show_in_the_filter_editor' => 'alias_or_column_name'
-     *  )
+     *  ]
      * </code>
      *
      * @var array
@@ -142,22 +142,22 @@ abstract class Repository implements Selectable
      *
      * This may be initialized by concrete repository implementations, in the following format
      * <code>
-     *  array(
-     *      'alias_or_column_name' => array(
+     *  [
+     *      'alias_or_column_name' => [
      *          'order'     => 'asc'
-     *      ),
-     *      'alias_or_column_name' => array(
-     *          'columns'   => array(
+     *      ],
+     *      'alias_or_column_name' => [
+     *          'columns'   => [
      *              'once_more_the_alias_or_column_name_as_in_the_parent_key',
      *              'an_additional_alias_or_column_name_with_a_specific_direction asc'
-     *          ),
+     *          ],
      *          'order'     => 'desc'
-     *      ),
-     *      'alias_or_column_name' => array(
-     *          'columns'   => array('a_different_alias_or_column_name_designated_to_act_as_the_only_sort_column')
+     *      ],
+     *      'alias_or_column_name' => [
+     *          'columns'   => ['a_different_alias_or_column_name_designated_to_act_as_the_only_sort_column']
      *          // Ascendant sort by default
-     *      )
-     *  )
+     *      ]
+     *  ]
      * </code>
      * Note that it's mandatory to supply the alias name in case there is one.
      *

--- a/library/Icinga/Repository/RepositoryQuery.php
+++ b/library/Icinga/Repository/RepositoryQuery.php
@@ -155,11 +155,11 @@ class RepositoryQuery implements QueryInterface, SortRules, FilterColumns, Itera
      */
     protected function prepareQueryColumns($target, ?array $desiredColumns = null)
     {
-        $this->customAliases = array();
+        $this->customAliases = [];
         if (empty($desiredColumns)) {
             $columns = $this->repository->requireAllQueryColumns($target);
         } else {
-            $columns = array();
+            $columns = [];
             foreach ($desiredColumns as $customAlias => $columnAlias) {
                 $resolvedColumn = $this->repository->requireQueryColumn($target, $columnAlias, $this);
                 if ($resolvedColumn !== $columnAlias) {
@@ -323,7 +323,7 @@ class RepositoryQuery implements QueryInterface, SortRules, FilterColumns, Itera
 
             $sortColumns = reset($sortRules);
             if (! array_key_exists('columns', $sortColumns)) {
-                $sortColumns['columns'] = array(key($sortRules));
+                $sortColumns['columns'] = [key($sortRules)];
             }
             if ($direction !== null || !array_key_exists('order', $sortColumns)) {
                 $sortColumns['order'] = $direction ?: static::SORT_ASC;
@@ -333,16 +333,16 @@ class RepositoryQuery implements QueryInterface, SortRules, FilterColumns, Itera
             if (! $ignoreDefault && array_key_exists($alias, $sortRules)) {
                 $sortColumns = $sortRules[$alias];
                 if (! array_key_exists('columns', $sortColumns)) {
-                    $sortColumns['columns'] = array($alias);
+                    $sortColumns['columns'] = [$alias];
                 }
                 if ($direction !== null || !array_key_exists('order', $sortColumns)) {
                     $sortColumns['order'] = $direction ?: static::SORT_ASC;
                 }
             } else {
-                $sortColumns = array(
-                    'columns'   => array($alias),
+                $sortColumns = [
+                    'columns'   => [$alias],
                     'order'     => $direction
-                );
+                ];
             }
         }
 
@@ -398,7 +398,7 @@ class RepositoryQuery implements QueryInterface, SortRules, FilterColumns, Itera
                 : static::SORT_ASC;
         }
 
-        return array($column, $direction);
+        return [$column, $direction];
     }
 
     /**
@@ -613,7 +613,7 @@ class RepositoryQuery implements QueryInterface, SortRules, FilterColumns, Itera
             if ($this->repository->providesValueConversion($this->target, $colOne)
                 || $this->repository->providesValueConversion($this->target, $colTwo)
             ) {
-                $newResults = array();
+                $newResults = [];
                 foreach ($results as $colOneValue => $colTwoValue) {
                     $colOneValue = $this->repository->retrieveColumn($this->target, $colOne, $colOneValue, $this);
                     $newResults[$colOneValue] = $this->repository->retrieveColumn(
@@ -661,7 +661,7 @@ class RepositoryQuery implements QueryInterface, SortRules, FilterColumns, Itera
                     );
                 }
 
-                foreach (($this->getOrder() ?: array()) as $rule) {
+                foreach (($this->getOrder() ?: []) as $rule) {
                     $nativeAlias = $this->getNativeAlias($rule[0]);
                     if (! array_key_exists($rule[0], $flippedColumns) && property_exists($row, $rule[0])) {
                         if ($this->repository->providesValueConversion($this->target, $nativeAlias)) {
@@ -682,7 +682,7 @@ class RepositoryQuery implements QueryInterface, SortRules, FilterColumns, Itera
             }
 
             if ($updateOrder) {
-                uasort($results, array($this->query, 'compare'));
+                uasort($results, [$this->query, 'compare']);
             }
         }
 

--- a/library/Icinga/Test/BaseTestCase.php
+++ b/library/Icinga/Test/BaseTestCase.php
@@ -78,8 +78,8 @@ namespace Icinga\Test {
          *
          * @var array
          */
-        protected static $dbConfiguration = array(
-            'mysql' => array(
+        protected static $dbConfiguration = [
+            'mysql' => [
                 'type'      => 'db',
                 'db'        => 'mysql',
                 'host'      => '127.0.0.1',
@@ -87,8 +87,8 @@ namespace Icinga\Test {
                 'dbname'    => 'icinga_unittest',
                 'username'  => 'icinga_unittest',
                 'password'  => 'icinga_unittest'
-            ),
-            'pgsql' => array(
+            ],
+            'pgsql' => [
                 'type'      => 'db',
                 'db'        => 'pgsql',
                 'host'      => '127.0.0.1',
@@ -96,8 +96,8 @@ namespace Icinga\Test {
                 'dbname'    => 'icinga_unittest',
                 'username'  => 'icinga_unittest',
                 'password'  => 'icinga_unittest'
-            ),
-        );
+            ],
+        ];
 
         /** @var Request */
         private $requestMock;
@@ -124,7 +124,7 @@ namespace Icinga\Test {
             $this->requestMock = Mockery::mock('Icinga\Web\Request')->shouldDeferMissing();
             $this->requestMock->shouldReceive('getPathInfo')->andReturn('')->byDefault()
                 ->shouldReceive('getBaseUrl')->andReturn('/')->byDefault()
-                ->shouldReceive('getQuery')->andReturn(array())->byDefault()
+                ->shouldReceive('getQuery')->andReturn([])->byDefault()
                 ->shouldReceive('getParam')->with(Mockery::type('string'), Mockery::type('string'))
                 ->andReturnUsing(function ($name, $default) {
                     return $default;
@@ -203,9 +203,9 @@ namespace Icinga\Test {
                 $conn = $e->getMessage();
             }
 
-            return array(
-                array($conn)
-            );
+            return [
+                [$conn]
+            ];
         }
 
         /**

--- a/library/Icinga/Test/ClassLoader.php
+++ b/library/Icinga/Test/ClassLoader.php
@@ -20,7 +20,7 @@ class ClassLoader
      *
      * @var array
      */
-    private $namespaces = array();
+    private $namespaces = [];
 
     /**
      * Register a base directory for a namespace prefix
@@ -94,7 +94,7 @@ class ClassLoader
      */
     public function register()
     {
-        spl_autoload_register(array($this, 'loadClass'));
+        spl_autoload_register([$this, 'loadClass']);
     }
 
     /**
@@ -102,7 +102,7 @@ class ClassLoader
      */
     public function unregister()
     {
-        spl_autoload_unregister(array($this, 'loadClass'));
+        spl_autoload_unregister([$this, 'loadClass']);
     }
 
     /**

--- a/library/Icinga/User.php
+++ b/library/Icinga/User.php
@@ -61,7 +61,7 @@ class User
      *
      * @var array
      */
-    protected $additionalInformation = array();
+    protected $additionalInformation = [];
 
     /**
      * Information if the user is externally authenticated
@@ -73,7 +73,7 @@ class User
      *
      * @var array
      */
-    protected $externalUserInformation = array();
+    protected $externalUserInformation = [];
 
     /**
      * Whether restrictions should not apply to this user
@@ -87,28 +87,28 @@ class User
      *
      * @var array
      */
-    protected $permissions = array();
+    protected $permissions = [];
 
     /**
      * Set of restrictions
      *
      * @var array
      */
-    protected $restrictions = array();
+    protected $restrictions = [];
 
     /**
      * Groups for this user
      *
      * @var array
      */
-    protected $groups = array();
+    protected $groups = [];
 
     /**
      * Roles of this user
      *
      * @var Role[]
      */
-    protected $roles = array();
+    protected $roles = [];
 
     /**
      * Preferences object
@@ -274,7 +274,7 @@ class User
             return $this->restrictions[$name];
         }
 
-        return array();
+        return [];
     }
 
     /**
@@ -535,7 +535,7 @@ class User
      */
     public function setExternalUserInformation($username, $field)
     {
-        $this->externalUserInformation = array($username, $field);
+        $this->externalUserInformation = [$username, $field];
         return $this;
     }
 
@@ -626,7 +626,7 @@ class User
         $config = Config::navigation($type === 'dashboard-pane' ? 'dashlet' : $type, $this->getUsername());
 
         if ($type === 'dashboard-pane') {
-            $panes = array();
+            $panes = [];
             foreach ($config as $dashletName => $dashletConfig) {
                 // TODO: Throw ConfigurationError if pane or url is missing
                 $panes[$dashletConfig->pane][$dashletName] = $dashletConfig->url;
@@ -636,10 +636,10 @@ class User
             foreach ($panes as $paneName => $dashlets) {
                 $navigation->addItem(
                     $paneName,
-                    array(
+                    [
                         'type'      => 'dashboard-pane',
                         'dashlets'  => $dashlets
-                    )
+                    ]
                 );
             }
         } else {

--- a/library/Icinga/User/Preferences.php
+++ b/library/Icinga/User/Preferences.php
@@ -18,7 +18,7 @@ use Countable;
  *
  * $preferences = new Preferences(); // Start with empty preferences
  *
- * $preferences = new Preferences(array('aPreference' => 'value')); // Start with initial preferences
+ * $preferences = new Preferences(['aPreference' => 'value']); // Start with initial preferences
  *
  * $preferences->aNewPreference = 'value'; // Set a preference
  *

--- a/library/Icinga/User/Preferences.php
+++ b/library/Icinga/User/Preferences.php
@@ -34,14 +34,14 @@ class Preferences implements Countable
      *
      * @var array
      */
-    protected $preferences = array();
+    protected $preferences = [];
 
     /**
      * Constructor
      *
      * @param   array   $preferences    Preferences key-value array
      */
-    public function __construct(array $preferences = array())
+    public function __construct(array $preferences = [])
     {
         $this->preferences = $preferences;
     }

--- a/library/Icinga/Util/ASN1.php
+++ b/library/Icinga/Util/ASN1.php
@@ -50,7 +50,7 @@ class ASN1
 \z/x
 EOD;
 
-        $matches = array();
+        $matches = [];
 
         if (preg_match($generalizedTimePattern, $value, $matches)) {
             $dateTimeRaw = $matches['YmdH'];

--- a/library/Icinga/Util/Color.php
+++ b/library/Icinga/Util/Color.php
@@ -29,7 +29,7 @@ class Color
         $r = (float)intval(substr($color, 1, 2), 16);
         $g = (float)intval(substr($color, 3, 2), 16);
         $b = (float)intval(substr($color, 5, 2), 16);
-        return array($r, $g, $b);
+        return [$r, $g, $b];
     }
 
     /**

--- a/library/Icinga/Util/Dimension.php
+++ b/library/Icinga/Util/Dimension.php
@@ -116,7 +116,7 @@ class Dimension
      */
     public static function fromString($string)
     {
-        $matches = array();
+        $matches = [];
         if (!preg_match_all('/^ *([0-9]+)(px|pt|em|\%) */i', $string, $matches)) {
             return new Dimension(0);
         }

--- a/library/Icinga/Util/DirectoryIterator.php
+++ b/library/Icinga/Util/DirectoryIterator.php
@@ -162,7 +162,7 @@ class DirectoryIterator implements RecursiveIterator
 
                     if (is_dir($path)) {
                         if ($this->flags & static::FILES_FIRST === static::FILES_FIRST) {
-                            $this->queue[] = array($path, $file);
+                            $this->queue[] = [$path, $file];
                             $skip = true;
                         }
                         break;
@@ -210,7 +210,7 @@ class DirectoryIterator implements RecursiveIterator
             $this->files = new ArrayIterator($files);
         }
         $this->files->rewind();
-        $this->queue = array();
+        $this->queue = [];
         $this->next();
     }
 }

--- a/library/Icinga/Util/Format.php
+++ b/library/Icinga/Util/Format.php
@@ -13,19 +13,19 @@ class Format
     const STANDARD_SI  = 1;
     protected static $instance;
 
-    protected static $bitPrefix = array(
-        array('bit', 'Kibit', 'Mibit', 'Gibit', 'Tibit', 'Pibit', 'Eibit', 'Zibit', 'Yibit'),
-        array('bit', 'kbit', 'Mbit', 'Gbit', 'Tbit', 'Pbit', 'Ebit', 'Zbit', 'Ybit'),
-    );
-    protected static $bitBase = array(1024, 1000);
+    protected static $bitPrefix = [
+        ['bit', 'Kibit', 'Mibit', 'Gibit', 'Tibit', 'Pibit', 'Eibit', 'Zibit', 'Yibit'],
+        ['bit', 'kbit', 'Mbit', 'Gbit', 'Tbit', 'Pbit', 'Ebit', 'Zbit', 'Ybit'],
+    ];
+    protected static $bitBase = [1024, 1000];
 
-    protected static $bytePrefix = array(
-        array('B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB'),
-        array('B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'),
-    );
-    protected static $byteBase = array(1024, 1000);
+    protected static $bytePrefix = [
+        ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB'],
+        ['B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'],
+    ];
+    protected static $byteBase = [1024, 1000];
 
-    protected static $secondPrefix = array('s', 'ms', 'µs', 'ns', 'ps', 'fs', 'as');
+    protected static $secondPrefix = ['s', 'ms', 'µs', 'ns', 'ps', 'fs', 'as'];
     protected static $secondBase = 1000;
 
     public static function getInstance()

--- a/library/Icinga/Util/GlobFilter.php
+++ b/library/Icinga/Util/GlobFilter.php
@@ -42,10 +42,10 @@ class GlobFilter
      */
     public function __construct($filters)
     {
-        $patterns = array(array(''));
+        $patterns = [['']];
         $lastIndex1 = $lastIndex2 = 0;
 
-        foreach ((is_string($filters) ? array($filters) : $filters) as $rawPatterns) {
+        foreach ((is_string($filters) ? [$filters] : $filters) as $rawPatterns) {
             $escape = false;
 
             foreach (str_split($rawPatterns) as $c) {
@@ -58,7 +58,7 @@ class GlobFilter
                             $escape = true;
                             break;
                         case ',':
-                            $patterns[] = array('');
+                            $patterns[] = [''];
                             ++$lastIndex1;
                             $lastIndex2 = 0;
                             break;
@@ -80,7 +80,7 @@ class GlobFilter
             }
         }
 
-        $this->filters = array();
+        $this->filters = [];
 
         foreach ($patterns as $pattern) {
             foreach ($pattern as $i => $subPattern) {

--- a/library/Icinga/Util/GlobFilter.php
+++ b/library/Icinga/Util/GlobFilter.php
@@ -18,13 +18,13 @@ use stdClass;
  *
  * match this one:
  *
- * array(
- *   'foo' => array(
- *     'bar' => array(
+ * [
+ *   'foo' => [
+ *     'bar' => [
  *       'baz' => 'deadbeef'  // <---
- *     )
- *   )
- * )
+ *     ]
+ *   ]
+ * ]
  */
 class GlobFilter
 {

--- a/library/Icinga/Util/Json.php
+++ b/library/Icinga/Util/Json.php
@@ -109,7 +109,7 @@ class Json
                 return static::sanitizeUtf8String($value);
 
             case 'array':
-                $sanitized = array();
+                $sanitized = [];
 
                 foreach ($value as $key => $val) {
                     if (is_string($key)) {
@@ -122,7 +122,7 @@ class Json
                 return $sanitized;
 
             case 'object':
-                $sanitized = array();
+                $sanitized = [];
 
                 foreach ($value as $key => $val) {
                     if (is_string($key)) {

--- a/library/Icinga/Util/StringHelper.php
+++ b/library/Icinga/Util/StringHelper.php
@@ -149,10 +149,10 @@ class StringHelper
      *
      * <pre>
      *  cartesianProduct(
-     *      array(array('foo', 'bar'), array('mumble', 'grumble', null)),
+     *      [['foo', 'bar'], ['mumble', 'grumble', null]],
      *      '_'
      *  );
-     *     => array('foo_mumble', 'foo_grumble', 'bar_mumble', 'bar_grumble', 'foo', 'bar')
+     *     => ['foo_mumble', 'foo_grumble', 'bar_mumble', 'bar_grumble', 'foo', 'bar']
      * </pre>
      *
      * @param   array   $sets   An array of arrays containing all sets for which the cartesian

--- a/library/Icinga/Util/StringHelper.php
+++ b/library/Icinga/Util/StringHelper.php
@@ -111,10 +111,10 @@ class StringHelper
     public static function findSimilar($string, array $possibilities, $similarity = 0.33)
     {
         if (empty($string)) {
-            return array();
+            return [];
         }
 
-        $matches = array();
+        $matches = [];
         foreach ($possibilities as $possibility) {
             $distance = levenshtein($string, $possibility);
             if ($distance / strlen($string) <= $similarity) {
@@ -168,7 +168,7 @@ class StringHelper
             if (! isset($product)) {
                 $product = $set;
             } else {
-                $newProduct = array();
+                $newProduct = [];
                 foreach ($product as $strA) {
                     foreach ($set as $strB) {
                         if ($strB === null) {

--- a/library/Icinga/Web/Announcement.php
+++ b/library/Icinga/Web/Announcement.php
@@ -42,7 +42,7 @@ class Announcement
      *
      * @param array $properties
      */
-    public function __construct(array $properties = array())
+    public function __construct(array $properties = [])
     {
         foreach ($properties as $key => $value) {
             $method = 'set' . ucfirst($key);

--- a/library/Icinga/Web/Announcement/AnnouncementCookie.php
+++ b/library/Icinga/Web/Announcement/AnnouncementCookie.php
@@ -18,7 +18,7 @@ class AnnouncementCookie extends Cookie
      *
      * @var string[]
      */
-    protected $acknowledged = array();
+    protected $acknowledged = [];
 
     /**
      * ETag of the last known announcements.ini
@@ -131,10 +131,10 @@ class AnnouncementCookie extends Cookie
      */
     public function getValue()
     {
-        return Json::encode(array(
+        return Json::encode([
             'acknowledged'  => $this->getAcknowledged(),
             'etag'          => $this->getEtag(),
             'next'          => $this->getNextActive()
-        ));
+        ]);
     }
 }

--- a/library/Icinga/Web/Announcement/AnnouncementIniRepository.php
+++ b/library/Icinga/Web/Announcement/AnnouncementIniRepository.php
@@ -18,19 +18,19 @@ use Icinga\Web\Announcement;
  */
 class AnnouncementIniRepository extends IniRepository
 {
-    protected $queryColumns = array('announcement' => array('id', 'author', 'message', 'hash', 'start', 'end'));
+    protected $queryColumns = ['announcement' => ['id', 'author', 'message', 'hash', 'start', 'end']];
 
-    protected $triggers = array('announcement');
+    protected $triggers = ['announcement'];
 
-    protected $configs = array('announcement' => array(
+    protected $configs = ['announcement' => [
         'name'      => 'announcements',
         'keyColumn' => 'id'
-    ));
+    ]];
 
-    protected $conversionRules = array('announcement' => array(
+    protected $conversionRules = ['announcement' => [
         'start' => 'timestamp',
         'end'   => 'timestamp'
-    ));
+    ]];
 
     /**
      * Get a DateTime's timestamp
@@ -112,11 +112,11 @@ class AnnouncementIniRepository extends IniRepository
         $now = new DateTime();
 
         $query = $this
-            ->select(array('hash', 'message', 'start'))
-            ->setFilter(new FilterAnd(array(
+            ->select(['hash', 'message', 'start'])
+            ->setFilter(new FilterAnd([
                 Filter::expression('start', '<=', $now),
                 Filter::expression('end', '>=', $now)
-            )))
+            ]))
             ->order('start');
 
         return $query;
@@ -132,10 +132,10 @@ class AnnouncementIniRepository extends IniRepository
         $now = new DateTime();
 
         $query = $this
-            ->select(array('start', 'end'))
-            ->setFilter(Filter::matchAny(array(
+            ->select(['start', 'end'])
+            ->setFilter(Filter::matchAny([
                 Filter::expression('start', '>', $now), Filter::expression('end', '>', $now)
-            )));
+            ]));
 
         $refresh = null;
 

--- a/library/Icinga/Web/Controller.php
+++ b/library/Icinga/Web/Controller.php
@@ -101,11 +101,11 @@ class Controller extends ModuleActionController
      */
     public function renderForm(Form $form, $tab)
     {
-        $this->getTabs()->add(uniqid(), array(
+        $this->getTabs()->add(uniqid(), [
             'active'    => true,
             'label'     => $tab,
             'url'       => Url::fromRequest()
-        ));
+        ]);
         $this->view->form = $form;
         $this->render('simple-form', null, true);
     }
@@ -236,20 +236,20 @@ class Controller extends ModuleActionController
         ?array $searchColumns = null,
         ?array $preserveParams = null
     ) {
-        $defaultPreservedParams = array(
+        $defaultPreservedParams = [
             'limit', // setupPaginationControl()
             'sort', // setupSortControl()
             'dir', // setupSortControl()
             'backend', // Framework
             'showCompact', // Framework
             '_dev' // Framework
-        );
+        ];
 
         $editor = Widget::create('filterEditor');
         /** @var \Icinga\Web\Widget\FilterEditor $editor */
         call_user_func_array(
-            array($editor, 'preserveParams'),
-            array_merge($defaultPreservedParams, $preserveParams ?: array())
+            [$editor, 'preserveParams'],
+            array_merge($defaultPreservedParams, $preserveParams ?: [])
         );
 
         $editor

--- a/library/Icinga/Web/Controller/ActionController.php
+++ b/library/Icinga/Web/Controller/ActionController.php
@@ -135,7 +135,7 @@ class ActionController extends Zend_Controller_Action
     public function __construct(
         Zend_Controller_Request_Abstract $request,
         Zend_Controller_Response_Abstract $response,
-        array $invokeArgs = array()
+        array $invokeArgs = []
     ) {
         /** @var \Icinga\Web\Request $request */
         /** @var \Icinga\Web\Response $response */
@@ -614,7 +614,7 @@ class ActionController extends Zend_Controller_Action
         $deprecatedMethod = '_' . $name;
 
         if (method_exists($this, $deprecatedMethod)) {
-            return call_user_func_array(array($this, $deprecatedMethod), $params);
+            return call_user_func_array([$this, $deprecatedMethod], $params);
         }
 
         parent::__call($name, $params);

--- a/library/Icinga/Web/Controller/AuthBackendController.php
+++ b/library/Icinga/Web/Controller/AuthBackendController.php
@@ -42,7 +42,7 @@ class AuthBackendController extends CompatController
      */
     protected function loadUserBackends($interface = null)
     {
-        $backends = array();
+        $backends = [];
         foreach (Config::app('authentication') as $backendName => $backendConfig) {
             $candidate = UserBackend::create($backendName, $backendConfig);
             if (! $interface || $candidate instanceof $interface) {
@@ -101,7 +101,7 @@ class AuthBackendController extends CompatController
      */
     protected function loadUserGroupBackends($interface = null)
     {
-        $backends = array();
+        $backends = [];
         foreach (Config::app('groups') as $backendName => $backendConfig) {
             $candidate = UserGroupBackend::create($backendName, $backendConfig);
             if (! $interface || $candidate instanceof $interface) {

--- a/library/Icinga/Web/Controller/BasePreferenceController.php
+++ b/library/Icinga/Web/Controller/BasePreferenceController.php
@@ -25,7 +25,7 @@ class BasePreferenceController extends ActionController
      */
     public static function createProvidedTabs()
     {
-        return array();
+        return [];
     }
 
     /**

--- a/library/Icinga/Web/Controller/ControllerTabCollector.php
+++ b/library/Icinga/Web/Controller/ControllerTabCollector.php
@@ -55,7 +55,7 @@ class ControllerTabCollector
     {
         $moduleManager = Icinga::app()->getModuleManager();
         $modules = $moduleManager->listEnabledModules();
-        $tabs = array();
+        $tabs = [];
         foreach ($modules as $module) {
             $tabs += self::createModuleConfigurationTabs($controller, $moduleManager->getModule($module));
         }
@@ -86,14 +86,14 @@ class ControllerTabCollector
         if (is_readable($controllerDir)) {
             require_once(realpath($controllerDir));
             if (! method_exists($controllerName, 'createProvidedTabs')) {
-                return array();
+                return [];
             }
             $tab = $controllerName::createProvidedTabs();
             if (! is_array($tab)) {
-                $tab = array($name => $tab);
+                $tab = [$name => $tab];
             }
             return $tab;
         }
-        return array();
+        return [];
     }
 }

--- a/library/Icinga/Web/Controller/ModuleActionController.php
+++ b/library/Icinga/Web/Controller/ModuleActionController.php
@@ -17,7 +17,7 @@ class ModuleActionController extends ActionController
 {
     protected $config;
 
-    protected $configs = array();
+    protected $configs = [];
 
     protected $module;
 

--- a/library/Icinga/Web/CookieSet.php
+++ b/library/Icinga/Web/CookieSet.php
@@ -19,7 +19,7 @@ class CookieSet implements IteratorAggregate
      *
      * @var Cookie[]
      */
-    protected $cookies = array();
+    protected $cookies = [];
 
     /**
      * Get an iterator for traversing the cookies in this set

--- a/library/Icinga/Web/FileCache.php
+++ b/library/Icinga/Web/FileCache.php
@@ -12,7 +12,7 @@ class FileCache
      *
      * @var array
      */
-    protected static $instances = array();
+    protected static $instances = [];
 
     /**
      * Cache instance base directory
@@ -248,11 +248,11 @@ class FileCache
     public static function etagForFiles($files)
     {
         if (is_string($files)) {
-            $files = array($files);
+            $files = [$files];
         }
 
-        $sizes  = array();
-        $mtimes = array();
+        $sizes  = [];
+        $mtimes = [];
 
         foreach ($files as $file) {
             $file = realpath($file);

--- a/library/Icinga/Web/Form.php
+++ b/library/Icinga/Web/Form.php
@@ -221,14 +221,14 @@ class Form extends Zend_Form
      *
      * @var array
      */
-    public static $defaultElementDecorators = array(
-        array('Label', array('tag'=>'span', 'separator' => '', 'class' => 'control-label')),
-        array(array('labelWrap' => 'HtmlTag'), array('tag' => 'div', 'class' => 'control-label-group')),
-        array('ViewHelper', array('separator' => '')),
-        array('Help', array()),
-        array('Errors', array('separator' => '')),
-        array('HtmlTag', array('tag' => 'div', 'class' => 'control-group'))
-    );
+    public static $defaultElementDecorators = [
+        ['Label', ['tag'=>'span', 'separator' => '', 'class' => 'control-label']],
+        [['labelWrap' => 'HtmlTag'], ['tag' => 'div', 'class' => 'control-label-group']],
+        ['ViewHelper', ['separator' => '']],
+        ['Help', []],
+        ['Errors', ['separator' => '']],
+        ['HtmlTag', ['tag' => 'div', 'class' => 'control-group']]
+    ];
 
     /**
      * (non-PHPDoc)
@@ -238,18 +238,18 @@ class Form extends Zend_Form
     {
         // Zend's plugin loader reverses the order of added prefix paths thus trying our paths first before trying
         // Zend paths
-        $this->addPrefixPaths(array(
-            array(
+        $this->addPrefixPaths([
+            [
                 'prefix'    => 'Icinga\\Web\\Form\\Element\\',
                 'path'      => Icinga::app()->getLibraryDir('Icinga/Web/Form/Element'),
                 'type'      => static::ELEMENT
-            ),
-            array(
+            ],
+            [
                 'prefix'    => 'Icinga\\Web\\Form\\Decorator\\',
                 'path'      => Icinga::app()->getLibraryDir('Icinga/Web/Form/Decorator'),
                 'type'      => static::DECORATOR
-            )
-        ));
+            ]
+        ]);
 
         if (! isset($options['attribs']['class'])) {
             $options['attribs']['class'] = static::DEFAULT_CLASSES;
@@ -359,7 +359,7 @@ class Form extends Zend_Form
     public function setRedirectUrl($url)
     {
         if (is_string($url)) {
-            $url = Url::fromPath($url, array(), $this->getRequest());
+            $url = Url::fromPath($url, [], $this->getRequest());
         } elseif (! $url instanceof Url) {
             throw new ProgrammingError('$url must be a string or instance of Icinga\Web\Url');
         }
@@ -617,7 +617,7 @@ class Form extends Zend_Form
     public function getDescriptions()
     {
         if ($this->descriptions === null) {
-            return array();
+            return [];
         }
 
         return $this->descriptions;
@@ -661,7 +661,7 @@ class Form extends Zend_Form
     public function getNotifications()
     {
         if ($this->notifications === null) {
-            return array();
+            return [];
         }
 
         return $this->notifications;
@@ -704,7 +704,7 @@ class Form extends Zend_Form
     public function getHints()
     {
         if ($this->hints === null) {
-            return array();
+            return [];
         }
 
         return $this->hints;
@@ -772,7 +772,7 @@ class Form extends Zend_Form
      *
      * @return  $this
      */
-    public function create(array $formData = array())
+    public function create(array $formData = [])
     {
         if (! $this->created) {
             $this->createElements($formData);
@@ -850,17 +850,17 @@ class Form extends Zend_Form
             $this->addElement(
                 'submit',
                 'btn_submit',
-                array(
+                [
                     'class'                 => 'btn-primary',
                     'ignore'                => true,
                     'label'                 => $submitLabel,
                     'data-progress-label'   => $this->getProgressLabel(),
-                    'decorators'            => array(
+                    'decorators'            => [
                         'ViewHelper',
-                        array('Spinner', array('separator' => '')),
-                        array('HtmlTag', array('tag' => 'div', 'class' => 'control-group form-controls'))
-                    )
-                )
+                        ['Spinner', ['separator' => '']],
+                        ['HtmlTag', ['tag' => 'div', 'class' => 'control-group form-controls']]
+                    ]
+                ]
             );
         }
 
@@ -879,7 +879,7 @@ class Form extends Zend_Form
     public function addSubForm(Zend_Form $form, $name = null, $order = null)
     {
         if ($form instanceof self) {
-            $form->setDecorators(array('FormElements')); // TODO: Makes it difficult to customise subform decorators..
+            $form->setDecorators(['FormElements']); // TODO: Makes it difficult to customise subform decorators..
             $form->setSubmitLabel('');
             $form->setTokenDisabled();
             $form->setUidDisabled();
@@ -921,30 +921,30 @@ class Form extends Zend_Form
                 if (! isset($options['data-progress-label']) && ($type === 'submit'
                     || ($type === 'button' && isset($options['type']) && $options['type'] === 'submit'))
                 ) {
-                    array_splice($options['decorators'], 1, 0, array(array('Spinner', array('separator' => ''))));
+                    array_splice($options['decorators'], 1, 0, [['Spinner', ['separator' => '']]]);
                 } elseif ($type === 'hidden') {
-                    $options['decorators'] = array('ViewHelper');
+                    $options['decorators'] = ['ViewHelper'];
                 }
             }
         } else {
-            $options = array('decorators' => static::$defaultElementDecorators);
+            $options = ['decorators' => static::$defaultElementDecorators];
             if ($type === 'submit') {
-                array_splice($options['decorators'], 1, 0, array(array('Spinner', array('separator' => ''))));
+                array_splice($options['decorators'], 1, 0, [['Spinner', ['separator' => '']]]);
             } elseif ($type === 'hidden') {
-                $options['decorators'] = array('ViewHelper');
+                $options['decorators'] = ['ViewHelper'];
             }
         }
 
         $el = parent::createElement($type, $name, $options);
-        $el->setTranslator(new ErrorLabeller(array('element' => $el)));
+        $el->setTranslator(new ErrorLabeller(['element' => $el]));
 
-        $el->addPrefixPaths(array(
-            array(
+        $el->addPrefixPaths([
+            [
                 'prefix'    => 'Icinga\\Web\\Form\\Validator\\',
                 'path'      => Icinga::app()->getLibraryDir('Icinga/Web/Form/Validator'),
                 'type'      => $el::VALIDATE
-            )
-        ));
+            ]
+        ]);
 
         if ($this->protectIds) {
             $el->setAttrib('id', $this->getRequest()->protectId($this->getId(false) . '_' . $el->getId()));
@@ -956,12 +956,12 @@ class Form extends Zend_Form
                 $warningText = $this->getView()->escape($this->translate(
                     'This page will be automatically updated upon change of the value'
                 ));
-                $autosubmitDecorator = $this->_getDecorator('Callback', array(
+                $autosubmitDecorator = $this->_getDecorator('Callback', [
                     'placement' => 'PREPEND',
                     'callback'  => function ($content) use ($warningId, $warningText) {
                         return '<span class="sr-only" id="' . $warningId . '">' . $warningText . '</span>';
                     }
-                ));
+                ]);
             } else {
                 $autosubmitDecorator = new Autosubmit();
                 $autosubmitDecorator->setAccessible();
@@ -972,7 +972,7 @@ class Form extends Zend_Form
             $pos = array_search('Zend_Form_Decorator_ViewHelper', array_keys($decorators), true) + 1;
             $el->setDecorators(
                 array_slice($decorators, 0, $pos, true)
-                + array('autosubmit' => $autosubmitDecorator)
+                + ['autosubmit' => $autosubmitDecorator]
                 + array_slice($decorators, $pos, count($decorators) - $pos, true)
             );
 
@@ -997,15 +997,15 @@ class Form extends Zend_Form
 
         if ($el->getAttrib('preserveDefault')) {
             $el->addDecorator(
-                array('preserveDefault' => 'HtmlTag'),
-                array(
+                ['preserveDefault' => 'HtmlTag'],
+                [
                     'tag'   => 'input',
                     'type'  => 'hidden',
                     'name'  => $name . static::DEFAULT_SUFFIX,
                     'value' => $el instanceof DateTimePicker
                         ? $el->getValue()->format($el->getFormat())
                         : $el->getValue()
-                )
+                ]
             );
 
             unset($el->preserveDefault);
@@ -1061,11 +1061,11 @@ class Form extends Zend_Form
             $this->addElement(
                 'hidden',
                 $this->uidElementName,
-                array(
+                [
                     'ignore'        => true,
                     'value'         => $this->getName(),
-                    'decorators'    => array('ViewHelper')
-                )
+                    'decorators'    => ['ViewHelper']
+                ]
             );
         }
 
@@ -1189,7 +1189,7 @@ class Form extends Zend_Form
                             }
                         }
                         $this->getResponse()->json()
-                            ->setSuccessData($message !== null ? array('message' => $message) : null)
+                            ->setSuccessData($message !== null ? ['message' => $message] : null)
                             ->sendResponse();
                     } else {
                         $this->getResponse()->redirectAndExit($this->getRedirectUrl());
@@ -1327,27 +1327,27 @@ class Form extends Zend_Form
         $decorators = $this->getDecorators();
         if (empty($decorators)) {
             if ($this->viewScript) {
-                $this->addDecorator('ViewScript', array(
+                $this->addDecorator('ViewScript', [
                     'viewScript'    => $this->viewScript,
                     'form'          => $this
-                ));
+                ]);
             } else {
-                $this->addDecorator('Description', array('tag' => 'h1'));
+                $this->addDecorator('Description', ['tag' => 'h1']);
                 if ($this->getUseFormAutosubmit()) {
                     $this->getDecorator('Description')->setEscape(false);
                     $this->addDecorator(
                         'HtmlTag',
-                        array(
+                        [
                             'tag'   => 'div',
                             'class' => 'header',
                             'id'    => 'header-' . $this->getId()
-                        )
+                        ]
                     );
                 }
 
                 $this->addDecorator('FormDescriptions')
                     ->addDecorator('FormNotifications')
-                    ->addDecorator('FormErrors', array('onlyCustomFormErrors' => true))
+                    ->addDecorator('FormErrors', ['onlyCustomFormErrors' => true])
                     ->addDecorator('FormElements')
                     ->addDecorator('FormHints')
                     //->addDecorator('HtmlTag', array('tag' => 'dl', 'class' => 'zend_form'))
@@ -1400,7 +1400,7 @@ class Form extends Zend_Form
     {
         $description = parent::getDescription();
         if ($description && $this->getUseFormAutosubmit()) {
-            $autosubmit = $this->_getDecorator('Autosubmit', array('accessible' => true));
+            $autosubmit = $this->_getDecorator('Autosubmit', ['accessible' => true]);
             $autosubmit->setElement($this);
             $description = $autosubmit->render($this->getView()->escape($description));
         }
@@ -1491,7 +1491,7 @@ class Form extends Zend_Form
             return $this->request->{'get' . ($this->request->isPost() ? 'Post' : 'Query')}();
         }
 
-        return array();
+        return [];
     }
 
     /**

--- a/library/Icinga/Web/Form.php
+++ b/library/Icinga/Web/Form.php
@@ -1350,7 +1350,7 @@ class Form extends Zend_Form
                     ->addDecorator('FormErrors', ['onlyCustomFormErrors' => true])
                     ->addDecorator('FormElements')
                     ->addDecorator('FormHints')
-                    //->addDecorator('HtmlTag', array('tag' => 'dl', 'class' => 'zend_form'))
+                    //->addDecorator('HtmlTag', ['tag' => 'dl', 'class' => 'zend_form'])
                     ->addDecorator('Form');
             }
         }

--- a/library/Icinga/Web/Form/Decorator/Autosubmit.php
+++ b/library/Icinga/Web/Form/Decorator/Autosubmit.php
@@ -100,10 +100,10 @@ class Autosubmit extends Zend_Form_Decorator_Abstract
             $warning = $isForm
                 ? t('This page will be automatically updated upon change of any of this form\'s fields')
                 : t('This page will be automatically updated upon change of the value');
-            $content .= $this->getView()->icon('cw', $warning, array(
+            $content .= $this->getView()->icon('cw', $warning, [
                 'aria-hidden'   => $isForm ? 'false' : 'true',
                 'class'         => 'spinner autosubmit-info'
-            ));
+            ]);
             if (! $isForm && $this->getAccessible()) {
                 $content = '<span id="'
                     . $this->getWarningId()

--- a/library/Icinga/Web/Form/Decorator/FormDescriptions.php
+++ b/library/Icinga/Web/Form/Decorator/FormDescriptions.php
@@ -68,7 +68,7 @@ class FormDescriptions extends Zend_Form_Decorator_Abstract
      */
     protected function recurseForm(Form $form)
     {
-        $descriptions = array($form->getDescriptions());
+        $descriptions = [$form->getDescriptions()];
         foreach ($form->getSubForms() as $subForm) {
             $descriptions[] = $this->recurseForm($subForm);
         }

--- a/library/Icinga/Web/Form/Decorator/FormHints.php
+++ b/library/Icinga/Web/Form/Decorator/FormHints.php
@@ -28,14 +28,14 @@ class FormHints extends Zend_Form_Decorator_Abstract
     public function __construct($options = null)
     {
         parent::__construct($options);
-        $this->blacklist = array(
+        $this->blacklist = [
             'Zend_Form_Element_Hidden',
             'Zend_Form_Element_Submit',
             'Zend_Form_Element_Button',
             'Icinga\Web\Form\Element\Note',
             'Icinga\Web\Form\Element\Button',
             'Icinga\Web\Form\Element\CsrfCounterMeasure'
-        );
+        ];
     }
 
     /**
@@ -99,7 +99,7 @@ class FormHints extends Zend_Form_Decorator_Abstract
      */
     protected function recurseForm(Form $form, &$entirelyRequired = null, $elementsPassed = false)
     {
-        $requiredLabels = array();
+        $requiredLabels = [];
         if ($form->getRequiredCue() !== null) {
             $partiallyRequired = $partiallyOptional = false;
             foreach ($form->getElements() as $element) {
@@ -128,7 +128,7 @@ class FormHints extends Zend_Form_Decorator_Abstract
             }
         }
 
-        $hints = array($form->getHints());
+        $hints = [$form->getHints()];
         foreach ($form->getSubForms() as $subForm) {
             $hints[] = $this->recurseForm($subForm, $entirelyRequired, $elementsPassed);
         }

--- a/library/Icinga/Web/Form/Decorator/FormNotifications.php
+++ b/library/Icinga/Web/Form/Decorator/FormNotifications.php
@@ -40,7 +40,7 @@ class FormNotifications extends Zend_Form_Decorator_Abstract
         }
 
         $html = '<ul class="form-notification-list">';
-        foreach (array(Form::NOTIFICATION_ERROR, Form::NOTIFICATION_WARNING, Form::NOTIFICATION_INFO) as $type) {
+        foreach ([Form::NOTIFICATION_ERROR, Form::NOTIFICATION_WARNING, Form::NOTIFICATION_INFO] as $type) {
             if (isset($notifications[$type])) {
                 $html .= '<li><ul class="notification-' . $this->getNotificationTypeName($type) . '">';
                 foreach ($notifications[$type] as $message) {

--- a/library/Icinga/Web/Form/Decorator/Help.php
+++ b/library/Icinga/Web/Form/Decorator/Help.php
@@ -98,10 +98,10 @@ class Help extends Zend_Form_Decorator_Abstract
             $helpContent = $this->getView()->icon(
                 'info-circled',
                 $description . ($description && $requirement ? ' ' : '') . $requirement,
-                array(
+                [
                     'class'         => 'control-info',
                     'aria-hidden'   => $this->accessible ? 'true' : 'false'
-                )
+                ]
             ) . $helpContent;
         }
 

--- a/library/Icinga/Web/Form/Element/Button.php
+++ b/library/Icinga/Web/Form/Element/Button.php
@@ -31,7 +31,7 @@ class Button extends FormElement
     public function __construct($spec, $options = null)
     {
         if (is_string($spec) && ((null !== $options) && is_string($options))) {
-            $options = array('label' => $options);
+            $options = ['label' => $options];
         }
 
         if (!isset($options['ignore'])) {

--- a/library/Icinga/Web/Form/Element/Note.php
+++ b/library/Icinga/Web/Form/Element/Note.php
@@ -33,13 +33,13 @@ class Note extends FormElement
     public function init()
     {
         if (count($this->getDecorators()) === 0) {
-            $this->setDecorators(array(
+            $this->setDecorators([
                 'ViewHelper',
-                array(
+                [
                     'HtmlTag',
-                    array('tag' => 'p')
-                )
-            ));
+                    ['tag' => 'p']
+                ]
+            ]);
         }
     }
 

--- a/library/Icinga/Web/Form/Element/Number.php
+++ b/library/Icinga/Web/Form/Element/Number.php
@@ -49,11 +49,11 @@ class Number extends FormElement
     public function init()
     {
         if ($this->min !== null || $this->max !== null) {
-            $this->addValidator('Between', true, array(
+            $this->addValidator('Between', true, [
                 'min'       => $this->min === null ? -INF : $this->min,
                 'max'       => $this->max === null ? INF : $this->max,
                 'inclusive' => true
-            ));
+            ]);
         }
     }
 

--- a/library/Icinga/Web/Form/ErrorLabeller.php
+++ b/library/Icinga/Web/Form/ErrorLabeller.php
@@ -17,7 +17,7 @@ class ErrorLabeller extends Zend_Translate_Adapter
 {
     protected $messages;
 
-    public function __construct($options = array())
+    public function __construct($options = [])
     {
         if (! isset($options['element'])) {
             throw new BadMethodCallException('Option "element" is missing');
@@ -45,7 +45,7 @@ class ErrorLabeller extends Zend_Translate_Adapter
     {
         $label = $element->getLabel() ?: $element->getName();
 
-        return array(
+        return [
             Zend_Validate_NotEmpty::IS_EMPTY            => sprintf(t('%s is required and must not be empty'), $label),
             Zend_Validate_File_MimeType::FALSE_TYPE     => sprintf(
                 t('%s (%%value%%) has a false MIME type of "%%type%%"'),
@@ -59,10 +59,10 @@ class ErrorLabeller extends Zend_Translate_Adapter
                 t('%s not in the expected format: %%value%%'),
                 $label
             )
-        );
+        ];
     }
 
-    protected function _loadTranslationData($data, $locale, array $options = array())
+    protected function _loadTranslationData($data, $locale, array $options = [])
     {
         // nonsense, required as being abstract otherwise...
     }

--- a/library/Icinga/Web/Form/Validator/DateFormatValidator.php
+++ b/library/Icinga/Web/Form/Validator/DateFormatValidator.php
@@ -21,14 +21,14 @@ class DateFormatValidator extends Zend_Validate_Abstract
      * @see http://www.php.net/manual/en/function.date.php
      */
     private $validChars =
-        array('d', 'D', 'j', 'l', 'N', 'S', 'w', 'z', 'W', 'F', 'm', 'M', 'n', 't', 'L', 'o', 'Y', 'y');
+        ['d', 'D', 'j', 'l', 'N', 'S', 'w', 'z', 'W', 'F', 'm', 'M', 'n', 't', 'L', 'o', 'Y', 'y'];
 
     /**
      * List of sensible time separators
      *
      * @var array
      */
-    private $validSeparators = array(' ', ':', '-', '/', ';', ',', '.');
+    private $validSeparators = [' ', ':', '-', '/', ';', ',', '.'];
 
     /**
      * Error templates
@@ -37,9 +37,9 @@ class DateFormatValidator extends Zend_Validate_Abstract
      *
      * @see Zend_Validate_Abstract::$_messageTemplates
      */
-    protected $_messageTemplates = array(
+    protected $_messageTemplates = [
         'INVALID_CHARACTERS' => 'Invalid date format'
-    );
+    ];
 
     /**
      * Validate the input value

--- a/library/Icinga/Web/Form/Validator/DateTimeValidator.php
+++ b/library/Icinga/Web/Form/Validator/DateTimeValidator.php
@@ -25,10 +25,10 @@ class DateTimeValidator extends Zend_Validate_Abstract
      *
      * @see Zend_Validate_Abstract::$_messageTemplates‚
      */
-    protected $_messageTemplates = array(
+    protected $_messageTemplates = [
         self::INVALID_DATETIME_TYPE     => 'Invalid type given. Instance of DateTime or date/time string expected',
         self::INVALID_DATETIME_FORMAT   => 'Date/time string not in the expected format: %value%'
-    );
+    ];
 
     protected $local;
 

--- a/library/Icinga/Web/Form/Validator/ReadablePathValidator.php
+++ b/library/Icinga/Web/Form/Validator/ReadablePathValidator.php
@@ -25,10 +25,10 @@ class ReadablePathValidator extends Zend_Validate_Abstract
      *
      * @see Zend_Validate_Abstract::$_messageTemplates‚
      */
-    protected $_messageTemplates = array(
+    protected $_messageTemplates = [
         self::NOT_READABLE      => 'Path is not readable',
         self::DOES_NOT_EXIST    => 'Path does not exist'
-    );
+    ];
 
     /**
      * Check whether the given value is a readable filepath

--- a/library/Icinga/Web/Form/Validator/TimeFormatValidator.php
+++ b/library/Icinga/Web/Form/Validator/TimeFormatValidator.php
@@ -19,14 +19,14 @@ class TimeFormatValidator extends Zend_Validate_Abstract
      * @var array
      * @see http://www.php.net/manual/en/function.date.php
      */
-    private $validChars = array('a', 'A', 'B', 'g', 'G', 'h', 'H', 'i', 's', 'u');
+    private $validChars = ['a', 'A', 'B', 'g', 'G', 'h', 'H', 'i', 's', 'u'];
 
     /**
      * List of sensible time separators
      *
      * @var array
      */
-    private $validSeparators = array(' ', ':', '-', '/', ';', ',', '.');
+    private $validSeparators = [' ', ':', '-', '/', ';', ',', '.'];
 
     /**
      * Error templates
@@ -34,9 +34,9 @@ class TimeFormatValidator extends Zend_Validate_Abstract
      * @var array
      * @see Zend_Validate_Abstract::$_messageTemplates
      */
-    protected $_messageTemplates = array(
+    protected $_messageTemplates = [
         'INVALID_CHARACTERS' => 'Invalid time format'
-    );
+    ];
 
     /**
      * Validate the input value

--- a/library/Icinga/Web/Form/Validator/UrlValidator.php
+++ b/library/Icinga/Web/Form/Validator/UrlValidator.php
@@ -17,9 +17,9 @@ class UrlValidator extends Zend_Validate_Abstract
      */
     public function __construct()
     {
-        $this->_messageTemplates = array('HAS_QUOTES' => t(
+        $this->_messageTemplates = ['HAS_QUOTES' => t(
             'The url must not contain raw double quotes. If you really need double quotes, use %22 instead.'
-        ));
+        )];
     }
 
     /**

--- a/library/Icinga/Web/Form/Validator/WritablePathValidator.php
+++ b/library/Icinga/Web/Form/Validator/WritablePathValidator.php
@@ -22,10 +22,10 @@ class WritablePathValidator extends Zend_Validate_Abstract
      *
      * @see Zend_Validate_Abstract::$_messageTemplates‚
      */
-    protected $_messageTemplates = array(
+    protected $_messageTemplates = [
         self::NOT_WRITABLE      => 'Path is not writable',
         self::DOES_NOT_EXIST    => 'Path does not exist'
-    );
+    ];
 
     /**
      * When true, the file or directory must exist

--- a/library/Icinga/Web/Helper/CookieHelper.php
+++ b/library/Icinga/Web/Helper/CookieHelper.php
@@ -66,7 +66,7 @@ class CookieHelper
     {
         setcookie(self::CHECK_COOKIE, '1');
 
-        $requestUri = $this->request->getUrl()->addParams(array('_checkCookie' => 1));
+        $requestUri = $this->request->getUrl()->addParams(['_checkCookie' => 1]);
         $this->request->getResponse()->redirectAndExit($requestUri);
     }
 

--- a/library/Icinga/Web/Helper/HtmlPurifier.php
+++ b/library/Icinga/Web/Helper/HtmlPurifier.php
@@ -27,7 +27,7 @@ class HtmlPurifier
     {
         $purifierConfig = \HTMLPurifier_Config::createDefault();
         $purifierConfig->set('Core.EscapeNonASCIICharacters', true);
-        $purifierConfig->set('Attr.AllowedFrameTargets', array('_blank'));
+        $purifierConfig->set('Attr.AllowedFrameTargets', ['_blank']);
 
         if (($cachePath = FileCache::instance()->directory('htmlpurifier.cache')) !== false) {
             $purifierConfig->set('Cache.SerializerPath', $cachePath);

--- a/library/Icinga/Web/Navigation/DashboardPane.php
+++ b/library/Icinga/Web/Navigation/DashboardPane.php
@@ -44,7 +44,7 @@ class DashboardPane extends NavigationItem
     public function getDashlets($ordered = true)
     {
         if ($this->dashlets === null) {
-            return array();
+            return [];
         }
 
         if ($ordered) {
@@ -61,7 +61,7 @@ class DashboardPane extends NavigationItem
      */
     public function init()
     {
-        $this->setUrl(Url::fromPath('dashboard', array('pane' => $this->getName())));
+        $this->setUrl(Url::fromPath('dashboard', ['pane' => $this->getName()]));
     }
 
     /**

--- a/library/Icinga/Web/Navigation/Navigation.php
+++ b/library/Icinga/Web/Navigation/Navigation.php
@@ -60,7 +60,7 @@ class Navigation implements ArrayAccess, Countable, IteratorAggregate
      *
      * @var NavigationItem[]
      */
-    protected $items = array();
+    protected $items = [];
 
     /**
      * This navigation's layout
@@ -178,7 +178,7 @@ class Navigation implements ArrayAccess, Countable, IteratorAggregate
      *
      * @throws  InvalidArgumentException            In case $name is neither a string nor an instance of NavigationItem
      */
-    public function addItem($name, array $properties = array())
+    public function addItem($name, array $properties = [])
     {
         if (is_string($name)) {
             if (isset($properties['permission'])) {
@@ -316,7 +316,7 @@ class Navigation implements ArrayAccess, Countable, IteratorAggregate
      */
     public function order()
     {
-        uasort($this->items, array($this, 'compareItems'));
+        uasort($this->items, [$this, 'compareItems']);
         foreach ($this->items as $item) {
             if ($item->hasChildren()) {
                 $item->getChildren()->order();
@@ -447,18 +447,18 @@ class Navigation implements ArrayAccess, Countable, IteratorAggregate
      */
     public static function getItemTypeConfiguration()
     {
-        $defaultItemTypes = array(
-            'menu-item' => array(
+        $defaultItemTypes = [
+            'menu-item' => [
                 'label'     => t('Menu Entry'),
                 'config'    => 'menu'
-            )/*, // Disabled, until it is able to fully replace the old implementation
+            ]/*, // Disabled, until it is able to fully replace the old implementation
             'dashlet'   => array(
                 'label'     => 'Dashlet',
                 'config'    => 'dashboard'
             )*/
-        );
+        ];
 
-        $moduleItemTypes = array();
+        $moduleItemTypes = [];
         $moduleManager = Icinga::app()->getModuleManager();
         foreach ($moduleManager->getLoadedModules() as $module) {
             if (Auth::getInstance()->hasPermission($moduleManager::MODULE_PERMISSION_NS . $module->getName())) {
@@ -492,7 +492,7 @@ class Navigation implements ArrayAccess, Countable, IteratorAggregate
             throw new InvalidArgumentException('Argument $config must be an array or a instance of Traversable');
         }
 
-        $flattened = $orphans = $topLevel = array();
+        $flattened = $orphans = $topLevel = [];
         foreach ($config as $sectionName => $sectionConfig) {
             $parentName = $sectionConfig->parent;
             unset($sectionConfig->parent);

--- a/library/Icinga/Web/Navigation/Navigation.php
+++ b/library/Icinga/Web/Navigation/Navigation.php
@@ -452,10 +452,10 @@ class Navigation implements ArrayAccess, Countable, IteratorAggregate
                 'label'     => t('Menu Entry'),
                 'config'    => 'menu'
             ]/*, // Disabled, until it is able to fully replace the old implementation
-            'dashlet'   => array(
+            'dashlet'   => [
                 'label'     => 'Dashlet',
                 'config'    => 'dashboard'
-            )*/
+            ]*/
         ];
 
         $moduleItemTypes = [];

--- a/library/Icinga/Web/Navigation/NavigationItem.php
+++ b/library/Icinga/Web/Navigation/NavigationItem.php
@@ -338,7 +338,7 @@ class NavigationItem implements IteratorAggregate
      */
     public function getAttributes()
     {
-        return $this->attributes ?: array();
+        return $this->attributes ?: [];
     }
 
     /**
@@ -587,7 +587,7 @@ class NavigationItem implements IteratorAggregate
     public function getUrl()
     {
         if ($this->url === null && $this->hasChildren()) {
-            $this->setUrl(Url::fromPath('navigation/dashboard', array('name' => strtolower($this->getName()))));
+            $this->setUrl(Url::fromPath('navigation/dashboard', ['name' => strtolower($this->getName())]));
         }
 
         return $this->url;
@@ -652,7 +652,7 @@ class NavigationItem implements IteratorAggregate
      */
     public function getUrlParameters()
     {
-        return $this->urlParameters ?: array();
+        return $this->urlParameters ?: [];
     }
 
     /**
@@ -778,7 +778,7 @@ class NavigationItem implements IteratorAggregate
             $options = array_splice($name, 1);
             $name = $name[0];
         } else {
-            $options = array();
+            $options = [];
         }
 
         $renderer = null;

--- a/library/Icinga/Web/Navigation/Renderer/NavigationItemRenderer.php
+++ b/library/Icinga/Web/Navigation/Renderer/NavigationItemRenderer.php
@@ -57,7 +57,7 @@ class NavigationItemRenderer
             $this->setOptions($options);
         }
 
-        $this->internalLinkTargets = array('_main', '_self', '_next');
+        $this->internalLinkTargets = ['_main', '_self', '_next'];
         $this->init();
     }
 
@@ -197,7 +197,7 @@ class NavigationItemRenderer
                     'sha256',
                     $url->getAbsoluteUrl() . Session::getSession()->getId()
                 ));
-                $url = Url::fromPath('iframe', array('url' => $url));
+                $url = Url::fromPath('iframe', ['url' => $url]);
             }
 
             $content = sprintf(

--- a/library/Icinga/Web/Navigation/Renderer/NavigationRenderer.php
+++ b/library/Icinga/Web/Navigation/Renderer/NavigationRenderer.php
@@ -86,7 +86,7 @@ class NavigationRenderer implements RecursiveIterator, NavigationRendererInterfa
         $this->skipOuterElement = $skipOuterElement;
         $this->iterator = $navigation->getIterator();
         $this->navigation = $navigation;
-        $this->content = array();
+        $this->content = [];
     }
 
     /**
@@ -217,7 +217,7 @@ class NavigationRenderer implements RecursiveIterator, NavigationRendererInterfa
      */
     public function beginMarkup()
     {
-        $content = array();
+        $content = [];
         $content[] = sprintf(
             '<%s%s role="navigation">',
             $this->getElementTag(),
@@ -241,7 +241,7 @@ class NavigationRenderer implements RecursiveIterator, NavigationRendererInterfa
      */
     public function endMarkup()
     {
-        $content = array();
+        $content = [];
         $content[] = $this->endChildrenMarkup();
         $content[] = '</' . $this->getElementTag() . '>';
         return join("\n", $content);
@@ -256,7 +256,7 @@ class NavigationRenderer implements RecursiveIterator, NavigationRendererInterfa
      */
     public function beginChildrenMarkup($level = 1)
     {
-        $cssClass = array(static::CSS_CLASS_NAV);
+        $cssClass = [static::CSS_CLASS_NAV];
         if ($this->navigation->getLayout() === Navigation::LAYOUT_TABS) {
             $cssClass[] = static::CSS_CLASS_NAV_TABS;
         } elseif ($this->navigation->getLayout() === Navigation::LAYOUT_DROPDOWN) {
@@ -287,7 +287,7 @@ class NavigationRenderer implements RecursiveIterator, NavigationRendererInterfa
      */
     public function beginItemMarkup(NavigationItem $item)
     {
-        $cssClasses = array(static::CSS_CLASS_ITEM);
+        $cssClasses = [static::CSS_CLASS_ITEM];
 
         if ($item->hasChildren() && $item->getChildren()->getLayout() === Navigation::LAYOUT_DROPDOWN) {
             $cssClasses[] = static::CSS_CLASS_DROPDOWN;

--- a/library/Icinga/Web/Navigation/Renderer/RecursiveNavigationRenderer.php
+++ b/library/Icinga/Web/Navigation/Renderer/RecursiveNavigationRenderer.php
@@ -41,7 +41,7 @@ class RecursiveNavigationRenderer extends RecursiveIteratorIterator implements N
      */
     public function __construct(Navigation $navigation)
     {
-        $this->content = array();
+        $this->content = [];
         parent::__construct(
             new NavigationRenderer($navigation, true),
             RecursiveIteratorIterator::SELF_FIRST

--- a/library/Icinga/Web/Navigation/Renderer/SummaryNavigationItemRenderer.php
+++ b/library/Icinga/Web/Navigation/Renderer/SummaryNavigationItemRenderer.php
@@ -22,26 +22,26 @@ class SummaryNavigationItemRenderer extends BadgeNavigationItemRenderer
      *
      * @var array
      */
-    protected static $stateSeverityMap = array(
+    protected static $stateSeverityMap = [
         self::STATE_OK          => 0,
         self::STATE_PENDING     => 1,
         self::STATE_UNKNOWN     => 2,
         self::STATE_WARNING     => 3,
         self::STATE_CRITICAL    => 4,
-    );
+    ];
 
     /**
      * Severity to state map
      *
      * @var array
      */
-    protected static $severityStateMap = array(
+    protected static $severityStateMap = [
         self::STATE_OK,
         self::STATE_PENDING,
         self::STATE_UNKNOWN,
         self::STATE_WARNING,
         self::STATE_CRITICAL
-    );
+    ];
 
     /**
      * {@inheritdoc}
@@ -51,7 +51,7 @@ class SummaryNavigationItemRenderer extends BadgeNavigationItemRenderer
         if ($this->count === null) {
             $countMap = array_fill(0, 5, 0);
             $maxSeverity = 0;
-            $titles = array();
+            $titles = [];
             foreach ($this->getItem()->getChildren() as $child) {
                 $renderer = $child->getRenderer();
                 if ($renderer instanceof BadgeNavigationItemRenderer) {

--- a/library/Icinga/Web/Notification.php
+++ b/library/Icinga/Web/Notification.php
@@ -73,7 +73,7 @@ class Notification
      *
      * @var array
      */
-    protected $messages = array();
+    protected $messages = [];
 
     /**
      * Session
@@ -177,10 +177,10 @@ class Notification
                     break;
             }
         } else {
-            $this->messages[] = (object) array(
+            $this->messages[] = (object) [
                 'type'    => $type,
                 'message' => $message,
-            );
+            ];
         }
     }
 
@@ -192,7 +192,7 @@ class Notification
     public function popMessages()
     {
         $messages = $this->messages;
-        $this->messages = array();
+        $this->messages = [];
         return $messages;
     }
 

--- a/library/Icinga/Web/Paginator/ScrollingStyle/SlidingWithBorder.php
+++ b/library/Icinga/Web/Paginator/ScrollingStyle/SlidingWithBorder.php
@@ -24,7 +24,7 @@ class Icinga_Web_Paginator_ScrollingStyle_SlidingWithBorder implements Zend_Pagi
 
         $pageNumber = $paginator->getCurrentPageNumber();
         $pageCount = count($paginator);
-        $range = array();
+        $range = [];
 
         if ($pageCount < 10) {
             // Show all pages if we have less than 10.
@@ -38,7 +38,7 @@ class Icinga_Web_Paginator_ScrollingStyle_SlidingWithBorder implements Zend_Pagi
         } else {
             // More than 10 pages:
 
-            foreach (array(1, 2) as $i) {
+            foreach ([1, 2] as $i) {
                 $range[$i] = $i;
             }
             if ($pageNumber < 6) {
@@ -68,7 +68,7 @@ class Icinga_Web_Paginator_ScrollingStyle_SlidingWithBorder implements Zend_Pagi
                 $range[] = '...';
             }
 
-            foreach (array($pageCount - 1, $pageCount) as $i) {
+            foreach ([$pageCount - 1, $pageCount] as $i) {
                 $range[$i] = $i;
             }
         }

--- a/library/Icinga/Web/Response.php
+++ b/library/Icinga/Web/Response.php
@@ -181,7 +181,7 @@ class Response extends Zend_Controller_Response_Http
      */
     public function getHeader($name, $lastOnly = false)
     {
-        $result = ($lastOnly ? null : array());
+        $result = ($lastOnly ? null : []);
         $headers = $this->getHeaders();
         foreach ($headers as $header) {
             if ($header['name'] === $name) {
@@ -372,7 +372,7 @@ class Response extends Zend_Controller_Response_Http
 
             $notifications = Notification::getInstance();
             if ($notifications->hasMessages()) {
-                $notificationList = array();
+                $notificationList = [];
                 foreach ($notifications->popMessages() as $m) {
                     $notificationList[] = rawurlencode($m->type . ' ' . $m->message);
                 }

--- a/library/Icinga/Web/Response/JsonResponse.php
+++ b/library/Icinga/Web/Response/JsonResponse.php
@@ -206,9 +206,9 @@ class JsonResponse extends Response
      */
     public function outputBody()
     {
-        $body = array(
+        $body = [
             'status' => $this->status
-        );
+        ];
         switch ($this->status) {
             /** @noinspection PhpMissingBreakStatementInspection */
             case static::STATUS_ERROR:

--- a/library/Icinga/Web/Session/Php72Session.php
+++ b/library/Icinga/Web/Session/Php72Session.php
@@ -30,10 +30,10 @@ class Php72Session extends PhpSession
             true
         );
 
-        session_start(array(
+        session_start([
             'use_cookies'       => true,
             'use_only_cookies'  => true,
             'use_trans_sid'     => false
-        ));
+        ]);
     }
 }

--- a/library/Icinga/Web/Session/PhpSession.php
+++ b/library/Icinga/Web/Session/PhpSession.php
@@ -60,12 +60,12 @@ class PhpSession extends Session
      */
     public function __construct(?array $options = null)
     {
-        $defaultCookieOptions = array(
+        $defaultCookieOptions = [
             'use_trans_sid'     => false,
             'use_cookies'       => true,
             'cookie_httponly'   => true,
             'use_only_cookies'  => true
-        );
+        ];
 
         if (version_compare(PHP_VERSION, '7.1.0') < 0) {
             $defaultCookieOptions['hash_function'] = true;
@@ -191,7 +191,7 @@ class PhpSession extends Session
     public function purge()
     {
         $this->open();
-        $_SESSION = array();
+        $_SESSION = [];
         $this->clear();
         session_destroy();
         $this->clearCookies();

--- a/library/Icinga/Web/Session/Session.php
+++ b/library/Icinga/Web/Session/Session.php
@@ -17,14 +17,14 @@ abstract class Session extends SessionNamespace
      *
      * @var array
      */
-    protected $namespaces = array();
+    protected $namespaces = [];
 
     /**
      * The identifiers of all namespaces removed from this session
      *
      * @var array
      */
-    protected $removedNamespaces = array();
+    protected $removedNamespaces = [];
 
     /**
      * Read all values from the underlying session implementation
@@ -122,7 +122,7 @@ abstract class Session extends SessionNamespace
     public function clear()
     {
         parent::clear();
-        $this->namespaces = array();
-        $this->removedNamespaces = array();
+        $this->namespaces = [];
+        $this->removedNamespaces = [];
     }
 }

--- a/library/Icinga/Web/Session/SessionNamespace.php
+++ b/library/Icinga/Web/Session/SessionNamespace.php
@@ -21,14 +21,14 @@ class SessionNamespace implements IteratorAggregate
      *
      * @var array
      */
-    protected $values = array();
+    protected $values = [];
 
     /**
      * The names of all values removed from this container
      *
      * @var array
      */
-    protected $removed = array();
+    protected $removed = [];
 
     /**
      * Return an iterator for all values in this namespace
@@ -197,7 +197,7 @@ class SessionNamespace implements IteratorAggregate
      */
     public function clear()
     {
-        $this->values = array();
-        $this->removed = array();
+        $this->values = [];
+        $this->removed = [];
     }
 }

--- a/library/Icinga/Web/Url.php
+++ b/library/Icinga/Web/Url.php
@@ -104,7 +104,7 @@ class Url
      *
      * @return  static
      */
-    public static function fromRequest($params = array(), $request = null)
+    public static function fromRequest($params = [], $request = null)
     {
         if ($request === null) {
             $request = static::getRequest();
@@ -160,7 +160,7 @@ class Url
      *
      * @return  static
      */
-    public static function fromPath($url, array $params = array(), $request = null)
+    public static function fromPath($url, array $params = [], $request = null)
     {
         if ($request === null) {
             $request = static::getRequest();

--- a/library/Icinga/Web/UrlParams.php
+++ b/library/Icinga/Web/UrlParams.php
@@ -11,9 +11,9 @@ class UrlParams
 {
     protected $separator = '&';
 
-    protected $params = array();
+    protected $params = [];
 
-    protected $index = array();
+    protected $index = [];
 
     public function isEmpty()
     {
@@ -80,13 +80,13 @@ class UrlParams
      *
      * @return mixed
      */
-    public function getValues($param, $default = array())
+    public function getValues($param, $default = [])
     {
         if (! $this->has($param)) {
             return $default;
         }
 
-        $ret = array();
+        $ret = [];
         foreach ($this->index[$param] as $key) {
             $ret[] = rawurldecode($this->params[$key][1]);
         }
@@ -166,7 +166,7 @@ class UrlParams
 
     public function addEncoded($param, $value = true)
     {
-        $this->params[] = array($param, $this->cleanupValue($value));
+        $this->params[] = [$param, $this->cleanupValue($value)];
         $this->indexLastOne();
         return $this;
     }
@@ -220,8 +220,8 @@ class UrlParams
 
     protected function clearValues()
     {
-        $this->params = array();
-        $this->index = array();
+        $this->params = [];
+        $this->index = [];
     }
 
     public function mergeValues($param, $values = null)
@@ -232,7 +232,7 @@ class UrlParams
             }
         } else {
             if (! is_array($values)) {
-                $values = array($values);
+                $values = [$values];
             }
             foreach ($values as $value) {
                 $this->set($param, $value);
@@ -261,7 +261,7 @@ class UrlParams
      */
     public function unshift($param, $value)
     {
-        array_unshift($this->params, array($this->urlEncode($param), $this->urlEncode($value)));
+        array_unshift($this->params, [$this->urlEncode($param), $this->urlEncode($value)]);
         $this->reIndexAll();
         return $this;
     }
@@ -287,10 +287,10 @@ class UrlParams
             unset($this->params[$remove]);
         }
 
-        $this->params[$this->index[$param][0]] = array(
+        $this->params[$this->index[$param][0]] = [
             $this->urlEncode($param),
             $this->urlEncode($this->cleanupValue($value))
-        );
+        ];
         $this->reIndexAll();
 
         return $this;
@@ -301,7 +301,7 @@ class UrlParams
         $changed = false;
 
         if (! is_array($param)) {
-            $param = array($param);
+            $param = [$param];
         }
 
         foreach ($param as $p) {
@@ -339,14 +339,14 @@ class UrlParams
     protected function addParamToIndex($param, $key)
     {
         if (! $this->has($param)) {
-            $this->index[$param] = array();
+            $this->index[$param] = [];
         }
         $this->index[$param][] = $key;
     }
 
     protected function reIndexAll()
     {
-        $this->index = array();
+        $this->index = [];
         $this->params = array_values($this->params);
         foreach ($this->params as $key => & $param) {
             $this->addParamToIndex($param[0], $key);
@@ -389,7 +389,7 @@ class UrlParams
             return $this->params;
         }
 
-        $params = array();
+        $params = [];
         foreach ($this->params as $param) {
             if ($param[1] === true) {
                 $params[] = $param[0];
@@ -406,7 +406,7 @@ class UrlParams
         if ($separator === null) {
             $separator = $this->separator;
         }
-        $parts = array();
+        $parts = [];
         foreach ($this->params as $p) {
             if ($p[1] === true) {
                 $parts[] = $p[0];

--- a/library/Icinga/Web/View.php
+++ b/library/Icinga/Web/View.php
@@ -33,13 +33,13 @@ use Icinga\Exception\ProgrammingError;
  *  @param  bool            $escape
  * }
  *
- * @method string img($url, $params = null, array $properties = array()) {
+ * @method string img($url, $params = null, array $properties = []) {
  *  @param  Url|string|null $url
  *  @param  string[]|null   $params
  *  @param  string[]        $properties
  * }
  *
- * @method string icon($img, $title = null, array $properties = array()) {
+ * @method string icon($img, $title = null, array $properties = []) {
  *  @param  string      $img
  *  @param  string|null $title
  *  @param  string[]    $properties

--- a/library/Icinga/Web/View.php
+++ b/library/Icinga/Web/View.php
@@ -215,7 +215,7 @@ class View extends Zend_View_Abstract
     /**
      * Registered helper functions
      */
-    private $helperFunctions = array();
+    private $helperFunctions = [];
 
     /**
      * Authentication manager
@@ -230,7 +230,7 @@ class View extends Zend_View_Abstract
      * @param array $config
      * @see Zend_View_Abstract::__construct
      */
-    public function __construct($config = array())
+    public function __construct($config = [])
     {
         $config['helperPath']['Icinga\\Web\\View\\Helper\\'] = Icinga::app()->getLibraryDir('Icinga/Web/View/Helper');
 

--- a/library/Icinga/Web/View/helpers/string.php
+++ b/library/Icinga/Web/View/helpers/string.php
@@ -13,7 +13,7 @@ $this->addHelperFunction('ellipsis', function ($string, $maxLength, $ellipsis = 
 });
 
 $this->addHelperFunction('nl2br', function ($string) {
-    return nl2br(str_replace(array('\r\n', '\r', '\n'), '<br>', $string), false);
+    return nl2br(str_replace(['\r\n', '\r', '\n'], '<br>', $string), false);
 });
 
 $this->addHelperFunction('markdown', function ($content, $containerAttribs = null) {

--- a/library/Icinga/Web/View/helpers/url.php
+++ b/library/Icinga/Web/View/helpers/url.php
@@ -64,7 +64,7 @@ $this->addHelperFunction(
     }
 );
 
-$this->addHelperFunction('img', function ($url, $params = null, array $properties = array()) use ($view) {
+$this->addHelperFunction('img', function ($url, $params = null, array $properties = []) use ($view) {
     if (! array_key_exists('alt', $properties)) {
         $properties['alt'] = '';
     }
@@ -85,7 +85,7 @@ $this->addHelperFunction('img', function ($url, $params = null, array $propertie
     );
 });
 
-$this->addHelperFunction('icon', function ($img, $title = null, array $properties = array()) use ($view) {
+$this->addHelperFunction('icon', function ($img, $title = null, array $properties = []) use ($view) {
     if (strpos($img, '.') !== false) {
         if (array_key_exists('class', $properties)) {
             $properties['class'] .= ' icon';
@@ -130,14 +130,14 @@ $this->addHelperFunction('propertiesToString', function ($properties) use ($view
     if (empty($properties)) {
         return '';
     }
-    $attributes = array();
+    $attributes = [];
 
     foreach ($properties as $key => $val) {
         if ($key === 'style' && is_array($val)) {
             if (empty($val)) {
                 continue;
             }
-            $parts = array();
+            $parts = [];
             foreach ($val as $k => $v) {
                 $parts[] = "$k: $v";
             }

--- a/library/Icinga/Web/Widget.php
+++ b/library/Icinga/Web/Widget.php
@@ -34,7 +34,7 @@ class Widget
      *
      * @return AbstractWidget
      */
-    public static function create($name, $options = array(), $module_name = null)
+    public static function create($name, $options = [], $module_name = null)
     {
         $class = 'Icinga\\Web\\Widget\\' . ucfirst($name);
 

--- a/library/Icinga/Web/Widget/AbstractWidget.php
+++ b/library/Icinga/Web/Widget/AbstractWidget.php
@@ -36,7 +36,7 @@ abstract class AbstractWidget
     protected static $view;
 
     // TODO: Should we kick this?
-    protected $properties = array();
+    protected $properties = [];
 
     /**
      * Getter for widget properties

--- a/library/Icinga/Web/Widget/Announcements.php
+++ b/library/Icinga/Web/Widget/Announcements.php
@@ -30,7 +30,7 @@ class Announcements extends AbstractWidget
             $cookie->setNextActive($repo->findNextActive());
             Icinga::app()->getResponse()->setCookie($cookie);
         }
-        $acked = array();
+        $acked = [];
         foreach ($cookie->getAcknowledged() as $hash) {
             $acked[] = Filter::expression('hash', '!=', $hash);
         }
@@ -41,7 +41,7 @@ class Announcements extends AbstractWidget
             $html = '<ul role="alert">';
             foreach ($announcements as $announcement) {
                 $ackForm = new AcknowledgeAnnouncementForm();
-                $ackForm->populate(array('hash' => $announcement->hash));
+                $ackForm->populate(['hash' => $announcement->hash]);
                 $html .= '<li><div class="message">'
                     . Markdown::text($announcement->message)
                     . '</div>'

--- a/library/Icinga/Web/Widget/Chart/HistoryColorGrid.php
+++ b/library/Icinga/Web/Widget/Chart/HistoryColorGrid.php
@@ -32,7 +32,7 @@ class HistoryColorGrid extends AbstractWidget
 
     private $start = null;
     private $end = null;
-    private $data = array();
+    private $data = [];
     private $color;
     public $opacity = 1.0;
 
@@ -257,10 +257,10 @@ class HistoryColorGrid extends AbstractWidget
      */
     private function createGrid()
     {
-        $weeks   = array(array());
+        $weeks   = [[]];
         $week    = 0;
-        $months  = array();
-        $years   = array();
+        $months  = [];
+        $years   = [];
         $start   = strtotime($this->start);
         $year    = intval(date('Y', $start));
         $month   = intval(date('n', $start));
@@ -280,7 +280,7 @@ class HistoryColorGrid extends AbstractWidget
             $weekday++;
             if ($weekday > 6) {
                 $weekday = 0;
-                $weeks[] = array();
+                $weeks[] = [];
                 // PRESENT => The last day of week determines the month
                 if ($this->weekFlow === self::CAL_GROW_INTO_PRESENT) {
                     $months[$week] = $month;
@@ -309,17 +309,17 @@ class HistoryColorGrid extends AbstractWidget
         $years[$week] = $year;
         $months[$week] = $month;
         if ($this->weekFlow == self::CAL_GROW_INTO_PAST) {
-            return array(
+            return [
                 'weeks'  => array_reverse($weeks),
                 'months' => array_reverse($months),
                 'years'  => array_reverse($years)
-            );
+            ];
         }
-        return array(
+        return [
             'weeks'  => $weeks,
             'months' => $months,
             'years'  => $years
-        );
+        ];
     }
 
     /**

--- a/library/Icinga/Web/Widget/Chart/InlinePie.php
+++ b/library/Icinga/Web/Widget/Chart/InlinePie.php
@@ -31,14 +31,14 @@ class InlinePie extends AbstractWidget
     const NUMBER_FORMAT_BYTES = 'bytes';
     const NUMBER_FORMAT_RATIO = 'ratio';
 
-    public static $colorsHostStates = array(
+    public static $colorsHostStates = [
         '#44bb77', // up
         '#ff99aa', // down
         '#cc77ff', // unreachable
         '#77aaff'  // pending
-    );
+    ];
 
-    public static $colorsHostStatesHandledUnhandled = array(
+    public static $colorsHostStatesHandledUnhandled = [
         '#44bb77', // up
         '#44bb77',
         '#ff99aa', // down
@@ -47,17 +47,17 @@ class InlinePie extends AbstractWidget
         '#aa44ff',
         '#77aaff', // pending
         '#77aaff'
-    );
+    ];
 
-    public static $colorsServiceStates = array(
+    public static $colorsServiceStates = [
         '#44bb77', // Ok
         '#ffaa44', // Warning
         '#ff99aa', // Critical
         '#aa44ff', // Unknown
         '#77aaff'  // Pending
-    );
+    ];
 
-    public static $colorsServiceStatesHandleUnhandled = array(
+    public static $colorsServiceStatesHandleUnhandled = [
         '#44bb77', // Ok
         '#44bb77',
         '#ffaa44', // Warning
@@ -68,7 +68,7 @@ class InlinePie extends AbstractWidget
         '#aa44ff',
         '#77aaff', // Pending
         '#77aaff'
-    );
+    ];
 
     /**
      * The template string used for rendering this widget
@@ -82,7 +82,7 @@ class InlinePie extends AbstractWidget
      *
      * @var array
      */
-    private $colors = array('#049BAF', '#ffaa44', '#ff5566', '#ddccdd');
+    private $colors = ['#049BAF', '#ffaa44', '#ff5566', '#ddccdd'];
 
     /**
      * The title of the chart

--- a/library/Icinga/Web/Widget/Dashboard.php
+++ b/library/Icinga/Web/Widget/Dashboard.php
@@ -33,7 +33,7 @@ class Dashboard extends AbstractWidget
      *
      * @var array
      */
-    private $panes = array();
+    private $panes = [];
 
     /**
      * The @see Icinga\Web\Widget\Tabs object for displaying displayable panes
@@ -75,7 +75,7 @@ class Dashboard extends AbstractWidget
         $navigation = new Navigation();
         $navigation->load('dashboard-pane');
 
-        $panes = array();
+        $panes = [];
         foreach ($navigation as $dashboardPane) {
             /** @var DashboardPane $dashboardPane */
             $pane = new Pane($dashboardPane->getLabel());
@@ -98,7 +98,7 @@ class Dashboard extends AbstractWidget
      */
     public function getConfig()
     {
-        $output = array();
+        $output = [];
         foreach ($this->panes as $pane) {
             if ($pane->isUserWidget()) {
                 $output[$pane->getName()] = $pane->toArray();
@@ -141,8 +141,8 @@ class Dashboard extends AbstractWidget
         if (! count($config)) {
             return false;
         }
-        $panes = array();
-        $dashlets = array();
+        $panes = [];
+        $dashlets = [];
         foreach ($config as $key => $part) {
             if (strpos($key, '.') === false) {
                 $dashboardPane = $dashboardNavigation->getItem($key);
@@ -246,15 +246,15 @@ class Dashboard extends AbstractWidget
                 }
                 $this->tabs->add(
                     $key,
-                    array(
+                    [
                         'title'       => sprintf(
                             t('Show %s', 'dashboard.pane.tooltip'),
                             $pane->getTitle()
                         ),
                         'label'     => $pane->getTitle(),
                         'url'       => clone($url),
-                        'urlParams' => array($this->tabParam => $key)
-                    )
+                        'urlParams' => [$this->tabParam => $key]
+                    ]
                 );
             }
         }
@@ -363,7 +363,7 @@ class Dashboard extends AbstractWidget
      */
     public function getPaneKeyTitleArray()
     {
-        $list = array();
+        $list = [];
         foreach ($this->panes as $name => $pane) {
             $list[$name] = $pane->getTitle();
         }

--- a/library/Icinga/Web/Widget/Dashboard/Dashlet.php
+++ b/library/Icinga/Web/Widget/Dashboard/Dashlet.php
@@ -208,10 +208,10 @@ EOD;
      */
     public function toArray()
     {
-        $array = array(
+        $array = [
             'url'   => $this->getUrl()->getRelativeUrl(),
             'title' => $this->getTitle()
-        );
+        ];
         if ($this->getDisabled() === true) {
             $array['disabled'] = 1;
         }
@@ -230,19 +230,19 @@ EOD;
         $view = $this->view();
 
         if (! $this->url) {
-            $searchTokens = array(
+            $searchTokens = [
                 '{TOOLTIP}',
                 '{TITLE}',
                 '{ERROR_MESSAGE}'
-            );
+            ];
 
-            $replaceTokens = array(
+            $replaceTokens = [
                 sprintf($view->translate('Show %s', 'dashboard.dashlet.tooltip'), $view->escape($this->getTitle())),
                 $view->escape($this->getTitle()),
                 $view->escape(
                     sprintf($view->translate('Cannot create dashboard dashlet "%s" without valid URL'), $this->title)
                 )
-            );
+            ];
 
             return str_replace($searchTokens, $replaceTokens, $this->errorTemplate);
         }
@@ -260,7 +260,7 @@ EOD;
                 . Session::getSession()->getId());
         }
 
-        $searchTokens = array(
+        $searchTokens = [
             '{URL}',
             '{URL_HASH}',
             '{FULL_URL}',
@@ -269,9 +269,9 @@ EOD;
             '{TITLE}',
             '{TITLE_PREFIX}',
             '{PROGRESS_LABEL}'
-        );
+        ];
 
-        $replaceTokens = array(
+        $replaceTokens = [
             $url,
             $urlHash,
             $fullUrl,
@@ -280,7 +280,7 @@ EOD;
             $view->escape($this->getTitle()),
             $view->translate('Dashlet') . ': ',
             $this->getProgressLabe()
-        );
+        ];
 
         return str_replace($searchTokens, $replaceTokens, $this->template);
     }

--- a/library/Icinga/Web/Widget/Dashboard/Pane.php
+++ b/library/Icinga/Web/Widget/Dashboard/Pane.php
@@ -34,7 +34,7 @@ class Pane extends UserWidget
      *
      * @var array
      */
-    private $dashlets = array();
+    private $dashlets = [];
 
     /**
      * Disabled flag of a pane
@@ -169,7 +169,7 @@ class Pane extends UserWidget
     public function removeDashlets(?array $dashlets = null)
     {
         if ($dashlets === null) {
-            $this->dashlets = array();
+            $this->dashlets = [];
         } else {
             foreach ($dashlets as $dashlet) {
                 $this->removeDashlet($dashlet);
@@ -287,9 +287,9 @@ class Pane extends UserWidget
      */
     public function toArray()
     {
-        $pane =  array(
+        $pane =  [
             'title'     => $this->getTitle(),
-        );
+        ];
 
         if ($this->getDisabled() === true) {
             $pane['disabled'] = 1;

--- a/library/Icinga/Web/Widget/FilterEditor.php
+++ b/library/Icinga/Web/Widget/FilterEditor.php
@@ -42,13 +42,13 @@ class FilterEditor extends AbstractWidget
 
     protected $cachedColumnSelect;
 
-    protected $preserveParams = array();
+    protected $preserveParams = [];
 
-    protected $preservedParams = array();
+    protected $preservedParams = [];
 
     protected $preservedUrl;
 
-    protected $ignoreParams = array();
+    protected $ignoreParams = [];
 
     protected $searchColumns;
 
@@ -236,7 +236,7 @@ class FilterEditor extends AbstractWidget
         $this->setUrl($request->getUrl()->without($this->ignoreParams));
         $params = $this->url()->getParams();
 
-        $preserve = array();
+        $preserve = [];
         foreach ($this->preserveParams as $key) {
             if (null !== ($value = $params->shift($key))) {
                 $preserve[$key] = $value;
@@ -275,7 +275,7 @@ class FilterEditor extends AbstractWidget
                     if (! $this->resetSearchColumns($filter)) {
                         $filter = Filter::matchAll();
                     }
-                    $filters = array();
+                    $filters = [];
                     $search = trim($search);
                     foreach ($this->searchColumns as $searchColumn) {
                         $filters[] = Filter::expression($searchColumn, '=', "*$search*");
@@ -420,10 +420,10 @@ class FilterEditor extends AbstractWidget
             '',
             $this->preservedUrl()->with('stripFilter', $filter->getId()),
             null,
-            array(
+            [
                 'icon'  => 'minus',
                 'title' => t('Strip this filter')
-            )
+            ]
         );
     }
 
@@ -433,10 +433,10 @@ class FilterEditor extends AbstractWidget
             '',
             $this->preservedUrl()->without('addFilter'),
             null,
-            array(
+            [
                 'icon'  => 'cancel',
                 'title' => t('Cancel this operation')
-            )
+            ]
         );
     }
 
@@ -467,7 +467,7 @@ class FilterEditor extends AbstractWidget
             return $html;
         }
 
-        $parts = array();
+        $parts = [];
         foreach ($filter->filters() as $f) {
             $parts[] = '<li>' . $this->renderFilter($f, $level + 1) . '</li>';
         }
@@ -538,7 +538,7 @@ class FilterEditor extends AbstractWidget
 
     protected function arrayForSelect($array, $flip = false)
     {
-        $res = array();
+        $res = [];
         foreach ($array as $k => $v) {
             if (is_int($k)) {
                 $res[$v] = ucwords(str_replace('_', ' ', $v));
@@ -563,11 +563,11 @@ class FilterEditor extends AbstractWidget
 
     protected function selectOperator(?Filter $filter = null)
     {
-        $ops = array(
+        $ops = [
             'AND' => 'AND',
             'OR'  => 'OR',
             'NOT' => 'NOT'
-        );
+        ];
 
         return $this->select(
             $this->elementId('operator', $filter),
@@ -579,14 +579,14 @@ class FilterEditor extends AbstractWidget
 
     protected function selectSign(?Filter $filter = null)
     {
-        $signs = array(
+        $signs = [
             '='  => '=',
             '!=' => '!=',
             '>'  => '>',
             '<'  => '<',
             '>=' => '>=',
             '<=' => '<=',
-        );
+        ];
 
         return $this->select(
             $this->elementId('sign', $filter),
@@ -632,9 +632,9 @@ class FilterEditor extends AbstractWidget
     protected function applyChanges($changes)
     {
         $filter = $this->filter;
-        $pairs = array();
+        $pairs = [];
         $addTo = null;
-        $add = array();
+        $add = [];
         foreach ($changes as $k => $v) {
             if (preg_match('/^(column|value|sign|operator)((?:_new)?)_([\d-]+)$/', $k, $m)) {
                 if ($m[2] === '_new') {
@@ -649,7 +649,7 @@ class FilterEditor extends AbstractWidget
             }
         }
 
-        $operators = array();
+        $operators = [];
         foreach ($pairs as $id => $fs) {
             if (array_key_exists('operator', $fs)) {
                 $operators[$id] = $fs['operator'];

--- a/library/Icinga/Web/Widget/Paginator.php
+++ b/library/Icinga/Web/Widget/Paginator.php
@@ -25,7 +25,7 @@ class Paginator extends AbstractWidget
      *
      * @var string|array
      */
-    protected $viewScript = array('mixedPagination.phtml', 'default');
+    protected $viewScript = ['mixedPagination.phtml', 'default'];
 
     /**
      * Set the query to create the paginator widget for
@@ -71,7 +71,7 @@ class Paginator extends AbstractWidget
         $pageCount = (int) ceil($totalItemCount / $itemCountPerPage);
         $currentPage = $this->query->hasOffset() ? ($this->query->getOffset() / $itemCountPerPage) + 1 : 1;
         $pagesInRange = $this->getPages($pageCount, $currentPage);
-        $variables = array(
+        $variables = [
             'totalItemCount'    => $totalItemCount,
             'pageCount'         => $pageCount,
             'itemCountPerPage'  => $itemCountPerPage,
@@ -81,7 +81,7 @@ class Paginator extends AbstractWidget
             'pagesInRange'      => $pagesInRange,
             'firstPageInRange'  => min($pagesInRange),
             'lastPageInRange'   => max($pagesInRange)
-        );
+        ];
 
         if ($currentPage > 1) {
             $variables['previous'] = $currentPage - 1;
@@ -109,7 +109,7 @@ class Paginator extends AbstractWidget
      */
     protected function getPages($pageCount, $currentPage)
     {
-        $range = array();
+        $range = [];
 
         if ($pageCount < 10) {
             // Show all pages if we have less than 10
@@ -122,7 +122,7 @@ class Paginator extends AbstractWidget
             }
         } else {
             // More than 10 pages:
-            foreach (array(1, 2) as $i) {
+            foreach ([1, 2] as $i) {
                 $range[$i] = $i;
             }
 
@@ -155,7 +155,7 @@ class Paginator extends AbstractWidget
                 $range[] = '...';
             }
 
-            foreach (array($pageCount - 1, $pageCount) as $i) {
+            foreach ([$pageCount - 1, $pageCount] as $i) {
                 $range[$i] = $i;
             }
         }

--- a/library/Icinga/Web/Widget/SearchDashboard.php
+++ b/library/Icinga/Web/Widget/SearchDashboard.php
@@ -30,11 +30,11 @@ class SearchDashboard extends Dashboard
             $this->tabs = new Tabs();
             $this->tabs->add(
                 'search',
-                array(
+                [
                     'title' => t('Show Search', 'dashboard.pane.tooltip'),
                     'label' => t('Search'),
                     'url'   => Url::fromRequest()
-                )
+                ]
             );
         }
         return $this->tabs;
@@ -53,7 +53,7 @@ class SearchDashboard extends Dashboard
         $this->activate(self::SEARCH_PANE);
 
         $manager = Icinga::app()->getModuleManager();
-        $searchUrls = array();
+        $searchUrls = [];
 
         foreach ($manager->getLoadedModules() as $module) {
             if ($this->getUser()->can($manager::MODULE_PERMISSION_NS . $module->getName())) {
@@ -68,12 +68,12 @@ class SearchDashboard extends Dashboard
             }
         }
 
-        usort($searchUrls, array($this, 'compareSearchUrls'));
+        usort($searchUrls, [$this, 'compareSearchUrls']);
 
         foreach (array_reverse($searchUrls) as $searchUrl) {
             $pane->createDashlet(
                 $searchUrl->title . ': ' . $searchString,
-                Url::fromPath($searchUrl->url, array('q' => $searchString))
+                Url::fromPath($searchUrl->url, ['q' => $searchString])
             )->setProgressLabel(t('Searching'));
         }
 

--- a/library/Icinga/Web/Widget/SortBox.php
+++ b/library/Icinga/Web/Widget/SortBox.php
@@ -150,7 +150,7 @@ class SortBox extends AbstractWidget
             $column = key($this->sortFields);
         }
 
-        return array($column, $direction);
+        return [$column, $direction];
     }
 
     /**
@@ -193,15 +193,15 @@ class SortBox extends AbstractWidget
         $columnForm->addElement(
             'select',
             'sort',
-            array(
+            [
                 'autosubmit'    => true,
                 'label'         => $this->view()->translate('Sort by'),
                 'multiOptions'  => $this->sortFields,
-                'decorators'    => array(
-                    array('ViewHelper'),
-                    array('Label')
-                )
-            )
+                'decorators'    => [
+                    ['ViewHelper'],
+                    ['Label']
+                ]
+            ]
         );
 
         $column = null;
@@ -226,7 +226,7 @@ class SortBox extends AbstractWidget
         }
 
         // TODO(el): ToggleButton :)
-        $toggle = array('asc' => 'sort-name-down', 'desc' => 'sort-name-up');
+        $toggle = ['asc' => 'sort-name-down', 'desc' => 'sort-name-up'];
         unset($toggle[isset($direction) ? strtolower($direction) : 'asc']);
         $newDirection = key($toggle);
         $icon = current($toggle);
@@ -242,21 +242,21 @@ class SortBox extends AbstractWidget
         $orderForm->addElement(
             'button',
             'btn_submit',
-            array(
+            [
                 'ignore'        => true,
                 'type'          => 'submit',
                 'label'         => $this->view()->icon($icon),
-                'decorators'    => array('ViewHelper'),
+                'decorators'    => ['ViewHelper'],
                 'escape'        => false,
                 'class'         => 'link-button spinner',
                 'value'         => 'submit',
                 'title'         => t('Change sort direction'),
-            )
+            ]
         );
 
 
-        $columnForm->populate(array('sort' => $column));
-        $orderForm->populate(array('dir' => $newDirection));
+        $columnForm->populate(['sort' => $column]);
+        $orderForm->populate(['dir' => $newDirection]);
         return '<div class="sort-control">' . $columnForm . $orderForm . '</div>';
     }
 }

--- a/library/Icinga/Web/Widget/Tab.php
+++ b/library/Icinga/Web/Widget/Tab.php
@@ -63,7 +63,7 @@ class Tab extends AbstractWidget
      *
      * @var array
      */
-    private $urlParams = array();
+    private $urlParams = [];
 
     /**
      * The icon image to use for this tab or null if none
@@ -231,7 +231,7 @@ class Tab extends AbstractWidget
      *
      * @param array $properties     An array of properties
      */
-    public function __construct(array $properties = array())
+    public function __construct(array $properties = [])
     {
         foreach ($properties as $name => $value) {
             $setter = 'set' . ucfirst($name);
@@ -263,7 +263,7 @@ class Tab extends AbstractWidget
     public function render()
     {
         $view = $this->view();
-        $classes = array();
+        $classes = [];
         if ($this->active) {
             $classes[] = 'active';
         }
@@ -281,10 +281,10 @@ class Tab extends AbstractWidget
                 $tagParams['title'] = $this->title;
                 $tagParams['aria-label'] = $this->title;
             } else {
-                $tagParams = array(
+                $tagParams = [
                     'title'         => $this->title,
                     'aria-label'    => $this->title
-                );
+                ];
             }
         }
 
@@ -296,7 +296,7 @@ class Tab extends AbstractWidget
             if (strpos($this->icon, '.') === false) {
                 $caption = $view->icon($this->icon) . $caption;
             } else {
-                $caption = $view->img($this->icon, null, array('class' => 'icon')) . $caption;
+                $caption = $view->img($this->icon, null, ['class' => 'icon']) . $caption;
             }
         }
 

--- a/library/Icinga/Web/Widget/Tabextension/DashboardAction.php
+++ b/library/Icinga/Web/Widget/Tabextension/DashboardAction.php
@@ -24,14 +24,14 @@ class DashboardAction implements Tabextension
     {
         $tabs->addAsDropdown(
             'dashboard',
-            array(
+            [
                 'icon'      => 'dashboard',
                 'label'     => t('Add To Dashboard'),
                 'url'       => Url::fromPath('dashboard/new-dashlet'),
-                'urlParams' => array(
+                'urlParams' => [
                     'url' => rawurlencode(Url::fromRequest()->getRelativeUrl())
-                )
-            )
+                ]
+            ]
         );
     }
 }

--- a/library/Icinga/Web/Widget/Tabextension/DashboardSettings.php
+++ b/library/Icinga/Web/Widget/Tabextension/DashboardSettings.php
@@ -22,20 +22,20 @@ class DashboardSettings implements Tabextension
     {
         $tabs->addAsDropdown(
             'dashboard_add',
-            array(
+            [
                 'icon'      => 'dashboard',
                 'label'     => t('Add Dashlet'),
                 'url'       => Url::fromPath('dashboard/new-dashlet')
-            )
+            ]
         );
 
         $tabs->addAsDropdown(
             'dashboard_settings',
-            array(
+            [
                 'icon'      => 'dashboard',
                 'label'     => t('Settings'),
                 'url'       => Url::fromPath('dashboard/settings')
-            )
+            ]
         );
     }
 }

--- a/library/Icinga/Web/Widget/Tabextension/MenuAction.php
+++ b/library/Icinga/Web/Widget/Tabextension/MenuAction.php
@@ -24,14 +24,14 @@ class MenuAction implements Tabextension
     {
         $tabs->addAsDropdown(
             'menu-entry',
-            array(
+            [
                 'icon'      => 'menu',
                 'label'     => t('Add To Menu'),
                 'url'       => Url::fromPath('navigation/add'),
-                'urlParams' => array(
+                'urlParams' => [
                     'url' => rawurlencode(Url::fromRequest()->getRelativeUrl())
-                )
-            )
+                ]
+            ]
         );
     }
 }

--- a/library/Icinga/Web/Widget/Tabextension/OutputFormat.php
+++ b/library/Icinga/Web/Widget/Tabextension/OutputFormat.php
@@ -36,7 +36,7 @@ class OutputFormat implements Tabextension
      *
      * @var array
      */
-    private $tabs = array();
+    private $tabs = [];
 
     /**
      * Create a new OutputFormat extender
@@ -46,7 +46,7 @@ class OutputFormat implements Tabextension
      *
      * @param array $disabled An array of output types to <b>not</b> show.
      */
-    public function __construct(array $disabled = array())
+    public function __construct(array $disabled = [])
     {
         foreach ($this->getSupportedTypes() as $type => $tabConfig) {
             if (!in_array($type, $disabled)) {
@@ -82,33 +82,33 @@ class OutputFormat implements Tabextension
      */
     public function getSupportedTypes()
     {
-        $supportedTypes = array();
+        $supportedTypes = [];
 
         $pdfexport = Hook::has('Pdfexport');
 
         if ($pdfexport || Platform::extensionLoaded('gd')) {
-            $supportedTypes[self::TYPE_PDF] = array(
+            $supportedTypes[self::TYPE_PDF] = [
                 'name'      => 'pdf',
                 'label'     => 'PDF',
                 'icon'      => 'file-pdf',
-                'urlParams' => array('format' => 'pdf'),
-            );
+                'urlParams' => ['format' => 'pdf'],
+            ];
         }
 
-        $supportedTypes[self::TYPE_CSV] = array(
+        $supportedTypes[self::TYPE_CSV] = [
             'name'      => 'csv',
             'label'     => 'CSV',
             'icon'      => 'file-excel',
-            'urlParams' => array('format' => 'csv')
-        );
+            'urlParams' => ['format' => 'csv']
+        ];
 
         if (Platform::extensionLoaded('json')) {
-            $supportedTypes[self::TYPE_JSON] = array(
+            $supportedTypes[self::TYPE_JSON] = [
                 'name'      => 'json',
                 'label'     => 'JSON',
                 'icon'      => 'doc-text',
-                'urlParams' => array('format' => 'json')
-            );
+                'urlParams' => ['format' => 'json']
+            ];
         }
 
         return $supportedTypes;

--- a/library/Icinga/Web/Widget/Tabs.php
+++ b/library/Icinga/Web/Widget/Tabs.php
@@ -79,7 +79,7 @@ EOT;
      *
      * @var array<string, Tab>
      */
-    private $tabs = array();
+    private $tabs = [];
 
     /**
      * The name of the currently activated tab
@@ -93,7 +93,7 @@ EOT;
      *
      * @var array
      */
-    private $dropdownTabs = array();
+    private $dropdownTabs = [];
 
     /**
      * Whether only the close-button should by rendered for this tab
@@ -244,7 +244,7 @@ EOT;
         if ($tab instanceof Tab) {
             $this->tabs[$name] = $tab;
         } else {
-            $this->tabs[$name] = new Tab($tab + array('name' => $name));
+            $this->tabs[$name] = new Tab($tab + ['name' => $name]);
         }
         return $this;
     }
@@ -299,7 +299,7 @@ EOT;
             }
             $tabs .= $tab;
         }
-        return str_replace(array('{TABS}', '{TITLE}'), array($tabs, t('Dropdown menu')), $this->dropdownTpl);
+        return str_replace(['{TABS}', '{TITLE}'], [$tabs, t('Dropdown menu')], $this->dropdownTpl);
     }
 
     /**
@@ -346,16 +346,16 @@ EOT;
         $title = $label;
 
         $tpl = str_replace(
-            array(
+            [
                 '{URL}',
                 '{TITLE}',
                 '{LABEL}'
-            ),
-            array(
+            ],
+            [
                 $this->view()->escape($url->getAbsoluteUrl()),
                 $title,
                 $label
-            ),
+            ],
             $this->refreshTpl
         );
 
@@ -380,18 +380,18 @@ EOT;
         $refresh = $this->renderRefreshTab();
 
         return str_replace(
-            array(
+            [
                 '{TABS}',
                 '{DROPDOWN}',
                 '{REFRESH}',
                 '{CLOSE}'
-            ),
-            array(
+            ],
+            [
                 $tabs,
                 $drop,
                 $refresh,
                 $close
-            ),
+            ],
             $this->baseTpl
         );
     }

--- a/library/Icinga/Web/Wizard.php
+++ b/library/Icinga/Web/Wizard.php
@@ -66,7 +66,7 @@ class Wizard
      *
      * @var array
      */
-    protected $pages = array();
+    protected $pages = [];
 
     /**
      * Initialize a new wizard
@@ -117,7 +117,7 @@ class Wizard
      */
     public function getPages()
     {
-        $pages = array();
+        $pages = [];
         foreach ($this->pages as $page) {
             if ($page instanceof self) {
                 $pages = array_merge($pages, $page->getPages());
@@ -329,7 +329,7 @@ class Wizard
      */
     protected function getWizards()
     {
-        $wizards = array();
+        $wizards = [];
         foreach ($this->pages as $pageOrWizard) {
             if ($pageOrWizard instanceof self) {
                 $wizards[] = $pageOrWizard;
@@ -353,7 +353,7 @@ class Wizard
             return $request->{'get' . ($request->isPost() ? 'Post' : 'Query')}();
         }
 
-        return array();
+        return [];
     }
 
     /**
@@ -545,7 +545,7 @@ class Wizard
         $session = $this->getSession();
 
         if (false === isset($session->page_data)) {
-            $session->page_data = array();
+            $session->page_data = [];
         }
 
         $pageData = & $session->getByRef('page_data');
@@ -608,61 +608,61 @@ class Wizard
             $page->addElement(
                 'button',
                 static::BTN_NEXT,
-                array(
+                [
                     'class'         => 'control-button btn-primary',
                     'type'          => 'submit',
                     'value'         => $pages[1]->getName(),
                     'label'         => t('Next'),
-                    'decorators'    => array('ViewHelper', 'Spinner')
-                )
+                    'decorators'    => ['ViewHelper', 'Spinner']
+                ]
             );
         } elseif ($index < count($pages) - 1) {
             $page->addElement(
                 'button',
                 static::BTN_PREV,
-                array(
+                [
                     'class'             => 'control-button',
                     'type'              => 'submit',
                     'value'             => $pages[$index - 1]->getName(),
                     'label'             => t('Back'),
-                    'decorators'        => array('ViewHelper'),
+                    'decorators'        => ['ViewHelper'],
                     'formnovalidate'    => 'formnovalidate'
-                )
+                ]
             );
             $page->addElement(
                 'button',
                 static::BTN_NEXT,
-                array(
+                [
                     'class'         => 'control-button btn-primary',
                     'type'          => 'submit',
                     'value'         => $pages[$index + 1]->getName(),
                     'label'         => t('Next'),
-                    'decorators'    => array('ViewHelper')
-                )
+                    'decorators'    => ['ViewHelper']
+                ]
             );
         } else {
             $page->addElement(
                 'button',
                 static::BTN_PREV,
-                array(
+                [
                     'class'             => 'control-button',
                     'type'              => 'submit',
                     'value'             => $pages[$index - 1]->getName(),
                     'label'             => t('Back'),
-                    'decorators'        => array('ViewHelper'),
+                    'decorators'        => ['ViewHelper'],
                     'formnovalidate'    => 'formnovalidate'
-                )
+                ]
             );
             $page->addElement(
                 'button',
                 static::BTN_NEXT,
-                array(
+                [
                     'class'         => 'control-button btn-primary',
                     'type'          => 'submit',
                     'value'         => $page->getName(),
                     'label'         => t('Finish'),
-                    'decorators'    => array('ViewHelper')
-                )
+                    'decorators'    => ['ViewHelper']
+                ]
             );
         }
 
@@ -670,30 +670,30 @@ class Wizard
         $page->addElement(
             'note',
             static::PROGRESS_ELEMENT,
-            array(
+            [
                 'order'         => 99, // Ensures that it's shown on the right even if a sub-class adds another button
-                'decorators'    => array(
+                'decorators'    => [
                     'ViewHelper',
-                    array('Spinner', array('id' => static::PROGRESS_ELEMENT))
-                )
-            )
+                    ['Spinner', ['id' => static::PROGRESS_ELEMENT]]
+                ]
+            ]
         );
 
         $page->addDisplayGroup(
-            array(static::BTN_PREV, static::BTN_NEXT, static::PROGRESS_ELEMENT),
+            [static::BTN_PREV, static::BTN_NEXT, static::PROGRESS_ELEMENT],
             'buttons',
-            array(
-                'decorators' => array(
+            [
+                'decorators' => [
                     'FormElements',
-                    new ElementDoubler(array(
+                    new ElementDoubler([
                         'double'        => static::BTN_NEXT,
                         'condition'     => static::BTN_PREV,
                         'placement'     => ElementDoubler::PREPEND,
-                        'attributes'    => array('tabindex' => -1, 'class' => 'double')
-                    )),
-                    array('HtmlTag', array('tag' => 'div', 'class' => 'buttons'))
-                )
-            )
+                        'attributes'    => ['tabindex' => -1, 'class' => 'double']
+                    ]),
+                    ['HtmlTag', ['tag' => 'div', 'class' => 'buttons']]
+                ]
+            ]
         );
     }
 

--- a/modules/doc/application/controllers/IndexController.php
+++ b/modules/doc/application/controllers/IndexController.php
@@ -20,10 +20,10 @@ class IndexController extends DocController
      */
     public function indexAction()
     {
-        $this->getTabs()->add('documentation', array(
+        $this->getTabs()->add('documentation', [
             'active'    => true,
             'title'     => $this->translate('Documentation', 'Tab title'),
             'url'       => Url::fromRequest()
-        ));
+        ]);
     }
 }

--- a/modules/doc/application/controllers/ModuleController.php
+++ b/modules/doc/application/controllers/ModuleController.php
@@ -50,7 +50,7 @@ class ModuleController extends DocController
     public function indexAction()
     {
         $moduleManager = Icinga::app()->getModuleManager();
-        $modules = array();
+        $modules = [];
         foreach ($moduleManager->listInstalledModules() as $module) {
             $path = $this->getPath($module, $moduleManager->getModuleDir($module, '/doc'), true);
             if ($path !== null) {
@@ -58,11 +58,11 @@ class ModuleController extends DocController
             }
         }
         $this->view->modules = $modules;
-        $this->getTabs()->add('module-documentation', array(
+        $this->getTabs()->add('module-documentation', [
             'active'    => true,
             'title'     => $this->translate('Module Documentation', 'Tab title'),
             'url'       => Url::fromRequest()
-        ));
+        ]);
     }
 
     /**
@@ -98,7 +98,7 @@ class ModuleController extends DocController
                 $this->getPath($module, Icinga::app()->getModuleManager()->getModuleDir($module, '/doc')),
                 $name,
                 'doc/module/chapter',
-                array('moduleName' => $module)
+                ['moduleName' => $module]
             );
         } catch (DocException $e) {
             $this->httpNotFound($e->getMessage());
@@ -125,7 +125,7 @@ class ModuleController extends DocController
                 $chapter,
                 'doc/module/chapter',
                 'doc/module/img',
-                array('moduleName' => $module)
+                ['moduleName' => $module]
             );
         } catch (DocException $e) {
             $this->httpNotFound($e->getMessage());
@@ -202,7 +202,7 @@ class ModuleController extends DocController
             $this->getPath($module, Icinga::app()->getModuleManager()->getModuleDir($module, '/doc')),
             $module,
             'doc/module/chapter',
-            array('moduleName' => $module)
+            ['moduleName' => $module]
         );
     }
 }

--- a/modules/doc/application/controllers/SearchController.php
+++ b/modules/doc/application/controllers/SearchController.php
@@ -29,12 +29,12 @@ class SearchController extends DocController
         );
         $search->setUrl('doc/icingaweb/chapter');
         if (strlen($this->params->get('q')) < 3) {
-            $this->view->searches = array();
+            $this->view->searches = [];
             return;
         }
-        $searches = array(
+        $searches = [
             'Icinga Web 2' => $search
-        );
+        ];
         foreach (Icinga::app()->getModuleManager()->listEnabledModules() as $module) {
             if (($path = $this->getModulePath($module)) !== null) {
                 try {
@@ -50,7 +50,7 @@ class SearchController extends DocController
                 }
                 $search
                     ->setUrl('doc/module/chapter')
-                    ->setUrlParams(array('moduleName' => $module));
+                    ->setUrlParams(['moduleName' => $module]);
                 $searches[$module] = $search;
             }
         }

--- a/modules/doc/application/controllers/StyleController.php
+++ b/modules/doc/application/controllers/StyleController.php
@@ -27,17 +27,17 @@ class StyleController extends Controller
     {
         return Widget::create('tabs')->add(
             'guide',
-            array(
+            [
                 'label' => $this->translate('Style Guide'),
                 'url'   => 'doc/style/guide'
-            )
+            ]
         )->add(
             'font',
-            array(
+            [
                 'label' => $this->translate('Icons'),
                 'title' => $this->translate('List all available icons'),
                 'url'   => 'doc/style/font'
-            )
+            ]
         );
     }
 }

--- a/modules/doc/application/views/scripts/index/index.phtml
+++ b/modules/doc/application/views/scripts/index/index.phtml
@@ -7,13 +7,13 @@
             'Icinga Web 2',
             'doc/icingaweb/toc',
             null,
-            array('title' => $this->translate('Show the documentation\'s table of contents for Icinga Web 2'))
+            ['title' => $this->translate('Show the documentation\'s table of contents for Icinga Web 2')]
         ) ?></li>
         <li><?= $this->qlink(
             $this->translate('Module documentations'),
             'doc/module/',
             null,
-            array('title' => $this->translate('List all modules for which documentation is available'))
+            ['title' => $this->translate('List all modules for which documentation is available')]
         ) ?></li>
     </ul>
 </div>

--- a/modules/doc/application/views/scripts/module/index.phtml
+++ b/modules/doc/application/views/scripts/module/index.phtml
@@ -8,11 +8,11 @@
         <li><?= $this->qlink(
             $module->getTitle(),
             'doc/module/toc',
-            array('moduleName' => $module->getName()),
-            array('title' => sprintf(
+            ['moduleName' => $module->getName()],
+            ['title' => sprintf(
                 $this->translate('Show the documentation\'s table of contents for the %s'),
                 $module->getTitle()
-            ))
+            )]
         ) ?></li>
     <?php endforeach ?>
     </ul>

--- a/modules/doc/configuration.php
+++ b/modules/doc/configuration.php
@@ -5,22 +5,22 @@
 
 /** @var $this \Icinga\Application\Modules\Module */
 
-$section = $this->menuSection(N_('Documentation'), array(
+$section = $this->menuSection(N_('Documentation'), [
     'title'    => 'Documentation',
     'icon'     => 'book',
     'url'      => 'doc',
     'priority' => 700
-));
+]);
 
-$section->add('Icinga Web 2', array(
+$section->add('Icinga Web 2', [
     'url' => 'doc/icingaweb/toc',
-));
-$section->add('Module documentations', array(
+]);
+$section->add('Module documentations', [
     'url' => 'doc/module',
-));
-$section->add(N_('Developer - Style'), array(
+]);
+$section->add(N_('Developer - Style'), [
     'url' => 'doc/style/guide',
     'priority' => 790
-));
+]);
 
 $this->provideSearchUrl($this->translate('Doc'), 'doc/search', -10);

--- a/modules/doc/library/Doc/DocController.php
+++ b/modules/doc/library/Doc/DocController.php
@@ -40,7 +40,7 @@ class DocController extends Controller
      * @param string    $imageUrl   URL to images
      * @param array     $urlParams  Additional URL parameters
      */
-    protected function renderChapter($path, $chapter, $url, $imageUrl = null, array $urlParams = array())
+    protected function renderChapter($path, $chapter, $url, $imageUrl = null, array $urlParams = [])
     {
         $parser = new DocParser($path);
         $section = new DocSectionRenderer($parser->getDocTree(), DocSectionRenderer::decodeUrlParam($chapter));
@@ -56,12 +56,12 @@ class DocController extends Controller
         $title = $first === null ? ucfirst($chapter) : $first->getTitle();
         $this->view->title = $title;
         $this->getTabs()
-            ->add('toc', array(
+            ->add('toc', [
                 'active'    => true,
                 'title'     => $title,
                 'url'       => Url::fromRequest()
-            ))
-            ->extend(new OutputFormat(array(OutputFormat::TYPE_CSV, OutputFormat::TYPE_JSON)));
+            ])
+            ->extend(new OutputFormat([OutputFormat::TYPE_CSV, OutputFormat::TYPE_JSON]));
         $this->render('chapter', null, true);
     }
 
@@ -73,7 +73,7 @@ class DocController extends Controller
      * @param string    $url        URL to replace links with
      * @param array     $urlParams  Additional URL parameters
      */
-    protected function renderToc($path, $name, $url, array $urlParams = array())
+    protected function renderToc($path, $name, $url, array $urlParams = [])
     {
         $parser = new DocParser($path);
         $toc = new DocTocRenderer($parser->getDocTree()->getIterator());
@@ -83,12 +83,12 @@ class DocController extends Controller
         $name = ucfirst($name);
         $title = sprintf($this->translate('%s Documentation'), $name);
         $this->getTabs()
-            ->add('toc', array(
+            ->add('toc', [
                 'active'    => true,
                 'title'     => $title,
                 'url'       => Url::fromRequest()
-            ))
-            ->extend(new OutputFormat(array(OutputFormat::TYPE_CSV, OutputFormat::TYPE_JSON)));
+            ])
+            ->extend(new OutputFormat([OutputFormat::TYPE_CSV, OutputFormat::TYPE_JSON]));
         $this->render('toc', null, true);
     }
 
@@ -100,7 +100,7 @@ class DocController extends Controller
      * @param string    $url
      * @param array     $urlParams
      */
-    protected function renderPdf($path, $name, $url, array $urlParams = array())
+    protected function renderPdf($path, $name, $url, array $urlParams = [])
     {
         $parser = new DocParser($path);
         $toc = new DocTocRenderer($parser->getDocTree()->getIterator());

--- a/modules/doc/library/Doc/DocParser.php
+++ b/modules/doc/library/Doc/DocParser.php
@@ -120,7 +120,7 @@ class DocParser
             $id = null;
         }
         /** @noinspection PhpUndefinedVariableInspection */
-        return array($header, $id, $level, $headerStyle);
+        return [$header, $id, $level, $headerStyle];
     }
 
     /**
@@ -182,7 +182,7 @@ class DocParser
                         $stack->pop();
                     }
                     if ($id === null) {
-                        $path = array();
+                        $path = [];
                         foreach ($stack as $section) {
                             /** @var $section DocSection */
                             $path[] = $section->getTitle();

--- a/modules/doc/library/Doc/DocSection.php
+++ b/modules/doc/library/Doc/DocSection.php
@@ -24,7 +24,7 @@ class DocSection extends TreeNode
      *
      * @var array
      */
-    protected $content = array();
+    protected $content = [];
 
     /**
      * Header level

--- a/modules/doc/library/Doc/Renderer/DocRenderer.php
+++ b/modules/doc/library/Doc/Renderer/DocRenderer.php
@@ -35,7 +35,7 @@ abstract class DocRenderer extends RecursiveIteratorIterator
      *
      * @var array
      */
-    protected $urlParams = array();
+    protected $urlParams = [];
 
     /**
      * View
@@ -108,7 +108,7 @@ abstract class DocRenderer extends RecursiveIteratorIterator
      */
     public function setUrlParams(array $urlParams)
     {
-        $this->urlParams = array_map(array($this, 'encodeUrlParam'), $urlParams);
+        $this->urlParams = array_map([$this, 'encodeUrlParam'], $urlParams);
         return $this;
     }
 
@@ -171,7 +171,7 @@ abstract class DocRenderer extends RecursiveIteratorIterator
      */
     public static function encodeUrlParam($param)
     {
-        return str_replace(array('%2F','%5C'), array('%252F','%255C'), rawurlencode($param));
+        return str_replace(['%2F','%5C'], ['%252F','%255C'], rawurlencode($param));
     }
 
     /**
@@ -183,7 +183,7 @@ abstract class DocRenderer extends RecursiveIteratorIterator
      */
     public static function decodeUrlParam($param)
     {
-        return str_replace(array('%2F', '%5C'), array('/', '\\'), $param);
+        return str_replace(['%2F', '%5C'], ['/', '\\'], $param);
     }
 
     /**

--- a/modules/doc/library/Doc/Renderer/DocSearchRenderer.php
+++ b/modules/doc/library/Doc/Renderer/DocSearchRenderer.php
@@ -19,7 +19,7 @@ class DocSearchRenderer extends DocRenderer
      *
      * @var array
      */
-    protected $content = array();
+    protected $content = [];
 
     /**
      * Create a new renderer for doc searches
@@ -62,7 +62,7 @@ class DocSearchRenderer extends DocRenderer
                 continue;
             }
             $title = $this->getView()->escape($section->getTitle());
-            $contentMatches = array();
+            $contentMatches = [];
             foreach ($matches as $match) {
                 if ($match->getMatchType() === DocSearchMatch::MATCH_HEADER) {
                     $title = $match->highlight();
@@ -76,9 +76,9 @@ class DocSearchRenderer extends DocRenderer
             $path = $this->getView()->getHelper('Url')->url(
                 array_merge(
                     $this->getUrlParams(),
-                    array(
+                    [
                         'chapter' => $this->encodeUrlParam($section->getChapter()->getId())
-                    )
+                    ]
                 ),
                 $this->url,
                 false,
@@ -86,11 +86,11 @@ class DocSearchRenderer extends DocRenderer
             );
             $url = $this->getView()->url(
                 $path,
-                array('highlight-search' => $this->getInnerIterator()->getSearch()->getInput())
+                ['highlight-search' => $this->getInnerIterator()->getSearch()->getInput()]
             );
             /** @var \Icinga\Web\Url $url */
             $url->setAnchor($this->encodeAnchor($section->getId()));
-            $urlAttributes = array(
+            $urlAttributes = [
                 'data-base-target'  => '_next',
                 'title'             => $section->getId() === $section->getChapter()->getId()
                     ? sprintf(
@@ -110,7 +110,7 @@ class DocSearchRenderer extends DocRenderer
                         $section->getTitle(),
                         $section->getChapter()->getTitle()
                     )
-            );
+            ];
             if ($section->getNoFollow()) {
                 $urlAttributes['rel'] = 'nofollow';
             }

--- a/modules/doc/library/Doc/Renderer/DocSectionRenderer.php
+++ b/modules/doc/library/Doc/Renderer/DocSectionRenderer.php
@@ -29,7 +29,7 @@ class DocSectionRenderer extends DocRenderer
      *
      * @var array
      */
-    protected $content = array();
+    protected $content = [];
 
     /**
      * Search criteria to highlight
@@ -194,9 +194,9 @@ class DocSectionRenderer extends DocRenderer
         /** @var \DOMElement $img */
         $path = $this->getView()->getHelper('Url')->url(
             array_merge(
-                array(
+                [
                     'image' => trim($img->getAttribute('src'))
-                ),
+                ],
                 $this->urlParams
             ),
             $this->imageUrl,
@@ -225,9 +225,9 @@ class DocSectionRenderer extends DocRenderer
         $path = $this->getView()->getHelper('Url')->url(
             array_merge(
                 $this->urlParams,
-                array(
+                [
                     'chapter' => $this->encodeUrlParam($chapter->getChapter()->getId())
-                )
+                ]
             ),
             $this->url,
             false,
@@ -259,9 +259,9 @@ class DocSectionRenderer extends DocRenderer
         $path = $this->getView()->getHelper('Url')->url(
             array_merge(
                 $this->urlParams,
-                array(
+                [
                     'chapter' => $this->encodeUrlParam($section->getChapter()->getId())
-                )
+                ]
             ),
             $this->url,
             false,
@@ -314,27 +314,27 @@ class DocSectionRenderer extends DocRenderer
             }
             $html = preg_replace_callback(
                 '#<pre><code class="language-php">(.*?)</code></pre>#s',
-                array($this, 'highlightPhp'),
+                [$this, 'highlightPhp'],
                 $html
             );
             $html = preg_replace_callback(
                 '/<img[^>]+>/',
-                array($this, 'replaceImg'),
+                [$this, 'replaceImg'],
                 $html
             );
             $html = preg_replace_callback(
                 '#<blockquote>.+?</blockquote>#ms',
-                array($this, 'markupNotes'),
+                [$this, 'markupNotes'],
                 $html
             );
             $html = preg_replace_callback(
                 '/<a\s+(?P<attribs>[^>]*?\s+)?href="(?:(?!http:\/\/)[^"#]*)#(?P<section>[^"]+)"/',
-                array($this, 'replaceSectionLink'),
+                [$this, 'replaceSectionLink'],
                 $html
             );
             $html = preg_replace_callback(
                 '/<a\s+(?P<attribs>[^>]*?\s+)?href="(?:\d+-)?(?P<chapter>[^\/"#]+).md"/',
-                array($this, 'replaceChapterLink'),
+                [$this, 'replaceChapterLink'],
                 $html
             );
             if ($search !== null) {

--- a/modules/doc/library/Doc/Renderer/DocTocRenderer.php
+++ b/modules/doc/library/Doc/Renderer/DocTocRenderer.php
@@ -32,7 +32,7 @@ class DocTocRenderer extends DocRenderer
      *
      * @var array
      */
-    protected $content = array();
+    protected $content = [];
 
     /**
      * Create a new toc renderer
@@ -75,9 +75,9 @@ class DocTocRenderer extends DocRenderer
             $path = $zendUrlHelper->url(
                 array_merge(
                     $this->urlParams,
-                    array(
+                    [
                         'chapter' => $this->encodeUrlParam($section->getChapter()->getId())
-                    )
+                    ]
                 ),
                 $this->url,
                 false,
@@ -88,7 +88,7 @@ class DocTocRenderer extends DocRenderer
             if ($this->getDepth() > 0) {
                 $url->setAnchor($this->encodeAnchor($section->getId()));
             }
-            $urlAttributes = array(
+            $urlAttributes = [
                 'data-base-target'  => '_next',
                 'title'             => $section->getId() === $section->getChapter()->getId()
                     ? sprintf(
@@ -100,7 +100,7 @@ class DocTocRenderer extends DocRenderer
                         $section->getTitle(),
                         $section->getChapter()->getTitle()
                     )
-            );
+            ];
             if ($section->getNoFollow()) {
                 $urlAttributes['rel'] = 'nofollow';
             }

--- a/modules/doc/library/Doc/Search/DocSearch.php
+++ b/modules/doc/library/Doc/Search/DocSearch.php
@@ -32,9 +32,9 @@ class DocSearch
     public function __construct($search)
     {
         $this->input = $search = (string) $search;
-        $criteria = array();
+        $criteria = [];
         if (preg_match_all('/"(?P<search>[^"]*)"/', $search, $matches, PREG_SET_ORDER | PREG_OFFSET_CAPTURE)) {
-            $unquoted = array();
+            $unquoted = [];
             $offset = 0;
             foreach ($matches as $match) {
                 $fullMatch = $match[0];

--- a/modules/doc/library/Doc/Search/DocSearchIterator.php
+++ b/modules/doc/library/Doc/Search/DocSearchIterator.php
@@ -51,7 +51,7 @@ class DocSearchIterator extends RecursiveFilterIterator
     {
         /** @var $section DocSection */
         $section = $this->current();
-        $matches = array();
+        $matches = [];
         if (($match = $this->search->search($section->getTitle())) !== null) {
             $matches[] = $match->setMatchType(DocSearchMatch::MATCH_HEADER);
         }

--- a/modules/doc/library/Doc/Search/DocSearchMatch.php
+++ b/modules/doc/library/Doc/Search/DocSearchMatch.php
@@ -61,7 +61,7 @@ class DocSearchMatch
      *
      * @var array
      */
-    protected $matches = array();
+    protected $matches = [];
 
     /**
      * View

--- a/modules/doc/run.php
+++ b/modules/doc/run.php
@@ -11,51 +11,51 @@ if (Icinga::app()->isCli()) {
 
 $docModuleChapter = new Zend_Controller_Router_Route(
     'doc/module/:moduleName/chapter/:chapter',
-    array(
+    [
         'controller'    => 'module',
         'action'        => 'chapter',
         'module'        => 'doc'
-    )
+    ]
 );
 
 $docIcingaWebChapter = new Zend_Controller_Router_Route(
     'doc/icingaweb/chapter/:chapter',
-    array(
+    [
         'controller'    => 'icingaweb',
         'action'        => 'chapter',
         'module'        => 'doc'
-    )
+    ]
 );
 
 $docModuleToc = new Zend_Controller_Router_Route(
     'doc/module/:moduleName/toc',
-    array(
+    [
         'controller'    => 'module',
         'action'        => 'toc',
         'module'        => 'doc'
-    )
+    ]
 );
 
 $docModulePdf = new Zend_Controller_Router_Route(
     'doc/module/:moduleName/pdf',
-    array(
+    [
         'controller'    => 'module',
         'action'        => 'pdf',
         'module'        => 'doc'
-    )
+    ]
 );
 
 $docModuleImg = new Zend_Controller_Router_Route_Regex(
     'doc/module/([^/]+)/image/(.+)',
-    array(
+    [
         'controller'    => 'module',
         'action'        => 'image',
         'module'        => 'doc'
-    ),
-    array(
+    ],
+    [
         'moduleName'    => 1,
         'image'         => 2
-    ),
+    ],
     'doc/module/%s/image/%s'
 );
 

--- a/modules/migrate/application/clicommands/ConfigCommand.php
+++ b/modules/migrate/application/clicommands/ConfigCommand.php
@@ -84,7 +84,7 @@ class ConfigCommand extends Command
             $source = trim(file_get_contents($mapFile));
             $source = StringHelper::trimSplit($source, "\n");
 
-            $map = array();
+            $map = [];
 
             array_walk($source, function ($item) use ($separator, &$map) {
                 list($from, $to) = StringHelper::trimSplit($item, $separator, 2);
@@ -112,7 +112,7 @@ class ConfigCommand extends Command
                 $migrated = clone $user;
                 $migrated->setDomain($toDomain);
 
-                $migration = UserDomainMigration::fromMap(array($user->getUsername() => $migrated->getUsername()));
+                $migration = UserDomainMigration::fromMap([$user->getUsername() => $migrated->getUsername()]);
             }
         }
 

--- a/modules/migrate/library/Migrate/Config/UserDomainMigration.php
+++ b/modules/migrate/library/Migrate/Config/UserDomainMigration.php
@@ -75,15 +75,15 @@ class UserDomainMigration
     {
         $announces = new AnnouncementIniRepository();
 
-        $query = $announces->select(array('author'));
+        $query = $announces->select(['author']);
 
         if ($this->map !== null) {
             $query->where('author', array_keys($this->map));
         }
 
-        $migratedUsers = array();
+        $migratedUsers = [];
 
-        foreach ($announces->select(array('author')) as $announce) {
+        foreach ($announces->select(['author']) as $announce) {
             $user = new User($announce->author);
 
             if (! $this->mustMigrate($user)) {
@@ -98,7 +98,7 @@ class UserDomainMigration
 
             $announces->update(
                 'announcement',
-                array('author' => $migrated->getUsername()),
+                ['author' => $migrated->getUsername()],
                 Filter::where('author', $user->getUsername())
             );
 
@@ -110,7 +110,7 @@ class UserDomainMigration
     {
         $directory = Config::resolvePath('dashboards');
 
-        $migration = array();
+        $migration = [];
 
         if (DirectoryIterator::isReadable($directory)) {
             foreach (new DirectoryIterator($directory) as $username => $path) {
@@ -190,7 +190,7 @@ class UserDomainMigration
 
         $query = $conn
             ->select()
-            ->from('icingaweb_user_preference', array('username'))
+            ->from('icingaweb_user_preference', ['username'])
             ->group('username');
 
         if ($this->map !== null) {
@@ -199,7 +199,7 @@ class UserDomainMigration
 
         $users = $query->fetchColumn();
 
-        $migration = array();
+        $migration = [];
 
         foreach ($users as $username) {
             $user = new User($username);
@@ -219,7 +219,7 @@ class UserDomainMigration
             foreach ($migration as $originalUsername => $username) {
                 $conn->update(
                     'icingaweb_user_preference',
-                    array('username' => $username),
+                    ['username' => $username],
                     Filter::where('username', $originalUsername)
                 );
             }
@@ -276,7 +276,7 @@ class UserDomainMigration
 
             $query = $conn
                 ->select()
-                ->from('icingaweb_user', array('name'))
+                ->from('icingaweb_user', ['name'])
                 ->group('name');
 
             if ($this->map !== null) {
@@ -285,7 +285,7 @@ class UserDomainMigration
 
             $users = $query->fetchColumn();
 
-            $migration = array();
+            $migration = [];
 
             foreach ($users as $username) {
                 $user = new User($username);
@@ -305,7 +305,7 @@ class UserDomainMigration
                 foreach ($migration as $originalUsername => $username) {
                     $conn->update(
                         'icingaweb_user',
-                        array('name' => $username),
+                        ['name' => $username],
                         Filter::where('name', $originalUsername)
                     );
                 }
@@ -329,7 +329,7 @@ class UserDomainMigration
 
             $query = $conn
                 ->select()
-                ->from('icingaweb_group_membership', array('username'))
+                ->from('icingaweb_group_membership', ['username'])
                 ->group('username');
 
             if ($this->map !== null) {
@@ -338,7 +338,7 @@ class UserDomainMigration
 
             $users = $query->fetchColumn();
 
-            $migration = array();
+            $migration = [];
 
             foreach ($users as $username) {
                 $user = new User($username);
@@ -358,7 +358,7 @@ class UserDomainMigration
                 foreach ($migration as $originalUsername => $username) {
                     $conn->update(
                         'icingaweb_group_membership',
-                        array('username' => $username),
+                        ['username' => $username],
                         Filter::where('username', $originalUsername)
                     );
                 }

--- a/modules/setup/application/controllers/IndexController.php
+++ b/modules/setup/application/controllers/IndexController.php
@@ -55,14 +55,14 @@ class IndexController extends Controller
             $restartForm->addElement(
                 'button',
                 'btn_submit',
-                array(
+                [
                     'type'          => 'submit',
                     'value'         => 'btn_submit',
                     'escape'        => false,
                     'label'         => $this->view->icon('reply-all'),
                     'title'         => $this->translate('Restart the setup'),
-                    'decorators'    => array('ViewHelper')
-                )
+                    'decorators'    => ['ViewHelper']
+                ]
             );
 
             $this->view->restartForm = $restartForm;
@@ -79,12 +79,12 @@ class IndexController extends Controller
     {
         $this->assertHttpMethod('POST');
 
-        $form = new Form(array(
+        $form = new Form([
             'onSuccess' => function () {
                 $wizard = new WebWizard();
                 $wizard->clearSession(false);
             }
-        ));
+        ]);
         $form->setUidDisabled();
         $form->setRedirectUrl('setup');
         $form->setSubmitLabel('btn_submit');

--- a/modules/setup/application/forms/AdminAccountPage.php
+++ b/modules/setup/application/forms/AdminAccountPage.php
@@ -102,13 +102,13 @@ class AdminAccountPage extends Form
      */
     public function createElements(array $formData)
     {
-        $choices = array();
+        $choices = [];
         $groups = [];
         if ($this->backendConfig['backend'] !== 'db') {
             $choices['by_name'] = $this->translate('By Name', 'setup.admin');
             $choice = isset($formData['user_type']) ? $formData['user_type'] : 'by_name';
 
-            if (in_array($this->backendConfig['backend'], array('ldap', 'msldap'))) {
+            if (in_array($this->backendConfig['backend'], ['ldap', 'msldap'])) {
                 $groups = $this->fetchGroups();
                 if (! empty($groups)) {
                     $choices['user_group'] = $this->translate('User Group', 'setup.admin');
@@ -120,7 +120,7 @@ class AdminAccountPage extends Form
         }
 
         $users = [];
-        if (in_array($this->backendConfig['backend'], array('db', 'ldap', 'msldap'))) {
+        if (in_array($this->backendConfig['backend'], ['db', 'ldap', 'msldap'])) {
             $users = $this->fetchUsers();
             if (! empty($users)) {
                 $choices['existing_user'] = $this->translate('Existing User', 'setup.admin');
@@ -131,23 +131,23 @@ class AdminAccountPage extends Form
             $this->addElement(
                 'select',
                 'user_type',
-                array(
+                [
                     'required'      => true,
                     'autosubmit'    => true,
                     'label'         => $this->translate('Type Of Definition'),
                     'description'   => $this->translate('Choose how to define the desired account.'),
                     'multiOptions'  => $choices,
                     'value'         => $choice
-                )
+                ]
             );
         } else {
             $this->addElement(
                 'hidden',
                 'user_type',
-                array(
+                [
                     'required'  => true,
                     'value'     => key($choices)
-                )
+                ]
             );
         }
 
@@ -155,7 +155,7 @@ class AdminAccountPage extends Form
             $this->addElement(
                 'text',
                 'by_name',
-                array(
+                [
                     'required'      => true,
                     'value'         => $this->getUsername(),
                     'label'         => $this->translate('Username'),
@@ -163,7 +163,7 @@ class AdminAccountPage extends Form
                         'Define the initial administrative account by providing a username that reflects'
                         . ' a user created later or one that is authenticated using external mechanisms.'
                     )
-                )
+                ]
             );
         }
 
@@ -171,7 +171,7 @@ class AdminAccountPage extends Form
             $this->addElement(
                 'select',
                 'user_group',
-                array(
+                [
                     'required'      => true,
                     'label'         => $this->translate('Group Name'),
                     'description'   => $this->translate(
@@ -180,7 +180,7 @@ class AdminAccountPage extends Form
                         'setup.admin'
                     ),
                     'multiOptions'  => array_combine($groups, $groups)
-                )
+                ]
             );
         }
 
@@ -188,7 +188,7 @@ class AdminAccountPage extends Form
             $this->addElement(
                 'select',
                 'existing_user',
-                array(
+                [
                     'required'      => true,
                     'label'         => $this->translate('Username'),
                     'description'   => sprintf(
@@ -201,7 +201,7 @@ class AdminAccountPage extends Form
                             : 'LDAP'
                     ),
                     'multiOptions'  => array_combine($users, $users)
-                )
+                ]
             );
         }
 
@@ -209,18 +209,18 @@ class AdminAccountPage extends Form
             $this->addElement(
                 'text',
                 'new_user',
-                array(
+                [
                     'required'      => true,
                     'label'         => $this->translate('Username'),
                     'description'   => $this->translate(
                         'Enter the username to be used when creating an initial administrative account.'
                     )
-                )
+                ]
             );
             $this->addElement(
                 'password',
                 'new_user_password',
-                array(
+                [
                     'required'          => true,
                     'renderPassword'    => true,
                     'label'             => $this->translate('Password'),
@@ -228,22 +228,22 @@ class AdminAccountPage extends Form
                         'Enter the password to assign to the newly created account.'
                     ),
                     'autocomplete'      => 'new-password'
-                )
+                ]
             );
             $this->addElement(
                 'password',
                 'new_user_2ndpass',
-                array(
+                [
                     'required'          => true,
                     'renderPassword'    => true,
                     'label'             => $this->translate('Repeat password'),
                     'description'       => $this->translate(
                         'Please repeat the password given above to avoid typing errors.'
                     ),
-                    'validators'        => array(
-                        array('identical', false, array('new_user_password'))
-                    )
-                )
+                    'validators'        => [
+                        ['identical', false, ['new_user_password']]
+                    ]
+                ]
             );
         }
     }
@@ -300,9 +300,9 @@ class AdminAccountPage extends Form
         try {
             $query = $this
                 ->createUserBackend()
-                ->select(array('user_name'))
+                ->select(['user_name'])
                 ->order('user_name', 'asc', true);
-            if (in_array($this->backendConfig['backend'], array('ldap', 'msldap'))) {
+            if (in_array($this->backendConfig['backend'], ['ldap', 'msldap'])) {
                 /** @var LdapQuery $ldapQuery */
                 $ldapQuery = $query->getQuery();
                 $ldapQuery->setUsePagedResults();
@@ -311,7 +311,7 @@ class AdminAccountPage extends Form
             return $query->fetchColumn();
         } catch (Exception $_) {
             // No need to handle anything special here. Error means no users found.
-            return array();
+            return [];
         }
     }
 
@@ -361,8 +361,8 @@ class AdminAccountPage extends Form
         try {
             $query = $this
                 ->createUserGroupBackend()
-                ->select(array('group_name'));
-            if (in_array($this->backendConfig['backend'], array('ldap', 'msldap'))) {
+                ->select(['group_name']);
+            if (in_array($this->backendConfig['backend'], ['ldap', 'msldap'])) {
                 /** @var LdapQuery $ldapQuery */
                 $ldapQuery = $query->getQuery();
                 $ldapQuery->setUsePagedResults();
@@ -371,7 +371,7 @@ class AdminAccountPage extends Form
             return $query->fetchColumn();
         } catch (Exception $_) {
             // No need to handle anything special here. Error means no groups found.
-            return array();
+            return [];
         }
     }
 
@@ -409,16 +409,16 @@ class AdminAccountPage extends Form
         $backendConfig = new Config();
         $backendConfig->setSection($this->backendConfig['name'], array_merge(
             $this->backendConfig,
-            array('resource' => $this->resourceConfig['name'])
+            ['resource' => $this->resourceConfig['name']]
         ));
         UserBackend::setConfig($backendConfig);
 
         if (empty($this->groupConfig)) {
-            $groupConfig = new ConfigObject(array(
+            $groupConfig = new ConfigObject([
                 'backend'       => $this->backendConfig['backend'], // _Should_ be "db" or "msldap"
                 'resource'      => $this->resourceConfig['name'],
                 'user_backend'  => $this->backendConfig['name'] // Gets ignored if 'backend' is "db"
-            ));
+            ]);
         } else {
             $groupConfig = new ConfigObject($this->groupConfig);
         }

--- a/modules/setup/application/forms/AuthBackendPage.php
+++ b/modules/setup/application/forms/AuthBackendPage.php
@@ -30,7 +30,7 @@ class AuthBackendPage extends Form
      *
      * @var string[]
      */
-    protected $suggestions = array();
+    protected $suggestions = [];
 
     /**
      * Initialize this page
@@ -99,7 +99,7 @@ class AuthBackendPage extends Form
 
             $backendForm = new LdapBackendForm();
             $backendForm->setSuggestions($this->suggestions);
-            $backendForm->setResources(array($this->config['name']));
+            $backendForm->setResources([$this->config['name']]);
             $backendForm->create($formData);
             $backendForm->getElement('resource')->setIgnore(true);
             $this->addDescription($this->translate(
@@ -109,7 +109,7 @@ class AuthBackendPage extends Form
             $this->addElement(
                 'select',
                 'type',
-                array(
+                [
                     'ignore'            => true,
                     'required'          => true,
                     'autosubmit'        => true,
@@ -117,12 +117,12 @@ class AuthBackendPage extends Form
                     'description'       => $this->translate(
                         'The type of the resource being used for this authenticaton provider'
                     ),
-                    'multiOptions'      => array(
+                    'multiOptions'      => [
                         'ldap'      => 'LDAP',
                         'msldap'    => 'ActiveDirectory'
-                    ),
+                    ],
                     'value'             => $type
-                )
+                ]
             );
         }
 
@@ -201,15 +201,15 @@ class AuthBackendPage extends Form
                 $this->addElement(
                     'note',
                     'inspection_output',
-                    array(
+                    [
                         'order'         => 0,
                         'value'         => '<strong>' . $this->translate('Validation Log') . "</strong>\n\n"
                             . join("\n", array_map($join, $inspection->toArray())),
-                        'decorators'    => array(
+                        'decorators'    => [
                             'ViewHelper',
-                            array('HtmlTag', array('tag' => 'pre', 'class' => 'log-output')),
-                        )
-                    )
+                            ['HtmlTag', ['tag' => 'pre', 'class' => 'log-output']],
+                        ]
+                    ]
                 );
 
                 if ($inspection->hasError()) {
@@ -240,13 +240,13 @@ class AuthBackendPage extends Form
         $this->addElement(
             'checkbox',
             'skip_validation',
-            array(
+            [
                 'order'         => 0,
                 'ignore'        => true,
                 'required'      => true,
                 'label'         => $this->translate('Skip Validation'),
                 'description'   => $this->translate('Check this to not to validate authentication using this backend')
-            )
+            ]
         );
     }
 

--- a/modules/setup/application/forms/AuthenticationPage.php
+++ b/modules/setup/application/forms/AuthenticationPage.php
@@ -47,7 +47,7 @@ class AuthenticationPage extends Form
             }
         }
 
-        $backendTypes = array();
+        $backendTypes = [];
         if (Platform::hasMysqlSupport() || Platform::hasPostgresqlSupport()) {
             $backendTypes['db'] = $this->translate('Database');
         }
@@ -59,13 +59,13 @@ class AuthenticationPage extends Form
         $this->addElement(
             'select',
             'type',
-            array(
+            [
                 'required'      => true,
                 'autosubmit'    => true,
                 'label'         => $this->translate('Authentication Type'),
                 'description'   => $this->translate('The type of authentication to use when accessing Icinga Web 2'),
                 'multiOptions'  => $backendTypes
-            )
+            ]
         );
     }
 }

--- a/modules/setup/application/forms/DatabaseCreationPage.php
+++ b/modules/setup/application/forms/DatabaseCreationPage.php
@@ -110,23 +110,23 @@ class DatabaseCreationPage extends Form
         $this->addElement(
             'text',
             'username',
-            array(
+            [
                 'required'      => false === $skipValidation,
                 'label'         => $this->translate('Username'),
                 'description'   => $this->translate(
                     'A user which is able to create databases and/or touch the database schema'
                 )
-            )
+            ]
         );
         $this->addElement(
             'password',
             'password',
-            array(
+            [
                 'renderPassword'    => true,
                 'label'             => $this->translate('Password'),
                 'description'       => $this->translate('The password for the database user defined above'),
                 'autocomplete'      => 'new-password'
-            )
+            ]
         );
 
         if ($skipValidation) {
@@ -135,10 +135,10 @@ class DatabaseCreationPage extends Form
             $this->addElement(
                 'hidden',
                 'skip_validation',
-                array(
+                [
                     'required'  => true,
                     'value'     => 0
-                )
+                ]
             );
         }
     }
@@ -211,14 +211,14 @@ class DatabaseCreationPage extends Form
         $this->addElement(
             'checkbox',
             'skip_validation',
-            array(
+            [
                 'order'         => 0,
                 'required'      => true,
                 'label'         => $this->translate('Skip Validation'),
                 'description'   => $this->translate(
                     'Check this to not to validate the ability to login and required privileges'
                 )
-            )
+            ]
         );
     }
 }

--- a/modules/setup/application/forms/DbResourcePage.php
+++ b/modules/setup/application/forms/DbResourcePage.php
@@ -32,10 +32,10 @@ class DbResourcePage extends Form
         $this->addElement(
             'hidden',
             'type',
-            array(
+            [
                 'required'  => true,
                 'value'     => 'db'
-            )
+            ]
         );
 
         if (isset($formData['skip_validation']) && $formData['skip_validation']) {
@@ -44,10 +44,10 @@ class DbResourcePage extends Form
             $this->addElement(
                 'hidden',
                 'skip_validation',
-                array(
+                [
                     'required'  => true,
                     'value'     => 0
-                )
+                ]
             );
         }
 
@@ -181,11 +181,11 @@ class DbResourcePage extends Form
         $this->addElement(
             'checkbox',
             'skip_validation',
-            array(
+            [
                 'required'      => true,
                 'label'         => $this->translate('Skip Validation'),
                 'description'   => $this->translate('Check this to not to validate the configuration')
-            )
+            ]
         );
     }
 }

--- a/modules/setup/application/forms/LdapDiscoveryConfirmPage.php
+++ b/modules/setup/application/forms/LdapDiscoveryConfirmPage.php
@@ -88,24 +88,24 @@ EOT;
         $this->addElement(
             'note',
             'suggestion',
-            array(
+            [
                 'value'         => $html,
-                'decorators'    => array(
+                'decorators'    => [
                     'ViewHelper',
-                    array(
-                        'HtmlTag', array('tag' => 'div')
-                    )
-                )
-            )
+                    [
+                        'HtmlTag', ['tag' => 'div']
+                    ]
+                ]
+            ]
         );
 
         $this->addElement(
             'checkbox',
             'confirm',
-            array(
+            [
                 'value' => '1',
                 'label' => $this->translate('Use this configuration?')
-            )
+            ]
         );
     }
 

--- a/modules/setup/application/forms/LdapDiscoveryPage.php
+++ b/modules/setup/application/forms/LdapDiscoveryPage.php
@@ -48,10 +48,10 @@ class LdapDiscoveryPage extends Form
         $this->addElement(
             'checkbox',
             'skip_validation',
-            array(
+            [
                 'label'         => $this->translate('Skip'),
                 'description'   => $this->translate('Do not discover LDAP servers and enter all settings manually.')
-            )
+            ]
         );
     }
 
@@ -87,7 +87,7 @@ class LdapDiscoveryPage extends Form
                 ));
             }
         } else {
-            $labeller = new ErrorLabeller(array('element' => $this->getElement('domain')));
+            $labeller = new ErrorLabeller(['element' => $this->getElement('domain')]);
             $this->getElement('domain')->addError($labeller->translate(Zend_Validate_NotEmpty::IS_EMPTY));
         }
 
@@ -107,11 +107,11 @@ class LdapDiscoveryPage extends Form
             return [];
         }
         $disc = $this->discovery;
-        return array(
+        return [
             'domain' => $this->getValue('domain'),
             'type' => $disc->isAd() ? LdapDiscoveryConfirmPage::TYPE_AD : LdapDiscoveryConfirmPage::TYPE_MISC,
             'resource' => $disc->suggestResourceSettings(),
             'backend' => $disc->suggestBackendSettings()
-        );
+        ];
     }
 }

--- a/modules/setup/application/forms/LdapResourcePage.php
+++ b/modules/setup/application/forms/LdapResourcePage.php
@@ -36,10 +36,10 @@ class LdapResourcePage extends Form
         $this->addElement(
             'hidden',
             'type',
-            array(
+            [
                 'required'  => true,
                 'value'     => 'ldap'
-            )
+            ]
         );
 
         if (isset($formData['skip_validation']) && $formData['skip_validation']) {
@@ -48,10 +48,10 @@ class LdapResourcePage extends Form
             $this->addElement(
                 'hidden',
                 'skip_validation',
-                array(
+                [
                     'required'  => true,
                     'value'     => 0
-                )
+                ]
             );
         }
 
@@ -105,15 +105,15 @@ class LdapResourcePage extends Form
                 $this->addElement(
                     'note',
                     'inspection_output',
-                    array(
+                    [
                         'order'         => 0,
                         'value'         => '<strong>' . $this->translate('Validation Log') . "</strong>\n\n"
                             . join("\n", array_map($join, $inspection->toArray())),
-                        'decorators'    => array(
+                        'decorators'    => [
                             'ViewHelper',
-                            array('HtmlTag', array('tag' => 'pre', 'class' => 'log-output')),
-                        )
-                    )
+                            ['HtmlTag', ['tag' => 'pre', 'class' => 'log-output']],
+                        ]
+                    ]
                 );
 
                 if ($inspection->hasError()) {
@@ -142,13 +142,13 @@ class LdapResourcePage extends Form
         $this->addElement(
             'checkbox',
             'skip_validation',
-            array(
+            [
                 'required'      => true,
                 'label'         => $this->translate('Skip Validation'),
                 'description'   => $this->translate(
                     'Check this to not to validate connectivity with the given directory service'
                 )
-            )
+            ]
         );
     }
 }

--- a/modules/setup/application/forms/ModulePage.php
+++ b/modules/setup/application/forms/ModulePage.php
@@ -25,7 +25,7 @@ class ModulePage extends Form
         $this->setName('setup_modules');
         $this->setViewScript('form/setup-modules.phtml');
 
-        $this->modulePaths = array();
+        $this->modulePaths = [];
         if (($appModulePath = realpath(Icinga::app()->getApplicationDir() . '/../modules')) !== false) {
             $this->modulePaths[] = $appModulePath;
         }
@@ -44,12 +44,12 @@ class ModulePage extends Form
             $this->addElement(
                 'checkbox',
                 $module->getName(),
-                array(
+                [
                     'description'   => $module->getDescription(),
                     'label'         => ucfirst($module->getName()),
                     'value'         => (int) $checked,
-                    'decorators'    => array('ViewHelper')
-                )
+                    'decorators'    => ['ViewHelper']
+                ]
             );
         }
     }
@@ -62,7 +62,7 @@ class ModulePage extends Form
         if ($this->modules !== null) {
             return $this->modules;
         } else {
-            $this->modules = array();
+            $this->modules = [];
         }
 
         $moduleManager = Icinga::app()->getModuleManager();
@@ -84,7 +84,7 @@ class ModulePage extends Form
     {
         $modules = $this->getModules();
 
-        $checked = array();
+        $checked = [];
         foreach ($this->getElements() as $name => $element) {
             if (array_key_exists($name, $modules) && $element->isChecked()) {
                 $checked[$name] = $modules[$name];
@@ -98,7 +98,7 @@ class ModulePage extends Form
     {
         $checked = $this->getCheckedModules();
 
-        $wizards = array();
+        $wizards = [];
         foreach ($checked as $name => $module) {
             if ($module->providesSetupWizard()) {
                 $wizards[$name] = $module->getSetupWizard();

--- a/modules/setup/application/forms/UserGroupBackendPage.php
+++ b/modules/setup/application/forms/UserGroupBackendPage.php
@@ -115,20 +115,20 @@ class UserGroupBackendPage extends Form
         $backendForm->addElement(
             'hidden',
             'resource',
-            array(
+            [
                 'required'      => true,
                 'value'         => $this->resourceConfig['name'],
-                'decorators'    => array('ViewHelper')
-            )
+                'decorators'    => ['ViewHelper']
+            ]
         );
         $backendForm->addElement(
             'hidden',
             'user_backend',
-            array(
+            [
                 'required'      => true,
                 'value'         => $this->backendConfig['name'],
-                'decorators'    => array('ViewHelper')
-            )
+                'decorators'    => ['ViewHelper']
+            ]
         );
     }
 

--- a/modules/setup/application/forms/WelcomePage.php
+++ b/modules/setup/application/forms/WelcomePage.php
@@ -32,7 +32,7 @@ class WelcomePage extends Form
         $this->addElement(
             'text',
             'token',
-            array(
+            [
                 'autofocus'     => '',
                 'required'      => true,
                 'label'         => $this->translate('Setup Token'),
@@ -40,8 +40,8 @@ class WelcomePage extends Form
                     'For security reasons we need to ensure that you are permitted to run this wizard.'
                     . ' Please provide a token by following the instructions below.'
                 ),
-                'validators'    => array(new TokenValidator(Icinga::app()->getConfigDir() . '/setup.token'))
-            )
+                'validators'    => [new TokenValidator(Icinga::app()->getConfigDir() . '/setup.token')]
+            ]
         );
     }
 }

--- a/modules/setup/application/views/scripts/form/setup-modules.phtml
+++ b/modules/setup/application/views/scripts/form/setup-modules.phtml
@@ -15,7 +15,7 @@ use Icinga\Web\Wizard;
 <h2><?= $this->translate('Modules', 'setup.page.title'); ?></h2>
 <p><?= $this->translate('The following modules were found in your Icinga Web 2 installation. To enable and configure a module, just tick it and click "Next".'); ?></p>
 <?php foreach ($form->getElements() as $element): ?>
- <?php if (! in_array($element->getName(), array(Wizard::BTN_PREV, Wizard::BTN_NEXT, Wizard::PROGRESS_ELEMENT, $form->getTokenElementName(), $form->getUidElementName()))): ?>
+ <?php if (! in_array($element->getName(), [Wizard::BTN_PREV, Wizard::BTN_NEXT, Wizard::PROGRESS_ELEMENT, $form->getTokenElementName(), $form->getUidElementName()])): ?>
   <div class="module">
     <div class="header">
       <h3><label for="<?= $element->getId(); ?>"><strong><?= $element->getLabel(); ?></strong></label></h3>

--- a/modules/setup/application/views/scripts/form/setup-requirements.phtml
+++ b/modules/setup/application/views/scripts/form/setup-requirements.phtml
@@ -37,11 +37,11 @@ if (! $form->getWizard()->getRequirements()->fulfilled()) {
         $this->translate('Refresh'),
         null,
         null,
-        array(
+        [
           'class'       => 'button-link',
           'title'       => $title,
           'aria-label'  => sprintf($this->translate('Refresh the page; %s'), $title)
-        )
+        ]
       ); ?>
     </div>
   </div>

--- a/modules/setup/application/views/scripts/form/setup-welcome.phtml
+++ b/modules/setup/application/views/scripts/form/setup-welcome.phtml
@@ -14,13 +14,13 @@ $groupadd = null;
 $docker = getenv('ICINGAWEB_OFFICIAL_DOCKER_IMAGE');
 
 if (! (false === ($distro = Platform::getLinuxDistro(1)) || $distro === 'linux')) {
-    foreach (array(
-        'groupadd -r icingaweb2' => array(
+    foreach ([
+        'groupadd -r icingaweb2' => [
             'redhat', 'rhel', 'centos', 'fedora',
             'suse', 'sles', 'sled', 'opensuse'
-        ),
-        'addgroup --system icingaweb2' => array('debian', 'ubuntu')
-    ) as $groupadd_ => $distros) {
+        ],
+        'addgroup --system icingaweb2' => ['debian', 'ubuntu']
+    ] as $groupadd_ => $distros) {
         if (in_array($distro, $distros)) {
             $groupadd = $groupadd_;
             break;

--- a/modules/setup/application/views/scripts/index/parts/finish.phtml
+++ b/modules/setup/application/views/scripts/index/parts/finish.phtml
@@ -10,21 +10,21 @@
         $this->translate('Login to Icinga Web 2'),
         'authentication/login',
         null,
-        array(
+        [
             'class' => 'button-link login',
             'data-no-icinga-ajax' => true,
             'title' => $this->translate('Show the login page of Icinga Web 2')
-        )
+        ]
     ); ?>
   <?php else: ?>
     <?= $this->qlink(
         $this->translate('Back'),
         null,
         null,
-        array(
+        [
             'class' => 'button-link',
             'title' => $this->translate('Show previous wizard-page')
-        )
+        ]
     ); ?>
   <?php endif ?>
   </div>

--- a/modules/setup/library/Setup/Requirement.php
+++ b/modules/setup/library/Setup/Requirement.php
@@ -79,10 +79,10 @@ abstract class Requirement
      *
      * @throws  LogicException  In case there exists no setter for an option's key
      */
-    public function __construct(array $options = array())
+    public function __construct(array $options = [])
     {
         $this->optional = false;
-        $this->descriptions = array();
+        $this->descriptions = [];
 
         foreach ($options as $key => $value) {
             $setMethod = 'set' . ucfirst($key);

--- a/modules/setup/library/Setup/RequirementSet.php
+++ b/modules/setup/library/Setup/RequirementSet.php
@@ -68,7 +68,7 @@ class RequirementSet implements RecursiveIterator
     public function __construct($optional = false, $mode = null)
     {
         $this->optional = $optional;
-        $this->requirements = array();
+        $this->requirements = [];
         $this->setMode($mode ?: static::MODE_AND);
     }
 

--- a/modules/setup/library/Setup/Setup.php
+++ b/modules/setup/library/Setup/Setup.php
@@ -21,7 +21,7 @@ class Setup implements IteratorAggregate
 
     public function __construct()
     {
-        $this->steps = array();
+        $this->steps = [];
     }
 
     public function getIterator(): Traversable
@@ -73,7 +73,7 @@ class Setup implements IteratorAggregate
      */
     public function getSummary()
     {
-        $summaries = array();
+        $summaries = [];
         foreach ($this->steps as $step) {
             $summaries[] = $step->getSummary();
         }
@@ -88,7 +88,7 @@ class Setup implements IteratorAggregate
      */
     public function getReport()
     {
-        $reports = array();
+        $reports = [];
         foreach ($this->steps as $step) {
             $report = $step->getReport();
             if (! empty($report)) {

--- a/modules/setup/library/Setup/Steps/AuthenticationStep.php
+++ b/modules/setup/library/Setup/Steps/AuthenticationStep.php
@@ -41,7 +41,7 @@ class AuthenticationStep extends Step
 
     protected function createAuthenticationIni()
     {
-        $config = array();
+        $config = [];
         $backendConfig = $this->data['backendConfig'];
         $backendName = $backendConfig['name'];
         unset($backendConfig['name']);
@@ -66,23 +66,23 @@ class AuthenticationStep extends Step
     protected function createRolesIni()
     {
         if (isset($this->data['adminAccountData']['username'])) {
-            $config = array(
+            $config = [
                 'users'         => $this->data['adminAccountData']['username'],
                 'permissions'   => '*'
-            );
+            ];
 
             if ($this->data['backendConfig']['backend'] === 'db') {
                 $config['groups'] = mt('setup', 'Administrators', 'setup.role.name');
             }
         } else { // isset($this->data['adminAccountData']['groupname'])
-            $config = array(
+            $config = [
                 'groups'        => $this->data['adminAccountData']['groupname'],
                 'permissions'   => '*'
-            );
+            ];
         }
 
         try {
-            Config::fromArray(array(mt('setup', 'Administrators', 'setup.role.name') => $config))
+            Config::fromArray([mt('setup', 'Administrators', 'setup.role.name') => $config])
                 ->setConfigFile(Config::resolvePath('roles.ini'))
                 ->saveIni();
         } catch (Exception $e) {
@@ -102,11 +102,11 @@ class AuthenticationStep extends Step
             );
 
             if ($backend->select()->where('user_name', $this->data['adminAccountData']['username'])->count() === 0) {
-                $backend->insert('user', array(
+                $backend->insert('user', [
                     'user_name' => $this->data['adminAccountData']['username'],
                     'password'  => $this->data['adminAccountData']['password'],
                     'is_active' => true
-                ));
+                ]);
                 $this->dbError = false;
             }
         } catch (Exception $e) {
@@ -185,7 +185,7 @@ class AuthenticationStep extends Step
 
     public function getReport()
     {
-        $report = array();
+        $report = [];
 
         if ($this->authIniError === false) {
             $report[] = sprintf(

--- a/modules/setup/library/Setup/Steps/DatabaseStep.php
+++ b/modules/setup/library/Setup/Steps/DatabaseStep.php
@@ -23,7 +23,7 @@ class DatabaseStep extends Step
     public function __construct(array $data)
     {
         $this->data = $data;
-        $this->messages = array();
+        $this->messages = [];
     }
 
     public function apply()

--- a/modules/setup/library/Setup/Steps/GeneralConfigStep.php
+++ b/modules/setup/library/Setup/Steps/GeneralConfigStep.php
@@ -24,7 +24,7 @@ class GeneralConfigStep extends Step
 
     public function apply()
     {
-        $config = array();
+        $config = [];
         foreach ($this->data['generalConfig'] as $sectionAndPropertyName => $value) {
             list($section, $property) = explode('_', $sectionAndPropertyName, 2);
             $config[$section][$property] = $value;
@@ -118,18 +118,18 @@ class GeneralConfigStep extends Step
     public function getReport()
     {
         if ($this->error === false) {
-            return array(sprintf(
+            return [sprintf(
                 mt('setup', 'General configuration has been successfully written to: %s'),
                 Config::resolvePath('config.ini')
-            ));
+            )];
         } elseif ($this->error !== null) {
-            return array(
+            return [
                 sprintf(
                     mt('setup', 'General configuration could not be written to: %s. An error occured:'),
                     Config::resolvePath('config.ini')
                 ),
                 sprintf(mt('setup', 'ERROR: %s'), IcingaException::describe($this->error))
-            );
+            ];
         }
     }
 }

--- a/modules/setup/library/Setup/Steps/ResourceStep.php
+++ b/modules/setup/library/Setup/Steps/ResourceStep.php
@@ -24,7 +24,7 @@ class ResourceStep extends Step
 
     public function apply()
     {
-        $resourceConfig = array();
+        $resourceConfig = [];
         if (isset($this->data['dbResourceConfig'])) {
             $dbConfig = $this->data['dbResourceConfig'];
             $resourceName = $dbConfig['name'];
@@ -187,18 +187,18 @@ class ResourceStep extends Step
     public function getReport()
     {
         if ($this->error === false) {
-            return array(sprintf(
+            return [sprintf(
                 mt('setup', 'Resource configuration has been successfully written to: %s'),
                 Config::resolvePath('resources.ini')
-            ));
+            )];
         } elseif ($this->error !== null) {
-            return array(
+            return [
                 sprintf(
                     mt('setup', 'Resource configuration could not be written to: %s. An error occured:'),
                     Config::resolvePath('resources.ini')
                 ),
                 sprintf(mt('setup', 'ERROR: %s'), IcingaException::describe($this->error))
-            );
+            ];
         }
     }
 }

--- a/modules/setup/library/Setup/Steps/UserGroupStep.php
+++ b/modules/setup/library/Setup/Steps/UserGroupStep.php
@@ -43,17 +43,17 @@ class UserGroupStep extends Step
 
     protected function createGroupsIni()
     {
-        $config = array();
+        $config = [];
         if (isset($this->data['groupConfig'])) {
             $backendConfig = $this->data['groupConfig'];
             $backendName = $backendConfig['name'];
             unset($backendConfig['name']);
             $config[$backendName] = $backendConfig;
         } else {
-            $backendConfig = array(
+            $backendConfig = [
                 'backend'   => $this->data['backendConfig']['backend'], // "db" or "msldap"
                 'resource'  => $this->data['resourceName']
-            );
+            ];
 
             if ($backendConfig['backend'] === 'msldap') {
                 $backendConfig['user_backend'] = $this->data['backendConfig']['name'];
@@ -84,9 +84,9 @@ class UserGroupStep extends Step
 
             $groupName = mt('setup', 'Administrators', 'setup.role.name');
             if ($backend->select()->where('group_name', $groupName)->count() === 0) {
-                $backend->insert('group', array(
+                $backend->insert('group', [
                     'group_name'    => $groupName
-                ));
+                ]);
                 $this->groupError = false;
             }
         } catch (Exception $e) {
@@ -113,10 +113,10 @@ class UserGroupStep extends Step
                 ->where('user_name', $userName)
                 ->count() === 0
             ) {
-                $backend->insert('group_membership', array(
+                $backend->insert('group_membership', [
                     'group_name'    => $groupName,
                     'user_name'     => $userName
-                ));
+                ]);
                 $this->memberError = false;
             }
         } catch (Exception $e) {
@@ -167,7 +167,7 @@ class UserGroupStep extends Step
 
     public function getReport()
     {
-        $report = array();
+        $report = [];
 
         if ($this->groupIniError === false) {
             $report[] = sprintf(

--- a/modules/setup/library/Setup/Utils/DbTool.php
+++ b/modules/setup/library/Setup/Utils/DbTool.php
@@ -63,7 +63,7 @@ class DbTool
      *
      * @var array
      */
-    protected $mysqlGrantContexts = array(
+    protected $mysqlGrantContexts = [
         'ALL'                       => 31,
         'ALL PRIVILEGES'            => 31,
         'ALTER'                     => 13,
@@ -92,14 +92,14 @@ class DbTool
         'SHUTDOWN'                  => 1,
         'SUPER'                     => 1,
         'UPDATE'                    => 29
-    );
+    ];
 
     /**
      * All PostgreSQL GRANT privileges with their respective level identifiers
      *
      * @var array
      */
-    protected $pgsqlGrantContexts = array(
+    protected $pgsqlGrantContexts = [
         'ALL'               => 63,
         'ALL PRIVILEGES'    => 63,
         'CREATE'            => 13,
@@ -109,7 +109,7 @@ class DbTool
         'EXECUTE'           => 32,
         'USAGE'             => 33,
         'CREATEROLE'        => 1
-    );
+    ];
 
     /**
      * Create a new DbTool
@@ -256,17 +256,17 @@ class DbTool
             return;
         }
 
-        $config = array(
+        $config = [
             'dbname'    => $dbname,
             'host'      => $this->config['host'],
             'port'      => $this->config['port'],
             'username'  => $this->config['username'],
             'password'  => $this->config['password']
-        );
+        ];
 
         if ($this->config['db'] === 'mysql') {
             if (isset($this->config['use_ssl']) && $this->config['use_ssl']) {
-                $this->config['driver_options'] = array();
+                $this->config['driver_options'] = [];
                 # The presence of these keys as empty strings or null cause non-ssl connections to fail
                 if ($this->config['ssl_key']) {
                     $config['driver_options'][Mysql::ATTR_SSL_KEY] = $this->config['ssl_key'];
@@ -313,10 +313,10 @@ class DbTool
             return;
         }
 
-        $driverOptions = array(
+        $driverOptions = [
             PDO::ATTR_TIMEOUT => 1,
             PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION
-        );
+        ];
 
         if ($this->config['db'] === 'mysql'
             && isset($this->config['use_ssl'])
@@ -439,7 +439,7 @@ class DbTool
     public function escapeTableWildcards($tableName)
     {
         if ($this->config['db'] === 'mysql') {
-            return str_replace(array('_', '%'), array('\_', '\%'), $tableName);
+            return str_replace(['_', '%'], ['\_', '\%'], $tableName);
         }
 
         throw new LogicException('Unable to escape table wildcards.');
@@ -474,7 +474,7 @@ class DbTool
      *
      * @return  int
      */
-    public function exec($statement, $params = array())
+    public function exec($statement, $params = [])
     {
         if (empty($params)) {
             return $this->pdoConn->exec($statement);
@@ -495,7 +495,7 @@ class DbTool
      *
      * @return  mixed
      */
-    public function query($statement, $params = array())
+    public function query($statement, $params = [])
     {
         if ($this->zendConn !== null) {
             return $this->zendConn->query($statement, $params);
@@ -603,8 +603,8 @@ class DbTool
                 $this->quoteIdentifier($host)
             );
 
-            $dbPrivileges = array();
-            $tablePrivileges = array();
+            $dbPrivileges = [];
+            $tablePrivileges = [];
             foreach (array_intersect($privileges, array_keys($this->mysqlGrantContexts)) as $privilege) {
                 if (! empty($context) && $this->mysqlGrantContexts[$privilege] & static::TABLE_LEVEL) {
                     $tablePrivileges[] = $privilege;
@@ -628,7 +628,7 @@ class DbTool
                 );
             }
         } elseif ($this->config['db'] === 'pgsql') {
-            $dbPrivileges = array();
+            $dbPrivileges = [];
             $schemaPrivileges = [];
             foreach (array_intersect($privileges, array_keys($this->pgsqlGrantContexts)) as $privilege) {
                 if ($this->pgsqlGrantContexts[$privilege] & static::DATABASE_LEVEL) {
@@ -692,16 +692,16 @@ EOD;
 
             $query = $this->query(
                 $queryString,
-                array(
+                [
                     ':current'  => $this->config['username'],
                     ':wanted'   => $username
-                )
+                ]
             );
             return count($query->fetchAll()) > 0;
         } elseif ($this->config['db'] === 'pgsql') {
             $query = $this->query(
                 'SELECT 1 FROM pg_catalog.pg_user WHERE usename = :ident LIMIT 1',
-                array(':ident' => $username)
+                [':ident' => $username]
             );
             return count($query->fetchAll()) === 1;
         }
@@ -719,7 +719,7 @@ EOD;
             list($_, $host) = explode('@', $this->query('select current_user()')->fetchColumn());
             $this->exec(
                 'CREATE USER :user@:host IDENTIFIED BY :passw',
-                array(':user' => $username, ':host' => $host, ':passw' => $password)
+                [':user' => $username, ':host' => $host, ':passw' => $password]
             );
         } elseif ($this->config['db'] === 'pgsql') {
             $this->exec(sprintf(
@@ -752,8 +752,8 @@ EOD;
         $grantee = "'" . ($username === null ? $this->config['username'] : $username) . "'@'" . $host . "'";
 
         if (isset($this->config['dbname'])) {
-            $dbPrivileges = array();
-            $tablePrivileges = array();
+            $dbPrivileges = [];
+            $tablePrivileges = [];
             foreach ($mysqlPrivileges as $privilege) {
                 if (! empty($context) && $this->mysqlGrantContexts[$privilege] & static::TABLE_LEVEL) {
                     $tablePrivileges[] = $privilege;
@@ -775,8 +775,8 @@ EOD;
                     . ($requireGrants ? " AND is_grantable = 'YES'" : '');
 
                 $dbAndTableQuery = $this->query(
-                    sprintf($queryString, join(',', array_map(array($this, 'quote'), $dbPrivileges))),
-                    array(':grantee' => $grantee, ':dbname' => $this->escapeTableWildcards($this->config['dbname']))
+                    sprintf($queryString, join(',', array_map([$this, 'quote'], $dbPrivileges))),
+                    [':grantee' => $grantee, ':dbname' => $this->escapeTableWildcards($this->config['dbname'])]
                 );
                 $grantedDbAndTablePrivileges = (int) $dbAndTableQuery->fetchObject()->matches;
                 if ($grantedDbAndTablePrivileges === count($dbPrivileges)) {
@@ -790,11 +790,11 @@ EOD;
                     $dbExclusivePrivileges = array_diff($dbPrivileges, $tablePrivileges);
                     if (! empty($dbExclusivePrivileges)) {
                         $dbExclusiveQuery = $this->query(
-                            sprintf($queryString, join(',', array_map(array($this, 'quote'), $dbExclusivePrivileges))),
-                            array(
+                            sprintf($queryString, join(',', array_map([$this, 'quote'], $dbExclusivePrivileges))),
+                            [
                                 ':grantee'  => $grantee,
                                 ':dbname'   => $this->escapeTableWildcards($this->config['dbname'])
-                            )
+                            ]
                         );
                         $dbPrivilegesGranted = (int) $dbExclusiveQuery->fetchObject()->matches === count(
                             $dbExclusivePrivileges
@@ -809,10 +809,10 @@ EOD;
                     . ' FROM information_schema.table_privileges'
                     . ' WHERE grantee = :grantee'
                     . ' AND table_schema = :dbname'
-                    . ' AND table_name IN (' . join(',', array_map(array($this, 'quote'), $context)) . ')'
-                    . ' AND privilege_type IN (' . join(',', array_map(array($this, 'quote'), $tablePrivileges)) . ')'
+                    . ' AND table_name IN (' . join(',', array_map([$this, 'quote'], $context)) . ')'
+                    . ' AND privilege_type IN (' . join(',', array_map([$this, 'quote'], $tablePrivileges)) . ')'
                     . ($requireGrants ? " AND is_grantable = 'YES'" : ''),
-                    array(':grantee' => $grantee, ':dbname' => $this->config['dbname'])
+                    [':grantee' => $grantee, ':dbname' => $this->config['dbname']]
                 );
                 $expectedAmountOfMatches = count($context) * count($tablePrivileges);
                 $tablePrivilegesGranted = (int) $query->fetchObject()->matches === $expectedAmountOfMatches;
@@ -825,9 +825,9 @@ EOD;
 
         $query = $this->query(
             'SELECT COUNT(*) as matches FROM information_schema.user_privileges WHERE grantee = :grantee'
-            . ' AND privilege_type IN (' . join(',', array_map(array($this, 'quote'), $mysqlPrivileges)) . ')'
+            . ' AND privilege_type IN (' . join(',', array_map([$this, 'quote'], $mysqlPrivileges)) . ')'
             . ($requireGrants ? " AND is_grantable = 'YES'" : ''),
-            array(':grantee' => $grantee)
+            [':grantee' => $grantee]
         );
         return (int) $query->fetchObject()->matches === count($mysqlPrivileges);
     }
@@ -859,7 +859,7 @@ EOD;
 
         if ($this->dbFromConfig) {
             $schemaPrivileges = [];
-            $dbPrivileges = array();
+            $dbPrivileges = [];
             if (! $isSuperUser) {
                 foreach (array_intersect($privileges, array_keys($this->pgsqlGrantContexts)) as $privilege) {
                     if ($this->pgsqlGrantContexts[$privilege] & static::DATABASE_LEVEL) {
@@ -893,11 +893,11 @@ EOD;
                     foreach ($dbPrivileges as $dbPrivilege) {
                         $query = $this->query(
                             'SELECT has_database_privilege(:user, :dbname, :privilege) AS db_privilege_granted',
-                            array(
+                            [
                                 ':user'         => $owner,
                                 ':dbname'       => $this->config['dbname'],
                                 ':privilege'    => $dbPrivilege . ($requireGrants ? ' WITH GRANT OPTION' : '')
-                            )
+                            ]
                         );
                         if (! $query->fetchObject()->db_privilege_granted) {
                             // The user doesn't fully have the provided privileges.
@@ -930,7 +930,7 @@ EOD;
             if (in_array('CREATE', $privileges, true)) {
                 $query = $this->query(
                     'select rolcreatedb from pg_roles where rolname = :user',
-                    array(':user' => $username !== null ? $username : $this->config['username'])
+                    [':user' => $username !== null ? $username : $this->config['username']]
                 );
                 $privilegesGranted = $query->fetchColumn() !== false;
             }
@@ -939,7 +939,7 @@ EOD;
         if ($privilegesGranted && in_array('CREATEROLE', $privileges, true)) {
             $query = $this->query(
                 'select rolcreaterole from pg_roles where rolname = :user',
-                array(':user' => $username !== null ? $username : $this->config['username'])
+                [':user' => $username !== null ? $username : $this->config['username']]
             );
             $privilegesGranted = $query->fetchColumn() !== false;
         }

--- a/modules/setup/library/Setup/Utils/EnableModuleStep.php
+++ b/modules/setup/library/Setup/Utils/EnableModuleStep.php
@@ -25,7 +25,7 @@ class EnableModuleStep extends Step
     {
         $this->moduleNames = $moduleNames;
 
-        $this->modulePaths = array();
+        $this->modulePaths = [];
         if (($appModulePath = realpath(Icinga::app()->getApplicationDir() . '/../modules')) !== false) {
             $this->modulePaths[] = $appModulePath;
         }
@@ -61,7 +61,7 @@ class EnableModuleStep extends Step
         $okMessage = mt('setup', 'Module "%s" has been successfully enabled.');
         $failMessage = mt('setup', 'Module "%s" could not be enabled. An error occured:');
 
-        $report = array();
+        $report = [];
         foreach ($this->moduleNames as $moduleName) {
             if (isset($this->errors[$moduleName])) {
                 $report[] = sprintf($failMessage, $moduleName);

--- a/modules/setup/library/Setup/Web/Form/Validator/TokenValidator.php
+++ b/modules/setup/library/Setup/Web/Form/Validator/TokenValidator.php
@@ -29,7 +29,7 @@ class TokenValidator extends Zend_Validate_Abstract
     public function __construct($tokenPath)
     {
         $this->tokenPath = $tokenPath;
-        $this->_messageTemplates = array(
+        $this->_messageTemplates = [
             'TOKEN_FILE_ERROR'  => sprintf(
                 mt('setup', 'Cannot validate token: %s (%s)'),
                 $tokenPath,
@@ -40,7 +40,7 @@ class TokenValidator extends Zend_Validate_Abstract
                 $tokenPath
             ),
             'TOKEN_INVALID'     => mt('setup', 'Invalid token supplied.')
-        );
+        ];
     }
 
     /**

--- a/modules/setup/library/Setup/WebWizard.php
+++ b/modules/setup/library/Setup/WebWizard.php
@@ -52,29 +52,29 @@ class WebWizard extends Wizard implements SetupWizard
      *
      * @var array
      */
-    protected $databaseCreationPrivileges = array(
+    protected $databaseCreationPrivileges = [
         'CREATE',
         'CREATE USER', // MySQL
         'CREATEROLE' // PostgreSQL
-    );
+    ];
 
     /**
      * The privileges required by Icinga Web 2 to setup the database
      *
      * @var array
      */
-    protected $databaseSetupPrivileges = array(
+    protected $databaseSetupPrivileges = [
         'CREATE',
         'ALTER', // MySQL only
         'REFERENCES'
-    );
+    ];
 
     /**
      * The privileges required by Icinga Web 2 to operate the database
      *
      * @var array
      */
-    protected $databaseUsagePrivileges = array(
+    protected $databaseUsagePrivileges = [
         'SELECT',
         'INSERT',
         'UPDATE',
@@ -88,21 +88,21 @@ class WebWizard extends Wizard implements SetupWizard
         'USAGE', // PostgreSQL
         'TEMPORARY', // PostgreSql
         'CREATE TEMPORARY TABLES' // MySQL
-    );
+    ];
 
     /**
      * The database tables operated by Icinga Web 2
      *
      * @var array
      */
-    protected $databaseTables = array(
+    protected $databaseTables = [
         'icingaweb_group',
         'icingaweb_group_membership',
         'icingaweb_user',
         'icingaweb_user_preference',
         'icingaweb_rememberme',
         'icingaweb_schema'
-    );
+    ];
 
     /**
      * Register all pages and module wizards for this wizard
@@ -113,8 +113,8 @@ class WebWizard extends Wizard implements SetupWizard
         $this->addPage(new ModulePage());
         $this->addPage(new RequirementsPage());
         $this->addPage(new AuthenticationPage());
-        $this->addPage(new DbResourcePage(array('name' => 'setup_auth_db_resource')));
-        $this->addPage(new DatabaseCreationPage(array('name' => 'setup_auth_db_creation')));
+        $this->addPage(new DbResourcePage(['name' => 'setup_auth_db_resource']));
+        $this->addPage(new DatabaseCreationPage(['name' => 'setup_auth_db_creation']));
         $this->addPage(new LdapDiscoveryPage());
         //$this->addPage(new LdapDiscoveryConfirmPage());
         $this->addPage(new LdapResourcePage());
@@ -122,9 +122,9 @@ class WebWizard extends Wizard implements SetupWizard
         $this->addPage(new UserGroupBackendPage());
         $this->addPage(new AdminAccountPage());
         $this->addPage(new GeneralConfigPage());
-        $this->addPage(new DbResourcePage(array('name' => 'setup_config_db_resource')));
-        $this->addPage(new DatabaseCreationPage(array('name' => 'setup_config_db_creation')));
-        $this->addPage(new SummaryPage(array('name' => 'setup_summary')));
+        $this->addPage(new DbResourcePage(['name' => 'setup_config_db_resource']));
+        $this->addPage(new DatabaseCreationPage(['name' => 'setup_config_db_creation']));
+        $this->addPage(new SummaryPage(['name' => 'setup_summary']));
 
         if (($modulePageData = $this->getPageData('setup_modules')) !== null) {
             /** @var ModulePage $modulePage */
@@ -306,7 +306,7 @@ class WebWizard extends Wizard implements SetupWizard
         } elseif ($newPage->getName() === 'setup_config_db_resource') {
             $authData = $this->getPageData('setup_authentication_type');
             $skip = $authData['type'] === 'db';
-        } elseif (in_array($newPage->getName(), array('setup_auth_db_creation', 'setup_config_db_creation'))) {
+        } elseif (in_array($newPage->getName(), ['setup_auth_db_creation', 'setup_config_db_creation'])) {
             if (($newPage->getName() === 'setup_auth_db_creation' || $this->hasPageData('setup_config_db_resource'))
                 && (($config = $this->getPageData('setup_auth_db_resource')) !== null
                     || ($config = $this->getPageData('setup_config_db_resource')) !== null)
@@ -374,7 +374,7 @@ class WebWizard extends Wizard implements SetupWizard
 
         $authData = $this->getPageData('setup_authentication_type');
         $veto = $page->getName() === 'setup_authentication_backend' && $authData['type'] === 'db';
-        if (! $veto && in_array($page->getName(), array(
+        if (! $veto && in_array($page->getName(), [
             'setup_authentication_backend',
             'setup_auth_db_resource',
             'setup_config_db_resource',
@@ -383,17 +383,17 @@ class WebWizard extends Wizard implements SetupWizard
             'setup_icingadb_resource',
             'setup_icingadb_redis',
             'setup_icingadb_api_transport'
-        ))) {
+        ])) {
             $page->addElement(
                 'submit',
                 'backend_validation',
-                array(
+                [
                     'ignore'                => true,
                     'label'                 => t('Validate Configuration'),
                     'data-progress-label'   => t('Validation In Progress'),
-                    'decorators'            => array('ViewHelper'),
+                    'decorators'            => ['ViewHelper'],
                     'formnovalidate'        => 'formnovalidate'
-                )
+                ]
             );
             $page->getDisplayGroup('buttons')->addElement($page->getElement('backend_validation'));
         }
@@ -403,13 +403,13 @@ class WebWizard extends Wizard implements SetupWizard
                 $page->addElement(
                     'submit',
                     'transport_validation',
-                    array(
+                    [
                         'ignore'                => true,
                         'label'                 => t('Validate Configuration'),
                         'data-progress-label'   => t('Validation In Progress'),
-                        'decorators'            => array('ViewHelper'),
+                        'decorators'            => ['ViewHelper'],
                         'formnovalidate'        => 'formnovalidate'
-                    )
+                    ]
                 );
                 $page->getDisplayGroup('buttons')->addElement($page->getElement('transport_validation'));
             }
@@ -450,7 +450,7 @@ class WebWizard extends Wizard implements SetupWizard
             )
         ) {
             $setup->addStep(
-                new DatabaseStep(array(
+                new DatabaseStep([
                     'tables'            => $this->databaseTables,
                     'privileges'        => $this->databaseUsagePrivileges,
                     'resourceConfig'    => $pageData['setup_auth_db_resource'],
@@ -462,7 +462,7 @@ class WebWizard extends Wizard implements SetupWizard
                         : null,
                     'schemaPath'        => Config::module('setup')
                         ->get('schema', 'path', Icinga::app()->getBaseDir('schema'))
-                ))
+                ])
             );
         } elseif (isset($pageData['setup_config_db_resource'])
             && !$pageData['setup_config_db_resource']['skip_validation']
@@ -471,7 +471,7 @@ class WebWizard extends Wizard implements SetupWizard
             )
         ) {
             $setup->addStep(
-                new DatabaseStep(array(
+                new DatabaseStep([
                     'tables'            => $this->databaseTables,
                     'privileges'        => $this->databaseUsagePrivileges,
                     'resourceConfig'    => $pageData['setup_config_db_resource'],
@@ -483,12 +483,12 @@ class WebWizard extends Wizard implements SetupWizard
                         : null,
                     'schemaPath'        => Config::module('setup')
                         ->get('schema', 'path', Icinga::app()->getBaseDir('schema'))
-                ))
+                ])
             );
         }
 
         $setup->addStep(
-            new GeneralConfigStep(array(
+            new GeneralConfigStep([
                 'generalConfig' => $pageData['setup_general_config'],
                 'resourceName'  => isset($pageData['setup_auth_db_resource']['name'])
                     ? $pageData['setup_auth_db_resource']['name']
@@ -496,14 +496,14 @@ class WebWizard extends Wizard implements SetupWizard
                         ? $pageData['setup_config_db_resource']['name']
                         : null
                     )
-            ))
+            ])
         );
 
         $adminAccountType = $pageData['setup_admin_account']['user_type'];
         if ($adminAccountType === 'user_group') {
-            $adminAccountData = array('groupname' => $pageData['setup_admin_account'][$adminAccountType]);
+            $adminAccountData = ['groupname' => $pageData['setup_admin_account'][$adminAccountType]];
         } else {
-            $adminAccountData = array('username' => $pageData['setup_admin_account'][$adminAccountType]);
+            $adminAccountData = ['username' => $pageData['setup_admin_account'][$adminAccountType]];
             if ($adminAccountType === 'new_user' && !$pageData['setup_auth_db_resource']['skip_validation']
                 && (! isset($pageData['setup_auth_db_creation'])
                     || !$pageData['setup_auth_db_creation']['skip_validation']
@@ -515,18 +515,18 @@ class WebWizard extends Wizard implements SetupWizard
         }
         $authType = $pageData['setup_authentication_type']['type'];
         $setup->addStep(
-            new AuthenticationStep(array(
+            new AuthenticationStep([
                 'adminAccountData'  => $adminAccountData,
                 'backendConfig'     => $pageData['setup_authentication_backend'],
                 'resourceName'      => $authType === 'db' ? $pageData['setup_auth_db_resource']['name'] : (
                     $authType === 'ldap' ? $pageData['setup_ldap_resource']['name'] : null
                 )
-            ))
+            ])
         );
 
         if ($authType !== 'external') {
             $setup->addStep(
-                new UserGroupStep(array(
+                new UserGroupStep([
                     'backendConfig'     => $pageData['setup_authentication_backend'],
                     'groupConfig'       => isset($pageData['setup_usergroup_backend'])
                         ? $pageData['setup_usergroup_backend']
@@ -540,7 +540,7 @@ class WebWizard extends Wizard implements SetupWizard
                     'username'          => $authType === 'db'
                         ? $pageData['setup_admin_account'][$adminAccountType]
                         : null
-                ))
+                ])
             );
         }
 
@@ -549,17 +549,17 @@ class WebWizard extends Wizard implements SetupWizard
             || isset($pageData['setup_ldap_resource'])
         ) {
             $setup->addStep(
-                new ResourceStep(array(
+                new ResourceStep([
                     'dbResourceConfig'      => isset($pageData['setup_auth_db_resource'])
-                        ? array_diff_key($pageData['setup_auth_db_resource'], array('skip_validation' => null))
+                        ? array_diff_key($pageData['setup_auth_db_resource'], ['skip_validation' => null])
                         : (isset($pageData['setup_config_db_resource'])
-                            ? array_diff_key($pageData['setup_config_db_resource'], array('skip_validation' => null))
+                            ? array_diff_key($pageData['setup_config_db_resource'], ['skip_validation' => null])
                             : null
                         ),
                     'ldapResourceConfig'    => isset($pageData['setup_ldap_resource'])
-                        ? array_diff_key($pageData['setup_ldap_resource'], array('skip_validation' => null))
+                        ? array_diff_key($pageData['setup_ldap_resource'], ['skip_validation' => null])
                         : null
-                ))
+                ])
             );
         }
 
@@ -585,15 +585,15 @@ class WebWizard extends Wizard implements SetupWizard
     {
         $set = new RequirementSet();
 
-        $set->add(new PhpVersionRequirement(array(
-            'condition'     => array('>=', '8.2'),
+        $set->add(new PhpVersionRequirement([
+            'condition'     => ['>=', '8.2'],
             'description'   => sprintf(mt(
                 'setup',
                 'Running Icinga Web 2 requires PHP version %s.'
             ), '8.2')
-        )));
+        ]));
 
-        $set->add(new OSRequirement(array(
+        $set->add(new OSRequirement([
             'optional'      => true,
             'condition'     => 'linux',
             'description'   => mt(
@@ -601,112 +601,112 @@ class WebWizard extends Wizard implements SetupWizard
                 'Icinga Web 2 is developed for and tested on Linux. While we cannot'
                 . ' guarantee they will, other platforms may also perform as well.'
             )
-        )));
+        ]));
 
-        $set->add(new WebLibraryRequirement(array(
+        $set->add(new WebLibraryRequirement([
             'condition'     => ['icinga-php-library', '>=', '0.20.0'],
             'alias'         => 'Icinga PHP library',
             'description'   => mt(
                 'setup',
                 'The Icinga PHP library (IPL) is required for Icinga Web 2 and modules'
             )
-        )));
+        ]));
 
-        $set->add(new WebLibraryRequirement(array(
+        $set->add(new WebLibraryRequirement([
             'condition'     => ['icinga-php-thirdparty', '>=', '0.15.0'],
             'alias'         => 'Icinga PHP Thirdparty',
             'description'   => mt(
                 'setup',
                 'The Icinga PHP Thirdparty library is required for Icinga Web 2 and modules'
             )
-        )));
+        ]));
 
-        $set->add(new PhpModuleRequirement(array(
+        $set->add(new PhpModuleRequirement([
             'condition'     => 'OpenSSL',
             'description'   => mt(
                 'setup',
                 'The PHP module for OpenSSL is required to generate cryptographically safe password salts.'
             )
-        )));
+        ]));
 
-        $set->add(new PhpModuleRequirement(array(
+        $set->add(new PhpModuleRequirement([
             'condition'     => 'XML',
             'description'   => mt(
                 'setup',
                 'The XML module for PHP is required for Markdown and custom HTML annotations.'
             )
-        )));
+        ]));
 
-        $set->add(new PhpModuleRequirement(array(
+        $set->add(new PhpModuleRequirement([
             'condition'     => 'JSON',
             'description'   => mt(
                 'setup',
                 'The JSON module for PHP is required for various export functionalities as well as APIs.'
             )
-        )));
+        ]));
 
-        $set->add(new PhpModuleRequirement(array(
+        $set->add(new PhpModuleRequirement([
             'condition'     => 'gettext',
             'description'   => mt(
                 'setup',
                 'For message localization, the gettext module for PHP is required.'
             )
-        )));
+        ]));
 
-        $set->add(new PhpModuleRequirement(array(
+        $set->add(new PhpModuleRequirement([
             'condition'     => 'INTL',
             'description'   => mt(
                 'setup',
                 'For language, timezone and date/time format negotiation, the INTL module for PHP is required.'
             )
-        )));
+        ]));
 
-        $set->add(new PhpModuleRequirement(array(
+        $set->add(new PhpModuleRequirement([
             'condition'     => 'DOM',
             'description'   => mt(
                 'setup',
                 'For charts and exports of views and reports to PDF, the DOM module for PHP is required.'
             )
-        )));
+        ]));
 
-        $set->add(new PhpModuleRequirement(array(
+        $set->add(new PhpModuleRequirement([
             'optional'      => true,
             'condition'     => 'LDAP',
             'description'   => mt(
                 'setup',
                 'If you\'d like to authenticate users using LDAP the corresponding PHP module is required.'
             )
-        )));
+        ]));
 
-        $set->add(new PhpModuleRequirement(array(
+        $set->add(new PhpModuleRequirement([
             'optional'      => true,
             'condition'     => 'mbstring',
             'description'   => mt(
                 'setup',
                 'In case you want views being exported to PDF, you\'ll need the mbstring extension for PHP.'
             )
-        )));
+        ]));
 
-        $set->add(new PhpModuleRequirement(array(
+        $set->add(new PhpModuleRequirement([
             'optional'      => true,
             'condition'     => 'GD',
             'description'   => mt(
                 'setup',
                 'In case you want views being exported to PDF, you\'ll need the GD extension for PHP.'
             )
-        )));
+        ]));
 
-        $set->add(new PhpModuleRequirement(array(
+        $set->add(new PhpModuleRequirement([
             'optional'      => true,
             'condition'     => 'Imagick',
             'description'   => mt(
                 'setup',
                 'In case you want graphs being exported to PDF as well, you\'ll need the ImageMagick extension for PHP.'
             )
-        )));
+        ]));
 
         $dbSet = new RequirementSet(false, RequirementSet::MODE_OR);
-        $dbSet->add(new PhpModuleRequirement(array(
+        $dbSet->add(new PhpModuleRequirement([
             'optional'      => true,
             'condition'     => 'pdo_mysql',
             'alias'         => 'PDO-MySQL',
@@ -714,8 +714,8 @@ class WebWizard extends Wizard implements SetupWizard
                 'setup',
                 'To store users or preferences in a MySQL database the PDO-MySQL module for PHP is required.'
             )
-        )));
-        $dbSet->add(new PhpModuleRequirement(array(
+        ]));
+        $dbSet->add(new PhpModuleRequirement([
             'optional'      => true,
             'condition'     => 'pdo_pgsql',
             'alias'         => 'PDO-PostgreSQL',
@@ -723,10 +723,10 @@ class WebWizard extends Wizard implements SetupWizard
                 'setup',
                 'To store users or preferences in a PostgreSQL database the PDO-PostgreSQL module for PHP is required.'
             )
-        )));
+        ]));
         $set->merge($dbSet);
 
-        $dbRequire = (new SetRequirement(array(
+        $dbRequire = (new SetRequirement([
             'optional'      => false,
             'condition'     => $dbSet,
             'title'         =>'Database',
@@ -736,11 +736,11 @@ class WebWizard extends Wizard implements SetupWizard
                 'A database is mandatory, therefore at least one module '
                 . 'PDO-MySQL or PDO-PostgreSQL for PHP is required.'
             )
-        )));
+        ]));
 
         $set->add($dbRequire);
 
-        $set->add(new ConfigDirectoryRequirement(array(
+        $set->add(new ConfigDirectoryRequirement([
             'condition'     => Icinga::app()->getStorageDir(),
             'title'         => mt('setup', 'Read- and writable storage directory'),
             'description'   => mt(
@@ -748,16 +748,16 @@ class WebWizard extends Wizard implements SetupWizard
                 'The Icinga Web 2 storage directory defaults to "/var/lib/icingaweb2", if' .
                 ' not explicitly set in the environment variable "ICINGAWEB_STORAGEDIR".'
             )
-        )));
+        ]));
 
-        $set->add(new ConfigDirectoryRequirement(array(
+        $set->add(new ConfigDirectoryRequirement([
             'condition'     => Icinga::app()->getConfigDir(),
             'description'   => mt(
                 'setup',
                 'The Icinga Web 2 configuration directory defaults to "/etc/icingaweb2", if' .
                 ' not explicitly set in the environment variable "ICINGAWEB_CONFIGDIR".'
             )
-        )));
+        ]));
 
         if (! $skipModules) {
             foreach ($this->getWizards() as $wizard) {

--- a/modules/setup/library/Setup/Webserver.php
+++ b/modules/setup/library/Setup/Webserver.php
@@ -90,20 +90,20 @@ abstract class Webserver
         $template = $this->getTemplate();
         $fpmUri = $this->createFpmUri();
 
-        $searchTokens = array(
+        $searchTokens = [
             '{urlPath}',
             '{documentRoot}',
             '{aliasDocumentRoot}',
             '{configDir}',
             '{fpmUri}'
-        );
-        $replaceTokens = array(
+        ];
+        $replaceTokens = [
             $this->getUrlPath(),
             $this->getDocumentRoot(),
             preg_match('~/$~', $this->getUrlPath()) ? $this->getDocumentRoot() . '/' : $this->getDocumentRoot(),
             $this->getConfigDir(),
             $fpmUri
-        );
+        ];
         $template = str_replace($searchTokens, $replaceTokens, $template);
         return $template;
     }

--- a/modules/setup/test/php/library/Setup/RequirementSetTest.php
+++ b/modules/setup/test/php/library/Setup/RequirementSetTest.php
@@ -86,7 +86,7 @@ class RequirementSetTest extends BaseTestCase
     public function testFlatMixedRequirementsOfTypeAnd()
     {
         $mandatoryOptionalTrueSet = new RequirementSet();
-        $mandatoryOptionalTrueSet->add(new TrueRequirement(array('optional' => true)));
+        $mandatoryOptionalTrueSet->add(new TrueRequirement(['optional' => true]));
         $mandatoryOptionalTrueSet->add(new FalseRequirement());
         $this->assertFalse(
             $mandatoryOptionalTrueSet->fulfilled(),
@@ -95,14 +95,14 @@ class RequirementSetTest extends BaseTestCase
 
         $mandatoryOptionalFalseSet = new RequirementSet();
         $mandatoryOptionalFalseSet->add(new TrueRequirement());
-        $mandatoryOptionalFalseSet->add(new FalseRequirement(array('optional' => true)));
+        $mandatoryOptionalFalseSet->add(new FalseRequirement(['optional' => true]));
         $this->assertTrue(
             $mandatoryOptionalFalseSet->fulfilled(),
             'A mandatory set of type and with one mandatory True- and one optional FalseRequirement is not fulfilled'
         );
 
         $optionalOptionalTrueSet = new RequirementSet(true);
-        $optionalOptionalTrueSet->add(new TrueRequirement(array('optional' => true)));
+        $optionalOptionalTrueSet->add(new TrueRequirement(['optional' => true]));
         $optionalOptionalTrueSet->add(new FalseRequirement());
         $this->assertTrue(
             $optionalOptionalTrueSet->fulfilled(),
@@ -111,7 +111,7 @@ class RequirementSetTest extends BaseTestCase
 
         $optionalOptionalFalseSet = new RequirementSet(true);
         $optionalOptionalFalseSet->add(new TrueRequirement());
-        $optionalOptionalFalseSet->add(new FalseRequirement(array('optional' => true)));
+        $optionalOptionalFalseSet->add(new FalseRequirement(['optional' => true]));
         $this->assertTrue(
             $optionalOptionalFalseSet->fulfilled(),
             'A optional set of type and with one mandatory True- and one optional FalseRequirement is not fulfilled'
@@ -177,7 +177,7 @@ class RequirementSetTest extends BaseTestCase
     public function testFlatMixedRequirementsOfTypeOr()
     {
         $mandatoryOptionalTrueSet = new RequirementSet(false, RequirementSet::MODE_OR);
-        $mandatoryOptionalTrueSet->add(new TrueRequirement(array('optional' => true)));
+        $mandatoryOptionalTrueSet->add(new TrueRequirement(['optional' => true]));
         $mandatoryOptionalTrueSet->add(new FalseRequirement());
         $this->assertTrue(
             $mandatoryOptionalTrueSet->fulfilled(),
@@ -186,14 +186,14 @@ class RequirementSetTest extends BaseTestCase
 
         $mandatoryOptionalFalseSet = new RequirementSet(false, RequirementSet::MODE_OR);
         $mandatoryOptionalFalseSet->add(new TrueRequirement());
-        $mandatoryOptionalFalseSet->add(new FalseRequirement(array('optional' => true)));
+        $mandatoryOptionalFalseSet->add(new FalseRequirement(['optional' => true]));
         $this->assertTrue(
             $mandatoryOptionalFalseSet->fulfilled(),
             'A mandatory set of type or with one mandatory True- and one optional FalseRequirement is not fulfilled'
         );
 
         $optionalOptionalTrueSet = new RequirementSet(true, RequirementSet::MODE_OR);
-        $optionalOptionalTrueSet->add(new TrueRequirement(array('optional' => true)));
+        $optionalOptionalTrueSet->add(new TrueRequirement(['optional' => true]));
         $optionalOptionalTrueSet->add(new FalseRequirement());
         $this->assertTrue(
             $optionalOptionalTrueSet->fulfilled(),
@@ -202,7 +202,7 @@ class RequirementSetTest extends BaseTestCase
 
         $optionalOptionalFalseSet = new RequirementSet(true, RequirementSet::MODE_OR);
         $optionalOptionalFalseSet->add(new TrueRequirement());
-        $optionalOptionalFalseSet->add(new FalseRequirement(array('optional' => true)));
+        $optionalOptionalFalseSet->add(new FalseRequirement(['optional' => true]));
         $this->assertTrue(
             $optionalOptionalFalseSet->fulfilled(),
             'A optional set of type or with one mandatory True- and one optional FalseRequirement is not fulfilled'
@@ -276,19 +276,19 @@ class RequirementSetTest extends BaseTestCase
         $mandatoryMandatoryTrueSet = new RequirementSet();
         $mandatoryMandatoryTrueSet->add(new TrueRequirement());
         $mandatoryOptionalTrueSet = new RequirementSet();
-        $mandatoryOptionalTrueSet->add(new TrueRequirement(array('optional' => true)));
+        $mandatoryOptionalTrueSet->add(new TrueRequirement(['optional' => true]));
         $mandatoryMandatoryFalseSet = new RequirementSet();
         $mandatoryMandatoryFalseSet->add(new FalseRequirement());
         $mandatoryOptionalFalseSet = new RequirementSet();
-        $mandatoryOptionalFalseSet->add(new FalseRequirement(array('optional' => true)));
+        $mandatoryOptionalFalseSet->add(new FalseRequirement(['optional' => true]));
         $optionalMandatoryTrueSet = new RequirementSet(true);
         $optionalMandatoryTrueSet->add(new TrueRequirement());
         $optionalOptionalTrueSet = new RequirementSet(true);
-        $optionalOptionalTrueSet->add(new TrueRequirement(array('optional' => true)));
+        $optionalOptionalTrueSet->add(new TrueRequirement(['optional' => true]));
         $optionalMandatoryFalseSet = new RequirementSet(true);
         $optionalMandatoryFalseSet->add(new FalseRequirement());
         $optionalOptionalFalseSet = new RequirementSet(true);
-        $optionalOptionalFalseSet->add(new FalseRequirement(array('optional' => true)));
+        $optionalOptionalFalseSet->add(new FalseRequirement(['optional' => true]));
 
         $mandatoryMandatoryOptionalTrueSet = new RequirementSet();
         $mandatoryMandatoryOptionalTrueSet->merge($mandatoryOptionalTrueSet);
@@ -394,19 +394,19 @@ class RequirementSetTest extends BaseTestCase
         $mandatoryMandatoryTrueSet = new RequirementSet(false, RequirementSet::MODE_OR);
         $mandatoryMandatoryTrueSet->add(new TrueRequirement());
         $mandatoryOptionalTrueSet = new RequirementSet(false, RequirementSet::MODE_OR);
-        $mandatoryOptionalTrueSet->add(new TrueRequirement(array('optional' => true)));
+        $mandatoryOptionalTrueSet->add(new TrueRequirement(['optional' => true]));
         $mandatoryMandatoryFalseSet = new RequirementSet(false, RequirementSet::MODE_OR);
         $mandatoryMandatoryFalseSet->add(new FalseRequirement());
         $mandatoryOptionalFalseSet = new RequirementSet(false, RequirementSet::MODE_OR);
-        $mandatoryOptionalFalseSet->add(new FalseRequirement(array('optional' => true)));
+        $mandatoryOptionalFalseSet->add(new FalseRequirement(['optional' => true]));
         $optionalMandatoryTrueSet = new RequirementSet(true, RequirementSet::MODE_OR);
         $optionalMandatoryTrueSet->add(new TrueRequirement());
         $optionalOptionalTrueSet = new RequirementSet(true, RequirementSet::MODE_OR);
-        $optionalOptionalTrueSet->add(new TrueRequirement(array('optional' => true)));
+        $optionalOptionalTrueSet->add(new TrueRequirement(['optional' => true]));
         $optionalMandatoryFalseSet = new RequirementSet(true, RequirementSet::MODE_OR);
         $optionalMandatoryFalseSet->add(new FalseRequirement());
         $optionalOptionalFalseSet = new RequirementSet(true, RequirementSet::MODE_OR);
-        $optionalOptionalFalseSet->add(new FalseRequirement(array('optional' => true)));
+        $optionalOptionalFalseSet->add(new FalseRequirement(['optional' => true]));
 
         $mandatoryMandatoryOptionalTrueSet = new RequirementSet(false, RequirementSet::MODE_OR);
         $mandatoryMandatoryOptionalTrueSet->merge($mandatoryOptionalTrueSet);

--- a/modules/translation/application/clicommands/TestCommand.php
+++ b/modules/translation/application/clicommands/TestCommand.php
@@ -18,7 +18,7 @@ use ipl\I18n\StaticTranslator;
  */
 class TestCommand extends TranslationCommand
 {
-    protected $locales = array();
+    protected $locales = [];
 
     /**
      * Get translation examples for DateFormatter
@@ -41,8 +41,8 @@ class TestCommand extends TranslationCommand
         /** @uses DateFormatter::timeAgo */
         $this->printTable($this->getMultiTranslated(
             'Time Ago',
-            array('Icinga\Date\DateFormatter', 'timeAgo'),
-            array(
+            ['Icinga\Date\DateFormatter', 'timeAgo'],
+            [
                 "15 sec" => $time - 15,
                 "62 sec" => $time - 62,
                 "10 min" => $time - 600,
@@ -50,13 +50,13 @@ class TestCommand extends TranslationCommand
                 "3h"     => $time - 3 * 3600,
                 "25h"    => $time - 25 * 3600,
                 "31d"    => $time - 31 * 24 * 3600,
-            )
+            ]
         ));
 
         $this->printTable($this->getMultiTranslated(
             'Time Since',
-            array('Icinga\Date\DateFormatter', 'timeSince'),
-            array(
+            ['Icinga\Date\DateFormatter', 'timeSince'],
+            [
                 "15 sec" => $time - 15,
                 "62 sec" => $time - 62,
                 "10 min" => $time - 600,
@@ -64,13 +64,13 @@ class TestCommand extends TranslationCommand
                 "3h"     => $time - 3 * 3600,
                 "25h"    => $time - 25 * 3600,
                 "31d"    => $time - 31 * 24 * 3600,
-            )
+            ]
         ));
 
         $this->printTable($this->getMultiTranslated(
             'Time Until',
-            array('Icinga\Date\DateFormatter', 'timeUntil'),
-            array(
+            ['Icinga\Date\DateFormatter', 'timeUntil'],
+            [
                 "15 sec" => $time + 15,
                 "62 sec" => $time + 62,
                 "10 min" => $time + 600,
@@ -78,7 +78,7 @@ class TestCommand extends TranslationCommand
                 "3h"     => $time + 3 * 3600,
                 "25h"    => $time + 25 * 3600,
                 "31d"    => $time + 31 * 24 * 3600,
-            )
+            ]
         ));
     }
 
@@ -115,13 +115,13 @@ class TestCommand extends TranslationCommand
         }
         array_unshift($locales, 'C');
 
-        $rows = array();
+        $rows = [];
 
         foreach ($arguments as $k => $args) {
-            $row = array($name => $k);
+            $row = [$name => $k];
 
             if (! is_array($args)) {
-                $args = array($args);
+                $args = [$args];
             }
             foreach ($locales as $locale) {
                 $row[$locale] = $this->callTranslated($callback, $args, $locale);

--- a/modules/translation/library/Translation/Cli/ArrayToTextTableHelper.php
+++ b/modules/translation/library/Translation/Cli/ArrayToTextTableHelper.php
@@ -23,17 +23,17 @@ class ArrayToTextTableHelper
     /**
      * @var int The column width settings
      */
-    protected $cs = array();
+    protected $cs = [];
 
     /**
      * @var int The Row lines settings
      */
-    protected $rs = array();
+    protected $rs = [];
 
     /**
      * @var int The Column index of keys
      */
-    protected $keys = array();
+    protected $keys = [];
 
     /**
      * @var int Max Column Height (returns)
@@ -59,8 +59,8 @@ class ArrayToTextTableHelper
     public function __construct($rows)
     {
         $this->rows =& $rows;
-        $this->cs = array();
-        $this->rs = array();
+        $this->cs = [];
+        $this->rs = [];
 
         if (! $xc = count($this->rows)) {
             return false;
@@ -143,7 +143,7 @@ class ArrayToTextTableHelper
 
     protected function setHeading()
     {
-        $data = array();
+        $data = [];
         foreach ($this->keys as $colKey => $value) {
             $this->setMax(false, $colKey, $value);
             $data[$colKey] = strtoupper($value);

--- a/modules/translation/library/Translation/Util/GettextTranslationHelper.php
+++ b/modules/translation/library/Translation/Util/GettextTranslationHelper.php
@@ -34,10 +34,10 @@ class GettextTranslationHelper
      *
      * @var array
      */
-    private $sourceExtensions = array(
+    private $sourceExtensions = [
         'php',
         'phtml'
-    );
+    ];
 
     /**
      * The module manager of the application's bootstrap
@@ -159,14 +159,14 @@ class GettextTranslationHelper
         $this->moduleDir = $this->moduleMgr->getModuleDir($module);
         $this->tablePath = implode(
             DIRECTORY_SEPARATOR,
-            array(
+            [
                 $this->moduleDir,
                 'application',
                 'locale',
                 $this->locale,
                 'LC_MESSAGES',
                 $module . '.po'
-            )
+            ]
         );
 
         $this->createFileCatalog();
@@ -184,14 +184,14 @@ class GettextTranslationHelper
         $this->moduleDir = $this->moduleMgr->getModuleDir($module);
         $this->tablePath = implode(
             DIRECTORY_SEPARATOR,
-            array(
+            [
                 $this->moduleDir,
                 'application',
                 'locale',
                 $this->locale,
                 'LC_MESSAGES',
                 $module . '.po'
-            )
+            ]
         );
 
         $this->compileTranslationTable();
@@ -232,7 +232,7 @@ class GettextTranslationHelper
         shell_exec(
             implode(
                 ' ',
-                array(
+                [
                     $this->getConfig()->get('translation', 'xgettext', '/usr/bin/env xgettext'),
                     '--language=PHP',
                     '--keyword=translate',
@@ -258,7 +258,7 @@ class GettextTranslationHelper
                     '--from-code=' . self::FILE_ENCODING,
                     '--files-from="' . $this->catalogPath . '"',
                     '--output="' . $this->templatePath . '"'
-                )
+                ]
             )
         );
     }
@@ -270,7 +270,7 @@ class GettextTranslationHelper
      */
     private function updateHeader($path)
     {
-        $headerInfo = array(
+        $headerInfo = [
             'title' => $this->moduleMgr->getModule($this->moduleName)->getTitle(),
             'copyright_holder' => 'TEAM NAME',
             'copyright_year' => date('Y'),
@@ -288,31 +288,31 @@ class GettextTranslationHelper
             'language_team_name' => 'LANGUAGE',
             'language_team_url' => 'LL@li.org',
             'charset' => self::FILE_ENCODING
-        );
+        ];
 
         $content = file_get_contents($path);
         if (strpos($content, '# ') === 0) {
-            $authorInfo = array();
+            $authorInfo = [];
             if (preg_match('@# (.+) <(.+)>, (\d+|YEAR)\.@', $content, $authorInfo)) {
                 $headerInfo['author_name'] = $authorInfo[1];
                 $headerInfo['author_mail'] = $authorInfo[2];
                 $headerInfo['author_year'] = $authorInfo[3];
             }
-            $revisionInfo = array();
+            $revisionInfo = [];
             if (preg_match('@Revision-Date: (\d{4}-\d{2}-\d{2} \d{2}:\d{2}\+\d{4})@', $content, $revisionInfo)) {
                 $headerInfo['po_revision_date'] = $revisionInfo[1];
             }
-            $translatorInfo = array();
+            $translatorInfo = [];
             if (preg_match('@Last-Translator: (.+) <(.+)>@', $content, $translatorInfo)) {
                 $headerInfo['translator_name'] = $translatorInfo[1];
                 $headerInfo['translator_mail'] = $translatorInfo[2];
             }
-            $languageTeamInfo = array();
+            $languageTeamInfo = [];
             if (preg_match('@Language-Team: (.+) <(.+)>@', $content, $languageTeamInfo)) {
                 $headerInfo['language_team_name'] = $languageTeamInfo[1];
                 $headerInfo['language_team_url'] = $languageTeamInfo[2];
             }
-            $languageInfo = array();
+            $languageInfo = [];
             if (preg_match('@Language: ([a-z]{2}_[A-Z]{2})@', $content, $languageInfo)) {
                 $headerInfo['language'] = $languageInfo[1];
             }
@@ -322,7 +322,7 @@ class GettextTranslationHelper
             $path,
             implode(
                 PHP_EOL,
-                array(
+                [
                     '# ' . $headerInfo['title'] . '.',
                     '# Copyright (C) ' . $headerInfo['copyright_year'] . ' ' . $headerInfo['copyright_holder'],
                     '# This file is distributed under the same license as ' . $headerInfo['project_name'] . '.',
@@ -349,7 +349,7 @@ class GettextTranslationHelper
                     '"X-Poedit-Basepath: .\n"',
                     '"X-Poedit-SearchPath-0: .\n"',
                     ''
-                )
+                ]
             ) . PHP_EOL . substr($content, strpos($content, '#: '))
         );
     }
@@ -404,7 +404,7 @@ class GettextTranslationHelper
             );
         }
 
-        $subdirs = array();
+        $subdirs = [];
         while (($filename = readdir($directoryHandle)) !== false) {
             if ($filename[0] === '.' || $filename === 'vendor') {
                 continue;
@@ -432,11 +432,11 @@ class GettextTranslationHelper
         shell_exec(
             implode(
                 ' ',
-                array(
+                [
                     $this->getConfig()->get('translation', 'msgfmt', '/usr/bin/env msgfmt'),
                     '-o ' . $targetPath,
                     $this->tablePath
-                )
+                ]
             )
         );
     }

--- a/test/php/application/forms/Config/UserBackendReorderFormTest.php
+++ b/test/php/application/forms/Config/UserBackendReorderFormTest.php
@@ -36,16 +36,16 @@ class UserBackendReorderFormTest extends BaseTestCase
     public function testMoveBackend()
     {
         $config = Config::fromArray(
-            array(
+            [
                 'test1' => '',
                 'test2' => '',
                 'test3' => ''
-            )
+            ]
         );
 
         $this->getRequestMock()->shouldReceive('getMethod')->andReturn('POST')
             ->shouldReceive('isPost')->andReturn(true)
-            ->shouldReceive('getPost')->andReturn(array('backend_newpos' => 'test3|1'));
+            ->shouldReceive('getPost')->andReturn(['backend_newpos' => 'test3|1']);
 
         $form = new UserBackendReorderFormProvidingConfigFormWithoutSave();
         $form->setIniConfig($config);
@@ -54,7 +54,7 @@ class UserBackendReorderFormTest extends BaseTestCase
         $form->handleRequest();
 
         $this->assertEquals(
-            array('test1', 'test3', 'test2'),
+            ['test1', 'test3', 'test2'],
             UserBackendConfigFormWithoutSave::$newConfig->keys(),
             'Moving elements with UserBackendReorderForm does not seem to properly work'
         );

--- a/test/php/library/Icinga/Application/ConfigTest.php
+++ b/test/php/library/Icinga/Application/ConfigTest.php
@@ -38,7 +38,7 @@ class ConfigTest extends BaseTestCase
 
     public function testWhetherConfigIsCountable()
     {
-        $config = Config::fromArray(array('a' => 'b', 'c' => array('d' => 'e')));
+        $config = Config::fromArray(['a' => 'b', 'c' => ['d' => 'e']]);
 
         $this->assertInstanceOf('Countable', $config, 'Config does not implement interface `Countable\'');
         $this->assertEquals(2, count($config), 'Config does not count sections correctly');
@@ -46,18 +46,18 @@ class ConfigTest extends BaseTestCase
 
     public function testWhetherConfigIsTraversable()
     {
-        $config = Config::fromArray(array('a' => array(), 'c' => array()));
+        $config = Config::fromArray(['a' => [], 'c' => []]);
         $config->setSection('e');
 
         $this->assertInstanceOf('Iterator', $config, 'Config does not implement interface `Iterator\'');
 
-        $actual = array();
+        $actual = [];
         foreach ($config as $key => $_) {
             $actual[] = $key;
         }
 
         $this->assertEquals(
-            array('a', 'c', 'e'),
+            ['a', 'c', 'e'],
             $actual,
             'Config does not iterate properly in the order its sections were inserted'
         );
@@ -74,10 +74,10 @@ class ConfigTest extends BaseTestCase
 
     public function testWhetherItIsPossibleToRetrieveAllSectionNames()
     {
-        $config = Config::fromArray(array('a' => array('b' => 'c'), 'd' => array('e' => 'f')));
+        $config = Config::fromArray(['a' => ['b' => 'c'], 'd' => ['e' => 'f']]);
 
         $this->assertEquals(
-            array('a', 'd'),
+            ['a', 'd'],
             $config->keys(),
             'Config::keys does not list section names correctly'
         );
@@ -85,10 +85,10 @@ class ConfigTest extends BaseTestCase
 
     public function testWhetherConfigCanBeConvertedToAnArray()
     {
-        $config = Config::fromArray(array('a' => 'b', 'c' => array('d' => 'e')));
+        $config = Config::fromArray(['a' => 'b', 'c' => ['d' => 'e']]);
 
         $this->assertEquals(
-            array('a' => 'b', 'c' => array('d' => 'e')),
+            ['a' => 'b', 'c' => ['d' => 'e']],
             $config->toArray(),
             'Config::toArray does not return the correct array'
         );
@@ -96,7 +96,7 @@ class ConfigTest extends BaseTestCase
 
     public function testWhetherItIsPossibleToDirectlyRetrieveASectionProperty()
     {
-        $config = Config::fromArray(array('a' => array('b' => 'c')));
+        $config = Config::fromArray(['a' => ['b' => 'c']]);
 
         $this->assertEquals(
             'c',
@@ -125,7 +125,7 @@ class ConfigTest extends BaseTestCase
 
     public function testWhetherConfigReturnsSingleSections()
     {
-        $config = Config::fromArray(array('a' => array('b' => 'c')));
+        $config = Config::fromArray(['a' => ['b' => 'c']]);
 
         $this->assertInstanceOf(
             'Icinga\Data\ConfigObject',
@@ -140,7 +140,7 @@ class ConfigTest extends BaseTestCase
     public function testWhetherConfigSetsSingleSections()
     {
         $config = new Config();
-        $config->setSection('a', array('b' => 'c'));
+        $config->setSection('a', ['b' => 'c']);
 
         $this->assertInstanceOf(
             'Icinga\Data\ConfigObject',
@@ -148,7 +148,7 @@ class ConfigTest extends BaseTestCase
             'Config::setSection does not set a new section'
         );
 
-        $config->setSection('a', array('bb' => 'cc'));
+        $config->setSection('a', ['bb' => 'cc']);
 
         $this->assertNull(
             $config->getSection('a')->b,
@@ -166,7 +166,7 @@ class ConfigTest extends BaseTestCase
      */
     public function testWhetherConfigRemovesSingleSections()
     {
-        $config = Config::fromArray(array('a' => array('b' => 'c'), 'd' => array('e' => 'f')));
+        $config = Config::fromArray(['a' => ['b' => 'c'], 'd' => ['e' => 'f']]);
         $config->removeSection('a');
 
         $this->assertEquals(
@@ -198,7 +198,7 @@ class ConfigTest extends BaseTestCase
     {
         $this->expectException(\UnexpectedValueException::class);
 
-        $config = Config::fromArray(array('a' => 'b'));
+        $config = Config::fromArray(['a' => 'b']);
         $config->get('a', 'b');
     }
 
@@ -220,17 +220,17 @@ class ConfigTest extends BaseTestCase
         $config = Config::fromIni(Config::resolvePath('config.ini'));
 
         $this->assertEquals(
-            array(
-                'logging' => array(
+            [
+                'logging' => [
                     'enable'    => 1
-                ),
-                'backend' => array(
+                ],
+                'backend' => [
                     'type'      => 'db',
                     'user'      => 'user',
                     'password'  => 'password',
                     'disable'   => 1
-                )
-            ),
+                ]
+            ],
             $config->toArray(),
             'Config::fromIni does not load INI files correctly'
         );
@@ -257,17 +257,17 @@ class ConfigTest extends BaseTestCase
         $config = Config::app('config', true);
 
         $this->assertEquals(
-            array(
-                'logging' => array(
+            [
+                'logging' => [
                     'enable'    => 1
-                ),
-                'backend' => array(
+                ],
+                'backend' => [
                     'type'      => 'db',
                     'user'      => 'user',
                     'password'  => 'password',
                     'disable'   => 1
-                )
-            ),
+                ]
+            ],
             $config->toArray(),
             'Config::app does not load INI files correctly'
         );
@@ -281,11 +281,11 @@ class ConfigTest extends BaseTestCase
         $config = Config::module('amodule');
 
         $this->assertEquals(
-            array(
-                'menu' => array(
+            [
+                'menu' => [
                     'breadcrumb' => 1
-                )
-            ),
+                ]
+            ],
             $config->toArray(),
             'Config::module does not load INI files correctly'
         );

--- a/test/php/library/Icinga/Chart/GraphChartTest.php
+++ b/test/php/library/Icinga/Chart/GraphChartTest.php
@@ -16,11 +16,11 @@ class GraphChartTest extends BaseTestCase
     {
         $chart = new GridChart();
         $chart->drawBars(
-            array(
+            [
                 'label' => 'My bar',
                 'color' => 'black',
-                'data'  => array(array(0, 0), array(1,1), array(1,2))
-            )
+                'data'  => [[0, 0], [1,1], [1,2]]
+            ]
         );
         $doc = new DOMDocument();
         $doc->preserveWhiteSpace = false;
@@ -35,11 +35,11 @@ class GraphChartTest extends BaseTestCase
     {
         $chart = new GridChart();
         $chart->drawLines(
-            array(
+            [
                 'label' => 'My bar',
                 'color' => 'black',
-                'data'  => array(array(0, 0), array(1,1), array(1,2))
-            )
+                'data'  => [[0, 0], [1,1], [1,2]]
+            ]
         );
         $doc = new DOMDocument();
         $doc->preserveWhiteSpace = false;

--- a/test/php/library/Icinga/Chart/PieChartTest.php
+++ b/test/php/library/Icinga/Chart/PieChartTest.php
@@ -16,11 +16,11 @@ class PieChartTest extends BaseTestCase
     {
         $chart = new PieChart();
         $chart->drawPie(
-            array(
+            [
                 'label' => 'My bar',
                 'color' => 'black', 'green', 'red',
-                'data'  => array(50,50,50)
-            )
+                'data'  => [50,50,50]
+            ]
         );
         $doc = new DOMDocument();
         $doc->preserveWhiteSpace = false;

--- a/test/php/library/Icinga/Data/ConfigObjectTest.php
+++ b/test/php/library/Icinga/Data/ConfigObjectTest.php
@@ -12,18 +12,18 @@ class ConfigObjectTest extends BaseTestCase
 {
     public function testWhetherInitializingAConfigWithAssociativeArraysCreatesHierarchicalConfigObjects()
     {
-        $config = new ConfigObject(array(
+        $config = new ConfigObject([
             'a' => 'b',
             'c' => 'd',
-            'e' => array(
+            'e' => [
                 'f' => 'g',
                 'h' => 'i',
-                'j' => array(
+                'j' => [
                     'k' => 'l',
                     'm' => 'n'
-                )
-            )
-        ));
+                ]
+            ]
+        ]);
 
         $this->assertInstanceOf(
             get_class($config),
@@ -42,12 +42,12 @@ class ConfigObjectTest extends BaseTestCase
      */
     public function testWhetherItIsPossibleToCloneConfigObjects()
     {
-        $config = new ConfigObject(array(
+        $config = new ConfigObject([
             'a' => 'b',
-            'c' => array(
+            'c' => [
                 'd' => 'e'
-            )
-        ));
+            ]
+        ]);
         $newConfig = clone $config;
 
         $this->assertNotSame(
@@ -64,18 +64,18 @@ class ConfigObjectTest extends BaseTestCase
 
     public function testWhetherConfigObjectsAreTraversable()
     {
-        $config = new ConfigObject(array('a' => 'b', 'c' => 'd'));
+        $config = new ConfigObject(['a' => 'b', 'c' => 'd']);
         $config->e = 'f';
 
         $this->assertInstanceOf('Iterator', $config, 'ConfigObject objects do not implement interface `Iterator\'');
 
-        $actual = array();
+        $actual = [];
         foreach ($config as $key => $value) {
             $actual[$key] = $value;
         }
 
         $this->assertEquals(
-            array('a' => 'b', 'c' => 'd', 'e' => 'f'),
+            ['a' => 'b', 'c' => 'd', 'e' => 'f'],
             $actual,
             'ConfigObject objects do not iterate properly in the order their values were inserted'
         );
@@ -83,7 +83,7 @@ class ConfigObjectTest extends BaseTestCase
 
     public function testWhetherOneCanCheckWhetherConfigObjectsHaveACertainPropertyOrSection()
     {
-        $config = new ConfigObject(array('a' => 'b', 'c' => array('d' => 'e')));
+        $config = new ConfigObject(['a' => 'b', 'c' => ['d' => 'e']]);
 
         $this->assertTrue(isset($config->a), 'ConfigObjects do not seem to implement __isset() properly');
         $this->assertTrue(isset($config->c->d), 'ConfigObjects do not seem to implement __isset() properly');
@@ -95,7 +95,7 @@ class ConfigObjectTest extends BaseTestCase
 
     public function testWhetherItIsPossibleToAccessProperties()
     {
-        $config = new ConfigObject(array('a' => 'b', 'c' => null));
+        $config = new ConfigObject(['a' => 'b', 'c' => null]);
 
         $this->assertEquals('b', $config->a, 'ConfigObjects do not allow property access');
         $this->assertNull($config['c'], 'ConfigObjects do not allow offset access');
@@ -106,7 +106,7 @@ class ConfigObjectTest extends BaseTestCase
     {
         $config = new ConfigObject();
         $config->a = 'b';
-        $config['c'] = array('d' => 'e');
+        $config['c'] = ['d' => 'e'];
 
         $this->assertTrue(isset($config->a), 'ConfigObjects do not allow to set properties');
         $this->assertTrue(isset($config->c), 'ConfigObjects do not allow to set offsets');
@@ -127,7 +127,7 @@ class ConfigObjectTest extends BaseTestCase
 
     public function testWhetherItIsPossibleToUnsetPropertiesAndSections()
     {
-        $config = new ConfigObject(array('a' => 'b', 'c' => array('d' => 'e')));
+        $config = new ConfigObject(['a' => 'b', 'c' => ['d' => 'e']]);
         unset($config->a);
         unset($config['c']);
 
@@ -149,7 +149,7 @@ class ConfigObjectTest extends BaseTestCase
      */
     public function testWhetherItIsPossibleToRetrieveDefaultValuesForNonExistentPropertiesOrSections()
     {
-        $config = new ConfigObject(array('a' => 'b'));
+        $config = new ConfigObject(['a' => 'b']);
 
         $this->assertEquals(
             'b',
@@ -169,10 +169,10 @@ class ConfigObjectTest extends BaseTestCase
 
     public function testWhetherItIsPossibleToRetrieveAllPropertyAndSectionNames()
     {
-        $config = new ConfigObject(array('a' => 'b', 'c' => array('d' => 'e')));
+        $config = new ConfigObject(['a' => 'b', 'c' => ['d' => 'e']]);
 
         $this->assertEquals(
-            array('a', 'c'),
+            ['a', 'c'],
             $config->keys(),
             'ConfigObjects do not list property and section names correctly'
         );
@@ -180,10 +180,10 @@ class ConfigObjectTest extends BaseTestCase
 
     public function testWhetherConfigObjectsCanBeConvertedToArrays()
     {
-        $config = new ConfigObject(array('a' => 'b', 'c' => array('d' => 'e')));
+        $config = new ConfigObject(['a' => 'b', 'c' => ['d' => 'e']]);
 
         $this->assertEquals(
-            array('a' => 'b', 'c' => array('d' => 'e')),
+            ['a' => 'b', 'c' => ['d' => 'e']],
             $config->toArray(),
             'ConfigObjects cannot be correctly converted to arrays'
         );
@@ -194,18 +194,18 @@ class ConfigObjectTest extends BaseTestCase
      */
     public function testWhetherItIsPossibleToMergeConfigObjects()
     {
-        $config = new ConfigObject(array('a' => 'b'));
+        $config = new ConfigObject(['a' => 'b']);
 
-        $config->merge(array('a' => 'bb', 'c' => 'd', 'e' => array('f' => 'g')));
+        $config->merge(['a' => 'bb', 'c' => 'd', 'e' => ['f' => 'g']]);
         $this->assertEquals(
-            array('a' => 'bb', 'c' => 'd', 'e' => array('f' => 'g')),
+            ['a' => 'bb', 'c' => 'd', 'e' => ['f' => 'g']],
             $config->toArray(),
             'ConfigObjects cannot be extended with arrays'
         );
 
-        $config->merge(new ConfigObject(array('c' => array('d' => 'ee'), 'e' => array('h' => 'i'))));
+        $config->merge(new ConfigObject(['c' => ['d' => 'ee'], 'e' => ['h' => 'i']]));
         $this->assertEquals(
-            array('a' => 'bb', 'c' => array('d' => 'ee'), 'e' => array('f' => 'g', 'h' => 'i')),
+            ['a' => 'bb', 'c' => ['d' => 'ee'], 'e' => ['f' => 'g', 'h' => 'i']],
             $config->toArray(),
             'ConfigObjects cannot be extended with other ConfigObjects'
         );

--- a/test/php/library/Icinga/Data/Filter/FilterTest.php
+++ b/test/php/library/Icinga/Data/Filter/FilterTest.php
@@ -66,29 +66,29 @@ class FilterTest extends BaseTestCase
     public function setUp(): void
     {
         parent::setUp();
-        $this->sampleData = array(
-            (object) array(
+        $this->sampleData = [
+            (object) [
                 'host'    => 'localhost',
                 'problem' => '1',
                 'service' => 'ping',
                 'state'   => '2',
                 'handled' => '1'
-            ),
-            (object) array(
+            ],
+            (object) [
                 'host'    => 'localhost',
                 'problem' => '1',
                 'service' => 'www.icinga.com',
                 'state'   => '0',
                 'handled' => '0'
-            ),
-            (object) array(
+            ],
+            (object) [
                 'host'    => 'localhost',
                 'problem' => '1',
                 'service' => 'www.icinga.com',
                 'state'   => '1',
                 'handled' => '0'
-            )
-        );
+            ]
+        ];
     }
 // TODO: expect exception when filtering for invalid column
 
@@ -149,7 +149,7 @@ class FilterTest extends BaseTestCase
         $this->assertTrue(
             Filter::where(
                 'service',
-                array('nada', 'nothing', 'ping')
+                ['nada', 'nothing', 'ping']
             )->matches($this->row(0))
         );
     }
@@ -159,7 +159,7 @@ class FilterTest extends BaseTestCase
         $this->assertFalse(
             Filter::where(
                 'service',
-                array('nada', 'nothing', 'ping')
+                ['nada', 'nothing', 'ping']
             )->matches($this->row(1))
         );
     }
@@ -218,55 +218,55 @@ class FilterTest extends BaseTestCase
     {
         $columnWithWhitespaces = Filter::where(' host ', 'localhost');
         $this->assertTrue(
-            $columnWithWhitespaces->matches((object) array(
+            $columnWithWhitespaces->matches((object) [
                 'host' => 'localhost'
-            )),
+            ]),
             'Filter doesn\'t remove leading and trailing whitespaces from columns'
         );
         $expressionWithLeadingWhitespaces = Filter::where('host', ' localhost');
         $this->assertTrue(
-            $expressionWithLeadingWhitespaces->matches((object) array(
+            $expressionWithLeadingWhitespaces->matches((object) [
                 'host' => ' localhost'
-            )),
+            ]),
             'Filter doesn\'t take leading whitespaces of expressions into account'
         );
         $this->assertFalse(
-            $expressionWithLeadingWhitespaces->matches((object) array(
+            $expressionWithLeadingWhitespaces->matches((object) [
                 'host' => ' localhost '
-            )),
+            ]),
             'Filter doesn\'t take trailing whitespaces of expressions into account'
         );
         $expressionWithTrailingWhitespaces = Filter::where('host', 'localhost ');
         $this->assertTrue(
-            $expressionWithTrailingWhitespaces->matches((object) array(
+            $expressionWithTrailingWhitespaces->matches((object) [
                 'host' => 'localhost '
-            )),
+            ]),
             'Filter doesn\'t take trailing whitespaces of expressions into account'
         );
         $this->assertFalse(
-            $expressionWithTrailingWhitespaces->matches((object) array(
+            $expressionWithTrailingWhitespaces->matches((object) [
                 'host' => ' localhost '
-            )),
+            ]),
             'Filter doesn\'t take leading whitespaces of expressions into account'
         );
         $expressionWithLeadingAndTrailingWhitespaces = Filter::where('host', ' localhost ');
         $this->assertTrue(
-            $expressionWithLeadingAndTrailingWhitespaces->matches((object) array(
+            $expressionWithLeadingAndTrailingWhitespaces->matches((object) [
                 'host' => ' localhost '
-            )),
+            ]),
             'Filter doesn\'t take leading and trailing whitespaces of expressions into account'
         );
         $this->assertFalse(
-            $expressionWithLeadingAndTrailingWhitespaces->matches((object) array(
+            $expressionWithLeadingAndTrailingWhitespaces->matches((object) [
                 'host' => ' localhost  '
-            )),
+            ]),
             'Filter doesn\'t take leading and trailing whitespaces of expressions into account'
         );
         $queryStringWithWhitespaces = Filter::fromQueryString(' host = localhost ');
         $this->assertTrue(
-            $queryStringWithWhitespaces->matches((object) array(
+            $queryStringWithWhitespaces->matches((object) [
                 'host' => ' localhost '
-            )),
+            ]),
             'Filter doesn\'t take leading and trailing whitespaces of expressions in query strings into account'
         );
     }

--- a/test/php/library/Icinga/File/CsvTest.php
+++ b/test/php/library/Icinga/File/CsvTest.php
@@ -13,21 +13,21 @@ class CsvTest extends BaseTestCase
 {
     public function testWhetherValidCsvIsRendered()
     {
-        $data = new ArrayDatasource(array(
-            array('col1' => 'val1', 'col2' => 'val2', 'col3' => 'val3', 'col4' => 'val4'),
-            array('col1' => 'val5', 'col2' => 'val6', 'col3' => 'val7', 'col4' => 'val8')
-        ));
+        $data = new ArrayDatasource([
+            ['col1' => 'val1', 'col2' => 'val2', 'col3' => 'val3', 'col4' => 'val4'],
+            ['col1' => 'val5', 'col2' => 'val6', 'col3' => 'val7', 'col4' => 'val8']
+        ]);
 
         $csv = Csv::fromQuery($data->select());
 
         $this->assertEquals(
             implode(
                 "\r\n",
-                array(
+                [
                     'col1,col2,col3,col4',
                     '"val1","val2","val3","val4"',
                     '"val5","val6","val7","val8"'
-                )
+                ]
             ) . "\r\n",
             (string) $csv,
             'Csv does not render valid/correct csv structured data'

--- a/test/php/library/Icinga/File/Ini/IniWriterTest.php
+++ b/test/php/library/Icinga/File/Ini/IniWriterTest.php
@@ -34,14 +34,14 @@ class IniWriterTest extends BaseTestCase
     {
         $writer = new IniWriter(
             Config::fromArray(
-                array(
-                    'section' => array(
+                [
+                    'section' => [
                         'foo.bar' => 1337
-                    ),
-                    'section.with.multiple.dots' => array(
+                    ],
+                    'section.with.multiple.dots' => [
                         'some more.nested stuff' => 'With more values'
-                    )
-                )
+                    ]
+                ]
             ),
             $this->tempFile
         );
@@ -53,7 +53,7 @@ class IniWriterTest extends BaseTestCase
     public function testWhetherNestedPropertiesAreInserted()
     {
         $target = $this->writeConfigToTemporaryFile('');
-        $config = Config::fromArray(array('a' => array('b' => 'c')));
+        $config = Config::fromArray(['a' => ['b' => 'c']]);
         $writer = new IniWriter($config, $target);
         $writer->write();
 
@@ -102,20 +102,20 @@ EOD;
         $target = $this->writeConfigToTemporaryFile($config);
         $writer = new IniWriter(
             Config::fromArray(
-                array(
-                    'three' => array(
+                [
+                    'three' => [
                         'foo.bar' => 'raboof',
                         'key' => 'value'
-                    ),
-                    'two' => array(
+                    ],
+                    'two' => [
                         'd.e' => 'f',
                         'a.b' => 'c'
-                    ),
-                    'one' => array(
+                    ],
+                    'one' => [
                         'key2' => '2',
                         'key1' => '1'
-                    )
-                )
+                    ]
+                ]
             ),
             $target
         );
@@ -147,10 +147,10 @@ EOD;
         $target = $this->writeConfigToTemporaryFile($config);
         $writer = new IniWriter(
             Config::fromArray(
-                array(
-                    'two' => array(),
-                    'one' => array()
-                )
+                [
+                    'two' => [],
+                    'one' => []
+                ]
             ),
             $target
         );
@@ -174,7 +174,7 @@ key = "value"
 ; boring comment
 EOD;
         $target = $this->writeConfigToTemporaryFile($config);
-        $writer = new IniWriter(Config::fromArray(array('blarg' => array('key' => 'value'))), $target);
+        $writer = new IniWriter(Config::fromArray(['blarg' => ['key' => 'value']]), $target);
 
         $this->assertEquals(
             trim($config),
@@ -195,12 +195,12 @@ EOD;
         $target = $this->writeConfigToTemporaryFile($config);
         $writer = new IniWriter(
             Config::fromArray(
-                array('blarg' => array(
+                ['blarg' => [
                     'foo' => 1337,
                     'bar' => 7331,
                     'key' => 'value',
                     'xxl' => 'very loooooooooooooooooooooong'
-                ))
+                ]]
             ),
             $target
         );
@@ -219,7 +219,7 @@ EOD;
 key = "value"
 EOD;
         $target = $this->writeConfigToTemporaryFile($config);
-        $writer = new IniWriter(Config::fromArray(array('section' => array('key' => 'value'))), $target);
+        $writer = new IniWriter(Config::fromArray(['section' => ['key' => 'value']]), $target);
 
         $this->assertEquals(
             trim($config),
@@ -240,14 +240,14 @@ EOD;
         $target = $this->writeConfigToTemporaryFile($config);
         $writer = new IniWriter(
             Config::fromArray(
-                array(
-                    'section' => array(
+                [
+                    'section' => [
                         'foo' => 1337,
                         'bar' => 7331,
                         'key' => 'value',
                         'xxl' => 'very loooooooooooooooooooooong'
-                    )
-                )
+                    ]
+                ]
             ),
             $target
         );
@@ -264,14 +264,14 @@ EOD;
         $target = $this->writeConfigToTemporaryFile('');
         $writer = new IniWriter(
             Config::fromArray(
-                array(
-                    'section' => array(
+                [
+                    'section' => [
                         'foo' => 'linebreak
 in line',
                         'linebreak
 inkey' => 'blarg'
-                    )
-                )
+                    ]
+                ]
             ),
             $target
         );
@@ -307,12 +307,12 @@ EOD;
         $target = $this->writeConfigToTemporaryFile($config);
         $writer = new IniWriter(
             Config::fromArray(
-                array(
-                    'section ;comment' => array('foo' => 'bar'),
-                    'section "quotes"' => array('foo' => 'bar'),
-                    'section with \\' => array('foo' => 'bar'),
-                    'section with' . PHP_EOL . 'newline' => array('foo' => 'bar')
-                )
+                [
+                    'section ;comment' => ['foo' => 'bar'],
+                    'section "quotes"' => ['foo' => 'bar'],
+                    'section with \\' => ['foo' => 'bar'],
+                    'section with' . PHP_EOL . 'newline' => ['foo' => 'bar']
+                ]
             ),
             $target
         );
@@ -343,12 +343,12 @@ EOD;
         $target = $this->writeConfigToTemporaryFile($config);
         $writer = new IniWriter(
             Config::fromArray(
-                array(
-                    'section' => array(
+                [
+                    'section' => [
                         'key1' => 'value with "quotes"',
                         'key2' => 'value with \\'
-                    )
-                )
+                    ]
+                ]
             ),
             $target
         );
@@ -385,10 +385,10 @@ EOD;
 
         $target = $this->writeConfigToTemporaryFile($config);
         $writer = new IniWriter(
-            Config::fromArray(array(
-                'section 1' => array('guarg' => 1),
-                'section 3' => array('guard' => 2)
-            )),
+            Config::fromArray([
+                'section 1' => ['guarg' => 1],
+                'section 3' => ['guard' => 2]
+            ]),
             $target
         );
 
@@ -414,7 +414,7 @@ EOD;
 
     public function testWhetherNullValuesGetPersisted()
     {
-        $config = Config::fromArray(array());
+        $config = Config::fromArray([]);
         $section = $config->getSection('garbage');
         $section->foobar = null;
         $config->setSection('garbage', $section);
@@ -429,7 +429,7 @@ EOD;
 
     public function testWhetherEmptyValuesGetPersisted()
     {
-        $config = Config::fromArray(array());
+        $config = Config::fromArray([]);
         $section = $config->getSection('garbage');
         $section->foobar = '';
         $config->setSection('garbage', $section);
@@ -445,7 +445,7 @@ EOD;
     public function testExplicitRemove()
     {
         $filename = tempnam(sys_get_temp_dir(), 'iw2');
-        $config = Config::fromArray(array('garbage' => array('foobar' => 'lolcat')));
+        $config = Config::fromArray(['garbage' => ['foobar' => 'lolcat']]);
         $iniWriter = new IniWriter($config, $filename);
         $iniWriter->write();
 

--- a/test/php/library/Icinga/Logger/Writer/StreamWriterTest.php
+++ b/test/php/library/Icinga/Logger/Writer/StreamWriterTest.php
@@ -28,7 +28,7 @@ class StreamWriterTest extends BaseTestCase
 
     public function testWhetherStreamWriterCreatesMissingFiles()
     {
-        new FileWriter(new ConfigObject(array('file' => $this->target)));
+        new FileWriter(new ConfigObject(['file' => $this->target]));
         $this->assertFileExists($this->target, 'StreamWriter does not create missing files on initialization');
     }
 
@@ -37,7 +37,7 @@ class StreamWriterTest extends BaseTestCase
      */
     public function testWhetherStreamWriterWritesMessages()
     {
-        $writer = new FileWriter(new ConfigObject(array('file' => $this->target)));
+        $writer = new FileWriter(new ConfigObject(['file' => $this->target]));
         $writer->log(Logger::ERROR, 'This is a test error');
         $log = file_get_contents($this->target);
         $this->assertStringContainsString('This is a test error', $log, 'StreamWriter does not write log messages');

--- a/test/php/library/Icinga/Protocol/Ldap/LdapUtilsTest.php
+++ b/test/php/library/Icinga/Protocol/Ldap/LdapUtilsTest.php
@@ -10,7 +10,7 @@ use Icinga\Test\BaseTestCase;
 
 class LdapUtilsTest extends BaseTestCase
 {
-    protected static $validDn = array(
+    protected static $validDn = [
         'dc=example,dc=com',
         'dc=example, dc=com',
         'dc = example , dc = com',
@@ -18,14 +18,14 @@ class LdapUtilsTest extends BaseTestCase
         '0.9.2342.19200300.100.1.25=Example,0.9.2342.19200300.100.1.25=Com',
         'CN=host,OU=Datacenter Servers,DC=example,DC=com',
         'CN=Doe\, John,OU=Admin Users,DC=example,DC=com'
-    );
+    ];
 
-    protected static $invalidDn = array(
+    protected static $invalidDn = [
         'testuser',
         'heinzimüller',
         'test.user@example.com',
         'test,user@example.com',
-    );
+    ];
 
     public function testIsDnForValidValues()
     {

--- a/test/php/library/Icinga/Protocol/Ldap/QueryTest.php
+++ b/test/php/library/Icinga/Protocol/Ldap/QueryTest.php
@@ -14,12 +14,12 @@ class QueryTest extends BaseTestCase
     private function emptySelect()
     {
         $config = new ConfigObject(
-            array(
+            [
                 'hostname' => 'localhost',
                 'root_dn'  => 'dc=example,dc=com',
                 'bind_dn'  => 'cn=user,ou=users,dc=example,dc=com',
                 'bind_pw'  => '***'
-            )
+            ]
         );
 
         $connection = new LdapConnection($config);
@@ -29,7 +29,7 @@ class QueryTest extends BaseTestCase
     private function prepareSelect()
     {
         $select = $this->emptySelect();
-        $select->from('dummyClass', array('testIntColumn', 'testStringColumn'))
+        $select->from('dummyClass', ['testIntColumn', 'testStringColumn'])
             ->where('testIntColumn', 1)
             ->where('testStringColumn', 'test')
             ->where('testWildcard', 'abc*')

--- a/test/php/library/Icinga/Test/BaseTestCaseTest.php
+++ b/test/php/library/Icinga/Test/BaseTestCaseTest.php
@@ -145,7 +145,7 @@ class BaseTestCaseTest extends BaseTestCase
 
     protected function dbAdapterSqlLoadTable($resource)
     {
-        $sqlContent = array();
+        $sqlContent = [];
         $sqlContent[] = 'CREATE TABLE dummyData(value VARCHAR(50) NOT NULL PRIMARY KEY);';
         for ($i=0; $i<20; $i++) {
             $sqlContent[] = 'INSERT INTO dummyData VALUES(\'' . uniqid(). '\');';

--- a/test/php/library/Icinga/User/PreferencesTest.php
+++ b/test/php/library/Icinga/User/PreferencesTest.php
@@ -21,7 +21,7 @@ class PreferencesTest extends BaseTestCase
 
     public function testWhetherPreferencesCanBeAccessed()
     {
-        $prefs = new Preferences(array('key' => 'value'));
+        $prefs = new Preferences(['key' => 'value']);
 
         $this->assertTrue($prefs->has('key'));
         $this->assertEquals('value', $prefs->get('key'));
@@ -29,7 +29,7 @@ class PreferencesTest extends BaseTestCase
 
     public function testWhetherPreferencesCanBeRemoved()
     {
-        $prefs = new Preferences(array('key' => 'value'));
+        $prefs = new Preferences(['key' => 'value']);
 
         unset($prefs->key);
         $this->assertFalse(isset($prefs->key));
@@ -41,19 +41,19 @@ class PreferencesTest extends BaseTestCase
 
     public function testWhetherPreferencesAreCountable()
     {
-        $prefs = new Preferences(array('key1' => '1', 'key2' => '2'));
+        $prefs = new Preferences(['key1' => '1', 'key2' => '2']);
 
         $this->assertEquals(2, count($prefs));
     }
 
     public function testWhetherGetValueReturnsExpectedValue()
     {
-        $prefs = new Preferences(array(
-            'test' => array (
+        $prefs = new Preferences([
+            'test' => [
                 'key1' => '1',
                 'key2' => '2',
-            )
-        ));
+            ]
+        ]);
 
         $result = $prefs->getValue('test', 'key2');
 

--- a/test/php/library/Icinga/User/Store/PreferencesStoreTest.php
+++ b/test/php/library/Icinga/User/Store/PreferencesStoreTest.php
@@ -13,9 +13,9 @@ use Icinga\Test\BaseTestCase;
 
 class DatabaseMock
 {
-    public $insertions = array();
-    public $deletions = array();
-    public $updates = array();
+    public $insertions = [];
+    public $deletions = [];
+    public $updates = [];
 
     public function quoteIdentifier($ident)
     {
@@ -76,7 +76,7 @@ class PreferencesStoreTest extends BaseTestCase
         $store->save(
             Mockery::mock(
                 'Icinga\User\Preferences',
-                array('toArray' => array('testsection' => array('key' => 'value')))
+                ['toArray' => ['testsection' => ['key' => 'value']]]
             )
         );
 
@@ -93,7 +93,7 @@ class PreferencesStoreTest extends BaseTestCase
         $store->save(
             Mockery::mock(
                 'Icinga\User\Preferences',
-                array('toArray' => array('testsection' => array('key' => 'value')))
+                ['toArray' => ['testsection' => ['key' => 'value']]]
             )
         );
     }
@@ -102,11 +102,11 @@ class PreferencesStoreTest extends BaseTestCase
     {
         $dbMock = new DatabaseMock();
         $store = $this->getStore($dbMock);
-        $store->setPreferences(array('testsection' => array('key' => 'value')));
+        $store->setPreferences(['testsection' => ['key' => 'value']]);
         $store->save(
             Mockery::mock(
                 'Icinga\User\Preferences',
-                array('toArray' => array('testsection' => array('key' => 'eulav')))
+                ['toArray' => ['testsection' => ['key' => 'eulav']]]
             )
         );
 
@@ -120,11 +120,11 @@ class PreferencesStoreTest extends BaseTestCase
         $this->expectException(\Icinga\Exception\NotWritableError::class);
 
         $store = $this->getStore(new FaultyDatabaseMock());
-        $store->setPreferences(array('testsection' => array('key' => 'value')));
+        $store->setPreferences(['testsection' => ['key' => 'value']]);
         $store->save(
             Mockery::mock(
                 'Icinga\User\Preferences',
-                array('toArray' => array('testsection' => array('key' => 'eulav')))
+                ['toArray' => ['testsection' => ['key' => 'eulav']]]
             )
         );
     }
@@ -133,11 +133,11 @@ class PreferencesStoreTest extends BaseTestCase
     {
         $dbMock = new DatabaseMock();
         $store = $this->getStore($dbMock);
-        $store->setPreferences(array('testsection' => array('key' => 'value')));
+        $store->setPreferences(['testsection' => ['key' => 'value']]);
         $store->save(
             Mockery::mock(
                 'Icinga\User\Preferences',
-                array('toArray' => array('testsection' => array()))
+                ['toArray' => ['testsection' => []]]
             )
         );
 
@@ -151,11 +151,11 @@ class PreferencesStoreTest extends BaseTestCase
         $this->expectException(\Icinga\Exception\NotWritableError::class);
 
         $store = $this->getStore(new FaultyDatabaseMock());
-        $store->setPreferences(array('testsection' => array('key' => 'value')));
+        $store->setPreferences(['testsection' => ['key' => 'value']]);
         $store->save(
             Mockery::mock(
                 'Icinga\User\Preferences',
-                array('toArray' => array('testsection' => array('key' => 'foo')))
+                ['toArray' => ['testsection' => ['key' => 'foo']]]
             )
         );
     }
@@ -164,11 +164,11 @@ class PreferencesStoreTest extends BaseTestCase
     {
         return new PreferencesStoreWithSetPreferences(
             new ConfigObject(
-                array(
-                    'connection' => Mockery::mock(array('getDbAdapter' => $dbMock))
-                )
+                [
+                    'connection' => Mockery::mock(['getDbAdapter' => $dbMock])
+                ]
             ),
-            Mockery::mock('Icinga\User', array('getUsername' => 'unittest'))
+            Mockery::mock('Icinga\User', ['getUsername' => 'unittest'])
         );
     }
 }

--- a/test/php/library/Icinga/Util/ASN1Test.php
+++ b/test/php/library/Icinga/Util/ASN1Test.php
@@ -13,9 +13,9 @@ class ASN1Test extends BaseTestCase
 {
     public function testAllValidGeneralizedTimeCombinations()
     {
-        foreach (array('', '04', '0405', '0460') as $is) {
-            foreach (array('', ',7890', '.7890') as $frac) {
-                foreach (array('Z', '-07', '-0742', '+07', '+0742') as $tz) {
+        foreach (['', '04', '0405', '0460'] as $is) {
+            foreach (['', ',7890', '.7890'] as $frac) {
+                foreach (['Z', '-07', '-0742', '+07', '+0742'] as $tz) {
                     $this->assertValidGeneralizedTime("1970010203$is$frac$tz");
                 }
             }
@@ -46,7 +46,7 @@ class ASN1Test extends BaseTestCase
         $this->assertValidGeneralizedTime('19700102030460Z');
         $this->assertBadGeneralizedTime('19700102030461Z');
 
-        foreach (array('-', '+') as $sign) {
+        foreach (['-', '+'] as $sign) {
             $this->assertValidGeneralizedTime("1970010203{$sign}00");
             $this->assertValidGeneralizedTime("1970010203{$sign}23");
             $this->assertBadGeneralizedTime("1970010203{$sign}24");

--- a/test/php/library/Icinga/Util/GlobFilterTest.php
+++ b/test/php/library/Icinga/Util/GlobFilterTest.php
@@ -23,27 +23,27 @@ class GlobFilterTest extends BaseTestCase
     {
         $this->assertGlobFilterRemovesMatching(
             'host.vars.cmdb_name',
-            array(
-                'host' => array(
-                    'vars' => array(
+            [
+                'host' => [
+                    'vars' => [
                         'cmdb_name' => '',
                         'cmdb_id' => '',
-                        'legacy' => array(
+                        'legacy' => [
                             'cmdb_name' => ''
-                        )
-                    )
-                )
-            ),
-            array(
-                'host' => array(
-                    'vars' => array(
+                        ]
+                    ]
+                ]
+            ],
+            [
+                'host' => [
+                    'vars' => [
                         'cmdb_id' => '',
-                        'legacy' => array(
+                        'legacy' => [
                             'cmdb_name' => ''
-                        )
-                    )
-                )
-            )
+                        ]
+                    ]
+                ]
+            ]
         );
     }
 
@@ -51,29 +51,29 @@ class GlobFilterTest extends BaseTestCase
     {
         $this->assertGlobFilterRemovesMatching(
             'host.vars.cmdb_*',
-            array(
-                'host' => array(
-                    'vars' => array(
+            [
+                'host' => [
+                    'vars' => [
                         'cmdb_name' => '',
                         'cmdb_id' => '',
                         'cmdb_location' => '',
                         'wiki_id' => '',
-                        'legacy' => array(
+                        'legacy' => [
                             'cmdb_name' => ''
-                        )
-                    )
-                )
-            ),
-            array(
-                'host' => array(
-                    'vars' => array(
+                        ]
+                    ]
+                ]
+            ],
+            [
+                'host' => [
+                    'vars' => [
                         'wiki_id' => '',
-                        'legacy' => array(
+                        'legacy' => [
                             'cmdb_name' => ''
-                        )
-                    )
-                )
-            )
+                        ]
+                    ]
+                ]
+            ]
         );
     }
 
@@ -81,28 +81,28 @@ class GlobFilterTest extends BaseTestCase
     {
         $this->assertGlobFilterRemovesMatching(
             'host.vars.*id',
-            array(
-                'host' => array(
-                    'vars' => array(
+            [
+                'host' => [
+                    'vars' => [
                         'cmdb_name' => '',
                         'cmdb_id' => '',
                         'wiki_id' => '',
-                        'legacy' => array(
+                        'legacy' => [
                             'wiki_id' => ''
-                        )
-                    )
-                )
-            ),
-            array(
-                'host' => array(
-                    'vars' => array(
+                        ]
+                    ]
+                ]
+            ],
+            [
+                'host' => [
+                    'vars' => [
                         'cmdb_name' => '',
-                        'legacy' => array(
+                        'legacy' => [
                             'wiki_id' => ''
-                        )
-                    )
-                )
-            )
+                        ]
+                    ]
+                ]
+            ]
         );
     }
 
@@ -110,41 +110,41 @@ class GlobFilterTest extends BaseTestCase
     {
         $this->assertGlobFilterRemovesMatching(
             'host.vars.*.mysql_password',
-            array(
-                'host' => array(
-                    'vars' => array(
+            [
+                'host' => [
+                    'vars' => [
                         'cmdb_name' => '',
-                        'passwords' => array(
+                        'passwords' => [
                             'mysql_password' => '',
                             'ldap_password' => ''
-                        ),
-                        'legacy' => array(
+                        ],
+                        'legacy' => [
                             'mysql_password' => ''
-                        ),
-                        'backup' => array(
-                            'passwords' => array(
+                        ],
+                        'backup' => [
+                            'passwords' => [
                                 'mysql_password' => ''
-                            )
-                        )
-                    )
-                )
-            ),
-            array(
-                'host' => array(
-                    'vars' => array(
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+            [
+                'host' => [
+                    'vars' => [
                         'cmdb_name' => '',
-                        'passwords' => array(
+                        'passwords' => [
                             'ldap_password' => ''
-                        ),
-                        'legacy' => array(),
-                        'backup' => array(
-                            'passwords' => array(
+                        ],
+                        'legacy' => [],
+                        'backup' => [
+                            'passwords' => [
                                 'mysql_password' => ''
-                            )
-                        )
-                    )
-                )
-            )
+                            ]
+                        ]
+                    ]
+                ]
+            ]
         );
     }
 
@@ -152,45 +152,45 @@ class GlobFilterTest extends BaseTestCase
     {
         $this->assertGlobFilterRemovesMatching(
             'host.vars.*.*password',
-            array(
-                'host' => array(
-                    'vars' => array(
+            [
+                'host' => [
+                    'vars' => [
                         'cmdb_name' => '',
-                        'passwords' => array(
+                        'passwords' => [
                             'mysql_password' => '',
                             'ldap_password' => '',
                             'mongodb_password' => ''
-                        ),
-                        'legacy' => array(
+                        ],
+                        'legacy' => [
                             'cmdb_name' => '',
                             'mysql_password' => ''
-                        ),
-                        'backup' => array(
-                            'passwords' => array(
+                        ],
+                        'backup' => [
+                            'passwords' => [
                                 'mysql_password' => '',
                                 'ldap_password' => ''
-                            )
-                        )
-                    )
-                )
-            ),
-            array(
-                'host' => array(
-                    'vars' => array(
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+            [
+                'host' => [
+                    'vars' => [
                         'cmdb_name' => '',
-                        'passwords' => array(),
-                        'legacy' => array(
+                        'passwords' => [],
+                        'legacy' => [
                             'cmdb_name' => ''
-                        ),
-                        'backup' => array(
-                            'passwords' => array(
+                        ],
+                        'backup' => [
+                            'passwords' => [
                                 'mysql_password' => '',
                                 'ldap_password' => ''
-                            )
-                        )
-                    )
-                )
-            )
+                            ]
+                        ]
+                    ]
+                ]
+            ]
         );
     }
 
@@ -198,44 +198,44 @@ class GlobFilterTest extends BaseTestCase
     {
         $this->assertGlobFilterRemovesMatching(
             'host.vars.*.mysql_password,host.vars.*.ldap_password',
-            array(
-                'host' => array(
-                    'vars' => array(
+            [
+                'host' => [
+                    'vars' => [
                         'cmdb_name' => '',
-                        'passwords' => array(
+                        'passwords' => [
                             'mysql_password' => '',
                             'ldap_password' => '',
                             'mongodb_password' => ''
-                        ),
-                        'legacy' => array(
+                        ],
+                        'legacy' => [
                             'mysql_password' => ''
-                        ),
-                        'backup' => array(
-                            'passwords' => array(
+                        ],
+                        'backup' => [
+                            'passwords' => [
                                 'mysql_password' => '',
                                 'ldap_password' => ''
-                            )
-                        )
-                    )
-                )
-            ),
-            array(
-                'host' => array(
-                    'vars' => array(
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+            [
+                'host' => [
+                    'vars' => [
                         'cmdb_name' => '',
-                        'passwords' => array(
+                        'passwords' => [
                             'mongodb_password' => ''
-                        ),
-                        'legacy' => array(),
-                        'backup' => array(
-                            'passwords' => array(
+                        ],
+                        'legacy' => [],
+                        'backup' => [
+                            'passwords' => [
                                 'mysql_password' => '',
                                 'ldap_password' => ''
-                            )
-                        )
-                    )
-                )
-            )
+                            ]
+                        ]
+                    ]
+                ]
+            ]
         );
     }
 
@@ -243,39 +243,39 @@ class GlobFilterTest extends BaseTestCase
     {
         $this->assertGlobFilterRemovesMatching(
             'host.vars.**.*password',
-            array(
-                'host' => array(
-                    'vars' => array(
+            [
+                'host' => [
+                    'vars' => [
                         'cmdb_location' => '',
-                        'passwords' => array(
+                        'passwords' => [
                             'mysql_password' => '',
                             'ldap_password' => '',
                             'mongodb_password' => ''
-                        ),
-                        'legacy' => array(
+                        ],
+                        'legacy' => [
                             'mysql_password' => '',
-                        ),
-                        'backup' => array(
-                            'passwords' => array(
+                        ],
+                        'backup' => [
+                            'passwords' => [
                                 'mysql_password' => '',
                                 'ldap_password' => ''
-                            )
-                        )
-                    )
-                )
-            ),
-            array(
-                'host' => array(
-                    'vars' => array(
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+            [
+                'host' => [
+                    'vars' => [
                         'cmdb_location' => '',
-                        'passwords' => array(),
-                        'legacy' => array(),
-                        'backup' => array(
-                            'passwords' => array()
-                        )
-                    )
-                )
-            )
+                        'passwords' => [],
+                        'legacy' => [],
+                        'backup' => [
+                            'passwords' => []
+                        ]
+                    ]
+                ]
+            ]
         );
     }
 
@@ -283,45 +283,45 @@ class GlobFilterTest extends BaseTestCase
     {
         $this->assertGlobFilterRemovesMatching(
             'host.vars.**.\*password',
-            array(
-                'host' => array(
-                    'vars' => array(
+            [
+                'host' => [
+                    'vars' => [
                         'wiki_id' => '',
-                        'passwords' => array(
+                        'passwords' => [
                             'mongodb_password' => '',
                             '*password' => ''
-                        ),
-                        'legacy' => array(
+                        ],
+                        'legacy' => [
                             'mysql_password' => '',
                             '*password' => ''
-                        ),
-                        'backup' => array(
-                            'passwords' => array(
+                        ],
+                        'backup' => [
+                            'passwords' => [
                                 '*password' => '',
                                 'ldap_password' => ''
-                            )
-                        )
-                    )
-                )
-            ),
-            array(
-                'host' => array(
-                    'vars' => array(
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+            [
+                'host' => [
+                    'vars' => [
                         'wiki_id' => '',
-                        'passwords' => array(
+                        'passwords' => [
                             'mongodb_password' => ''
-                        ),
-                        'legacy' => array(
+                        ],
+                        'legacy' => [
                             'mysql_password' => ''
-                        ),
-                        'backup' => array(
-                            'passwords' => array(
+                        ],
+                        'backup' => [
+                            'passwords' => [
                                 'ldap_password' => ''
-                            )
-                        )
-                    )
-                )
-            )
+                            ]
+                        ]
+                    ]
+                ]
+            ]
         );
     }
 }

--- a/test/php/library/Icinga/Util/StringHelperTest.php
+++ b/test/php/library/Icinga/Util/StringHelperTest.php
@@ -13,7 +13,7 @@ class StringHelperTest extends BaseTestCase
     public function testWhetherTrimSplitReturnsACorrectValue()
     {
         $this->assertEquals(
-            array('one', 'two', 'three'),
+            ['one', 'two', 'three'],
             StringHelper::trimSplit(' one ,two  , three'),
             'String::trimSplit does not properly split a string and/or trim its elements'
         );
@@ -22,7 +22,7 @@ class StringHelperTest extends BaseTestCase
     public function testWhetherTrimSplitSplitsByTheGivenDelimiter()
     {
         $this->assertEquals(
-            array('one', 'two', 'three'),
+            ['one', 'two', 'three'],
             StringHelper::trimSplit('one.two.three', '.'),
             'String::trimSplit does not split a string by the given delimiter'
         );

--- a/test/php/library/Icinga/Web/ConfigFormTest.php
+++ b/test/php/library/Icinga/Web/ConfigFormTest.php
@@ -12,11 +12,11 @@ class ConfigFormTest extends BaseTestCase
 {
     public function testWhetherTransformEmptyValuesToNullHandlesValuesCorrectly()
     {
-        $values = array(
+        $values = [
             'empty_string'      => '',
             'example_string'    => 'this is a test',
-            'empty_array'       => array(),
-            'example_array'     => array('test1', 'test2'),
+            'empty_array'       => [],
+            'example_array'     => ['test1', 'test2'],
             'zero_as_int'       => 0,
             'one_as_int'        => 1,
             'zero_as_string'    => '0',
@@ -24,7 +24,7 @@ class ConfigFormTest extends BaseTestCase
             'bool_true'         => true,
             'bool_false'        => false,
             'null'              => null
-        );
+        ];
 
         $values = ConfigForm::transformEmptyValuesToNull($values);
 

--- a/test/php/library/Icinga/Web/Form/Element/DateTimePickerTest.php
+++ b/test/php/library/Icinga/Web/Form/Element/DateTimePickerTest.php
@@ -31,9 +31,9 @@ class DateTimePickerTest extends BaseTestCase
     {
         $dateTime = new DateTimePicker(
             'name',
-            array(
+            [
                 'local' => false
-            )
+            ]
         );
         $now = new DateTime();
         $this->assertTrue(

--- a/test/php/library/Icinga/Web/FormTest.php
+++ b/test/php/library/Icinga/Web/FormTest.php
@@ -67,7 +67,7 @@ class FormTest extends BaseTestCase
         $form = new Form();
         $form->setTokenDisabled();
         $form->setSubmitLabel('test');
-        $form->populate(array('btn_submit' => true));
+        $form->populate(['btn_submit' => true]);
         $form->setRequest(new PostRequest());
 
         $this->assertTrue(
@@ -181,9 +181,9 @@ class FormTest extends BaseTestCase
 
         $this->assertTrue(
             $form->wasSent(
-                array(
+                [
                     $form->getUidElementName() => $form->getElement($form->getUidElementName())->getValue()
-                )
+                ]
             ),
             'Form::wasSent() does not return true in case a the form identification value is being sent'
         );
@@ -200,7 +200,7 @@ class FormTest extends BaseTestCase
         $form->create();
 
         $this->assertFalse(
-            $form->wasSent(array()),
+            $form->wasSent([]),
             'Form::wasSent() does not return false in case no form identification element was added'
         );
     }
@@ -255,7 +255,7 @@ class FormTest extends BaseTestCase
     {
         $this->expectException(\Icinga\Exception\ProgrammingError::class);
 
-        new Form(array('onSuccess' => '_invalid_'));
+        new Form(['onSuccess' => '_invalid_']);
     }
 
     /**
@@ -266,12 +266,12 @@ class FormTest extends BaseTestCase
     public function testWhetherAClosureCanBePassedAsOnSuccessCallback()
     {
         $request = new Request();
-        $form = new Form(array(
+        $form = new Form([
             'onSuccess' => function ($form) {
                 $form->getRequest()->setParam('test', 'tset');
                 return false;
             }
-        ));
+        ]);
         $form->setTokenDisabled();
         $form->setUidDisabled();
         $form->handleRequest($request);

--- a/test/php/library/Icinga/Web/HookTest.php
+++ b/test/php/library/Icinga/Web/HookTest.php
@@ -120,6 +120,6 @@ class HookTest extends BaseTestCase
 
     public function testReturnsAnEmptyArrayWithNoRegisteredHook()
     {
-        $this->assertEquals(array(), Hook::all('not_existing'));
+        $this->assertEquals([], Hook::all('not_existing'));
     }
 }

--- a/test/php/library/Icinga/Web/Session/PhpSessionTest.php
+++ b/test/php/library/Icinga/Web/Session/PhpSessionTest.php
@@ -16,10 +16,10 @@ class PhpSessionTest extends BaseTestCase
             $this->markTestSkipped('Could not write to session directory');
         }
         return PhpSession::create(
-            array(
+            [
                 'save_path'     => '/tmp',
                 'test_session_name' => 'IcingawebUnittest'
-            )
+            ]
         );
     }
     /**
@@ -72,14 +72,14 @@ class PhpSessionTest extends BaseTestCase
         $session = $this->getSession();
         $namespace = $session->getNamespace('test');
         $namespace->set('some_key', 'some_val');
-        $namespace->set('an_array', array(1, 2, 3));
+        $namespace->set('an_array', [1, 2, 3]);
         $session->write();
         $session->clear();
         $this->assertFalse($session->hasNamespace('test'));
         $session->read();
         $namespace = $session->getNamespace('test');
         $this->assertEquals($namespace->get('some_key'), 'some_val');
-        $this->assertEquals($namespace->get('an_array'), array(1, 2, 3));
+        $this->assertEquals($namespace->get('an_array'), [1, 2, 3]);
     }
 
     /**

--- a/test/php/library/Icinga/Web/Session/SessionNamespaceTest.php
+++ b/test/php/library/Icinga/Web/Session/SessionNamespaceTest.php
@@ -28,11 +28,11 @@ class SessionNamespaceTest extends BaseTestCase
         $this->assertEquals($values['key1'], 'val1');
         $this->assertEquals($values['key2'], 'val2');
 
-        $new_values = array(
+        $new_values = [
             'key1' => 'new1',
             'key2' => 'new2',
             'key3' => 'new3'
-        );
+        ];
         $ns->setAll($new_values);
         $this->assertEquals($ns->get('key1'), 'val1');
         $this->assertEquals($ns->get('key2'), 'val2');
@@ -78,7 +78,7 @@ class SessionNamespaceTest extends BaseTestCase
     public function testIteration()
     {
         $ns = new SessionNamespace();
-        $values = array('key1' => 'val1', 'key2' => 'val2');
+        $values = ['key1' => 'val1', 'key2' => 'val2'];
         $ns->setAll($values);
         foreach ($ns as $key => $value) {
             $this->assertEquals($value, $values[$key]);
@@ -88,12 +88,12 @@ class SessionNamespaceTest extends BaseTestCase
     public function testRetrievingValuesByReferenceWorks()
     {
         $ns = new SessionNamespace();
-        $ns->array = array(1, 2);
+        $ns->array = [1, 2];
         $array = & $ns->getByRef('array');
         $array[0] = 11;
 
         $this->assertEquals(
-            array(11, 2),
+            [11, 2],
             $ns->array,
             'Values retrieved with getByRef() seem not be affected by external changes'
         );
@@ -102,12 +102,12 @@ class SessionNamespaceTest extends BaseTestCase
     public function testSettingValuesByReferenceWorks()
     {
         $ns = new SessionNamespace();
-        $array = array(1, 2);
+        $array = [1, 2];
         $ns->setByRef('array', $array);
         $array[0] = 11;
 
         $this->assertEquals(
-            array(11, 2),
+            [11, 2],
             $ns->array,
             'Values set with setByRef() seem not to receive external changes'
         );

--- a/test/php/library/Icinga/Web/UrlTest.php
+++ b/test/php/library/Icinga/Web/UrlTest.php
@@ -210,12 +210,12 @@ class UrlTest extends BaseTestCase
         /*
         // Temporarily disabled, no [] support right now
         $this->assertEquals(
-            array('1', '2', '3'),
+            ['1', '2', '3'],
             $url->getParam('param3'),
             'Url::fromPath does not properly reassemble query parameter values as sequenced values'
         );
         $this->assertEquals(
-            array('key1' => 'val1', 'key2' => 'val2'),
+            ['key1' => 'val1', 'key2' => 'val2'],
             $url->getParam('param4'),
             'Url::fromPath does not properly reassemble query parameters as associative arrays'
         );

--- a/test/php/library/Icinga/Web/UrlTest.php
+++ b/test/php/library/Icinga/Web/UrlTest.php
@@ -92,7 +92,7 @@ class UrlTest extends BaseTestCase
     {
         $this->getRequestMock()->shouldReceive('getBaseUrl')->andReturn('/path/to')
             ->shouldReceive('getPathInfo')->andReturn('my/test/url.html')
-            ->shouldReceive('getQuery')->andReturn(array('param1' => 'value1', 'param2' => 'value2'));
+            ->shouldReceive('getQuery')->andReturn(['param1' => 'value1', 'param2' => 'value2']);
 
         $url = Url::fromRequest();
         $this->assertEquals(
@@ -107,9 +107,9 @@ class UrlTest extends BaseTestCase
         $request = Mockery::mock('Icinga\Web\Request');
         $request->shouldReceive('getPathInfo')->andReturn('my/test/url.html')
             ->shouldReceive('getBaseUrl')->andReturn('/path/to')
-            ->shouldReceive('getQuery')->andReturn(array());
+            ->shouldReceive('getQuery')->andReturn([]);
 
-        $url = Url::fromRequest(array(), $request);
+        $url = Url::fromRequest([], $request);
         $this->assertEquals(
             '/path/to/my/test/url.html',
             $url->getAbsoluteUrl(),
@@ -122,9 +122,9 @@ class UrlTest extends BaseTestCase
         $request = Mockery::mock('Icinga\Web\Request');
         $request->shouldReceive('getPathInfo')->andReturn('')
             ->shouldReceive('getBaseUrl')->andReturn('/')
-            ->shouldReceive('getQuery')->andReturn(array('key1' => 'val1'));
+            ->shouldReceive('getQuery')->andReturn(['key1' => 'val1']);
 
-        $url = Url::fromRequest(array('key1' => 'newval1', 'key2' => 'val2'), $request);
+        $url = Url::fromRequest(['key1' => 'newval1', 'key2' => 'val2'], $request);
         $this->assertEquals(
             'val2',
             $url->getParam('key2', 'wrongval'),
@@ -146,7 +146,7 @@ class UrlTest extends BaseTestCase
 
     public function testWhetherFromPathAcceptsAdditionalParameters()
     {
-        $url = Url::fromPath('/my/test/url.html', array('key' => 'value'));
+        $url = Url::fromPath('/my/test/url.html', ['key' => 'value']);
 
         $this->assertEquals(
             'value',
@@ -178,8 +178,8 @@ class UrlTest extends BaseTestCase
     {
         $url = Url::fromPath(
             '/path/to/my/test/url.html',
-            array(),
-            Mockery::mock(array('getBaseUrl' => '/path/to'))
+            [],
+            Mockery::mock(['getBaseUrl' => '/path/to'])
         );
 
         $this->assertEquals(
@@ -297,7 +297,7 @@ class UrlTest extends BaseTestCase
     public function testWhetherRemoveRemovesAGivenSetOfParameters()
     {
         $url = Url::fromPath('/my/test/url.html?param=val&param2=val2&param3=val3');
-        $url->remove(array('param', 'param2'));
+        $url->remove(['param', 'param2']);
 
         $this->assertEquals(
             'val3',
@@ -322,11 +322,11 @@ class UrlTest extends BaseTestCase
     public function testWhetherGetUrlWithoutReturnsACopyOfTheUrlWithoutAGivenSetOfParameters()
     {
         $url = Url::fromPath('/my/test/url.html?param=val&param2=val2&param3=val3');
-        $url2 = $url->getUrlWithout(array('param', 'param2'));
+        $url2 = $url->getUrlWithout(['param', 'param2']);
 
         $this->assertNotSame($url, $url2, 'Url::getUrlWithout does not return a new copy of the url');
         $this->assertEquals(
-            array(array('param3', 'val3')),
+            [['param3', 'val3']],
             $url2->getParams()->toArray(),
             'Url::getUrlWithout does not remove a given set of parameters from the url'
         );
@@ -338,7 +338,7 @@ class UrlTest extends BaseTestCase
     public function testWhetherAddParamsDoesNotOverwriteExistingParameters()
     {
         $url = Url::fromPath('/my/test/url.html?param=val&param2=val2&param3=val3');
-        $url->addParams(array('param4' => 'val4', 'param3' => 'newval3'));
+        $url->addParams(['param4' => 'val4', 'param3' => 'newval3']);
 
         $this->assertEquals(
             'val4',
@@ -351,7 +351,7 @@ class UrlTest extends BaseTestCase
             'Url::addParams does not overwrite existing existing parameters'
         );
         $this->assertEquals(
-            array('val3', 'newval3'),
+            ['val3', 'newval3'],
             $url->getParams()->getValues('param3'),
             'Url::addParams does not overwrite existing existing parameters'
         );
@@ -363,7 +363,7 @@ class UrlTest extends BaseTestCase
     public function testWhetherOverwriteParamsOverwritesExistingParameters()
     {
         $url = Url::fromPath('/my/test/url.html?param=val&param2=val2&param3=val3');
-        $url->overwriteParams(array('param4' => 'val4', 'param3' => 'newval3'));
+        $url->overwriteParams(['param4' => 'val4', 'param3' => 'newval3']);
 
         $this->assertEquals(
             'val4',
@@ -380,7 +380,7 @@ class UrlTest extends BaseTestCase
     public function testWhetherEqualUrlMaches()
     {
         $url1 = '/whatever/is/here?a=b&c=d';
-        $url2 = Url::fromPath('whatever/is/here', array('a' => 'b', 'c' => 'd'));
+        $url2 = Url::fromPath('whatever/is/here', ['a' => 'b', 'c' => 'd']);
         $this->assertEquals(
             true,
             $url2->matches($url1)
@@ -390,7 +390,7 @@ class UrlTest extends BaseTestCase
     public function testWhetherDifferentUrlDoesNotMatch()
     {
         $url1 = '/whatever/is/here?a=b&d=d';
-        $url2 = Url::fromPath('whatever/is/here', array('a' => 'b', 'c' => 'd'));
+        $url2 = Url::fromPath('whatever/is/here', ['a' => 'b', 'c' => 'd']);
         $this->assertEquals(
             false,
             $url2->matches($url1)

--- a/test/php/library/Icinga/Web/Widget/DashboardTest.php
+++ b/test/php/library/Icinga/Web/Widget/DashboardTest.php
@@ -65,10 +65,10 @@ class DashboardTest extends BaseTestCase
         $dashboard->createPane('test1');
         $dashboard->createPane('test2');
 
-        $panes = array(
+        $panes = [
             new Pane('test1a'),
             new Pane('test2a')
-        );
+        ];
 
         $dashboard->mergePanes($panes);
 
@@ -84,10 +84,10 @@ class DashboardTest extends BaseTestCase
         $dashboard->createPane('test1');
         $dashboard->createPane('test2');
 
-        $panes = array(
+        $panes = [
             new Pane('test1'),
             new Pane('test3')
-        );
+        ];
 
         $dashboard->mergePanes($panes);
 
@@ -192,10 +192,10 @@ class DashboardTest extends BaseTestCase
 
         $result = $dashboard->getPaneKeyTitleArray();
 
-        $expected = array(
+        $expected = [
             'test1' => 'Test1',
             'test2' => 'Test2'
-        );
+        ];
 
         $this->assertEquals(
             $expected,

--- a/test/php/library/Icinga/Web/Widget/SearchDashboardTest.php
+++ b/test/php/library/Icinga/Web/Widget/SearchDashboardTest.php
@@ -28,7 +28,7 @@ class SearchDashboardTest extends BaseTestCase
         $this->expectException(\Zend_Controller_Action_Exception::class);
 
         $user = new User('test');
-        $user->setPermissions(array('*' => '*'));
+        $user->setPermissions(['*' => '*']);
         $dashboard = new SearchDashboard();
         $dashboard->setUser($user);
         $dashboard = $dashboard->search('pending');


### PR DESCRIPTION
Replace the outdated `array()` spelling with the more modern `[]`. This is applied throughout the whole project, also including phpdocs, tests, view scripts and core modules.