### PR TITLE
Deprecate ProgrammingError in favor of LogicException

### DIFF
--- a/library/Icinga/Exception/ProgrammingError.php
+++ b/library/Icinga/Exception/ProgrammingError.php
@@ -7,7 +7,9 @@ namespace Icinga\Exception;
 
 /**
  * Class ProgrammingError
+ *
  * @package Icinga\Exception
+ * @deprecated Use {@see \LogicException} instead
  */
 class ProgrammingError extends IcingaException
 {


### PR DESCRIPTION
Mark `ProgrammingError` as `@deprecated` in favor of PHP SPL `LogicException`.

`ProgrammingError` is a thin wrapper around `IcingaException` that carries no additional semantics beyond what PHP's built-in `LogicException` already provides.

The one behavioral difference is that `IcingaException` accepts a vsprintf-style format string and arguments in its constructor, which `LogicException` does not.

`LogicException` is the PHP SPL type for errors that represent violations of program logic, incorrect API usage, missing setup, and violated preconditions, which is exactly what `ProgrammingError` was used for.