### PR TITLE
Remove dependency on pdfexport module for PDF export

### DIFF
--- a/library/Icinga/Application/Hook/PdfexportHook.php
+++ b/library/Icinga/Application/Hook/PdfexportHook.php
@@ -7,6 +7,7 @@ namespace Icinga\Application\Hook;
 
 use Icinga\Application\Hook;
 use Icinga\Application\Logger;
+use ipl\Html\ValidHtml;
 use RuntimeException;
 use Throwable;
 
@@ -44,15 +45,17 @@ abstract class PdfexportHook
     /**
      * Get whether PDF export is supported
      *
-     * @return  bool
+     * @return bool
      */
     abstract public function isSupported();
 
     /**
      * Render the specified HTML to PDF and stream it to the client
      *
-     * @param   string  $html       The HTML to render to PDF
-     * @param   string  $filename   The filename for the generated PDF
+     * @param ValidHtml $html The HTML to render to PDF
+     * @param string $filename The filename for the generated PDF
+     *
+     * @return never
      */
     abstract public function streamPdfFromHtml($html, $filename);
 

--- a/library/Icinga/Application/Hook/PdfexportHook.php
+++ b/library/Icinga/Application/Hook/PdfexportHook.php
@@ -5,11 +5,42 @@
 
 namespace Icinga\Application\Hook;
 
+use Icinga\Application\Hook;
+use Icinga\Application\Logger;
+use RuntimeException;
+use Throwable;
+
 /**
  * Base class for the PDF Export Hook
  */
 abstract class PdfexportHook
 {
+    /**
+     * Get the first hook
+     *
+     * @return static
+     */
+    public static function first()
+    {
+        if (! Hook::has('Pdfexport')) {
+            throw new RuntimeException('No PDF exporter available');
+        }
+
+        foreach (Hook::all('Pdfexport') as $exporter) {
+            try {
+                if (! $exporter->isSupported()) {
+                    continue;
+                }
+
+                return $exporter;
+            } catch (Throwable $e) {
+                Logger::error('PDF exporter reported an error during support check: %s', $e);
+            }
+        }
+
+        throw new RuntimeException('Not supported PDF exporter available');
+    }
+
     /**
      * Get whether PDF export is supported
      *

--- a/library/Icinga/Application/Hook/PdfexportHook.php
+++ b/library/Icinga/Application/Hook/PdfexportHook.php
@@ -55,4 +55,13 @@ abstract class PdfexportHook
      * @param   string  $filename   The filename for the generated PDF
      */
     abstract public function streamPdfFromHtml($html, $filename);
+
+    /**
+     * Render the specified HTML to PDF and return the PDF document as a string
+     *
+     * @param ValidHtml $html The HTML to render to PDF
+     *
+     * @return string
+     */
+    abstract public function htmlToPdf($html);
 }

--- a/library/Icinga/Common/PdfExport.php
+++ b/library/Icinga/Common/PdfExport.php
@@ -33,8 +33,8 @@ trait PdfExport
      */
     protected function sendAsPdf()
     {
-        if (! Icinga::app()->getModuleManager()->has('pdfexport')) {
-            throw new ConfigurationError('The pdfexport module is required for exports to PDF');
+        if (Hook::has('Pdfexport')) {
+            throw new ConfigurationError('A module implementing the pdfexport hook is required for exports to PDF');
         }
 
         putenv('ICINGAWEB_EXPORT_FORMAT=pdf');

--- a/library/Icinga/Common/PdfExport.php
+++ b/library/Icinga/Common/PdfExport.php
@@ -5,6 +5,8 @@
 
 namespace Icinga\Common;
 
+use Icinga\Application\Hook;
+use Icinga\Application\Hook\PdfexportHook;
 use Icinga\Application\Icinga;
 use Icinga\Date\DateFormatter;
 use Icinga\Exception\ConfigurationError;
@@ -26,7 +28,8 @@ trait PdfExport
      * Export the requested action to PDF and send it
      *
      * @return never
-     * @throws ConfigurationError If the pdfexport module is not available
+     *
+     * @throws ConfigurationError If no pdfexport module is available
      */
     protected function sendAsPdf()
     {
@@ -71,7 +74,7 @@ trait PdfExport
             $doc->getAttributes()->add('class', 'icinga-module module-' . $moduleName);
         }
 
-        \Icinga\Module\Pdfexport\ProvidedHook\Pdfexport::first()->streamPdfFromHtml($doc, sprintf(
+        PdfexportHook::first()->streamPdfFromHtml($doc, sprintf(
             '%s-%s',
             $this->view->title ?: $this->getRequest()->getActionName(),
             $time

--- a/library/Icinga/File/Pdf.php
+++ b/library/Icinga/File/Pdf.php
@@ -12,7 +12,7 @@ use Icinga\Application\Icinga;
 use Icinga\Exception\ProgrammingError;
 use Icinga\Util\Environment;
 use Icinga\Web\FileCache;
-use Icinga\Web\Hook;
+use Icinga\Application\Hook;
 use Icinga\Web\Url;
 
 class Pdf

--- a/library/Icinga/Web/Controller/ActionController.php
+++ b/library/Icinga/Web/Controller/ActionController.php
@@ -7,8 +7,8 @@ namespace Icinga\Web\Controller;
 
 use Icinga\Application\Benchmark;
 use Icinga\Application\Config;
+use Icinga\Application\Hook;
 use Icinga\Application\Hook\RequestHook;
-use Icinga\Application\Modules\Module;
 use Icinga\Authentication\Auth;
 use Icinga\Common\PdfExport;
 use Icinga\Exception\Http\HttpMethodNotAllowedException;
@@ -569,7 +569,7 @@ class ActionController extends Zend_Controller_Action
 
     protected function sendAsPdf()
     {
-        if (Module::exists('pdfexport')) {
+        if (Hook::has('Pdfexport')) {
             $this->newSendAsPdf();
         } else {
             $pdf = new Pdf();


### PR DESCRIPTION
The goal of this PR is to remove the hard dependency on our own pdfexport module for the generation on PDF documents. This would allow for other module developers to implement their own solutions.

- [x] Replace checks for pdfexport module with checks for Pdfexport hook.
- [ ] Provide a replacement for PrintableHtmlDocument
- [ ] Update Modules
  - [ ] Reporting
  Icinga/icingaweb2-module-reporting#276
  Icinga/icingaweb2-module-reporting#275
