### PR TITLE
Two-Factor Authentication Contract

### DIFF
--- a/application/controllers/AccountController.php
+++ b/application/controllers/AccountController.php
@@ -28,21 +28,23 @@ class AccountController extends Controller
             ->add('account', [
                 'title' => $this->translate('Update your account'),
                 'label' => $this->translate('My Account'),
-                'url'   => 'account'
+                'url'   => 'account',
             ])
             ->add('navigation', [
                 'title' => $this->translate('List and configure your own navigation items'),
                 'label' => $this->translate('Navigation'),
-                'url'   => 'navigation'
+                'url'   => 'navigation',
             ])
-            ->add(
-                'devices',
-                [
-                    'title' => $this->translate('List of devices you are logged in'),
-                    'label' => $this->translate('My Devices'),
-                    'url'   => 'my-devices'
-                ]
-            );
+            ->add('devices', [
+                'title' => $this->translate('List of devices you are logged in'),
+                'label' => $this->translate('My Devices'),
+                'url'   => 'my-devices',
+            ])
+            ->add('two-factor', [
+                'title' => $this->translate('Configure two-factor authentication'),
+                'label' => $this->translate('Two-Factor Auth'),
+                'url'   => 'two-factor/config',
+            ]);
     }
 
     /**

--- a/application/controllers/AuthenticationController.php
+++ b/application/controllers/AuthenticationController.php
@@ -187,7 +187,8 @@ class AuthenticationController extends CompatController
     public function twofactorAction(): void
     {
         $session = Session::getSession();
-        if (! (new TwoFactorState($session))->isChallenged()) {
+        $twoFactorState = new TwoFactorState($session);
+        if (! $twoFactorState->isChallenged()) {
             $this->redirectToLogin();
         }
 
@@ -199,7 +200,7 @@ class AuthenticationController extends CompatController
                     $this->redirectNow($redirectUrl);
                 }
             })
-            ->on(Form::ON_SENT, function (TwoFactorChallengeForm $form) use ($session) {
+            ->on(Form::ON_SENT, function (TwoFactorChallengeForm $form) use ($session, $twoFactorState) {
                 // ON_SENT because cancel is not the primary submit button and never
                 // triggers ON_SUBMIT. CSRF is checked manually. Without it a forged
                 // request could destroy the session and drop the 2FA challenge.
@@ -208,6 +209,15 @@ class AuthenticationController extends CompatController
                     $form->getPressedSubmitElement()?->getName() === TwoFactorChallengeForm::SUBMIT_CANCEL;
 
                 if ($csrfValid && $cancelPressed) {
+                    // The login flow may have persisted a remember-me record before
+                    // issuing the challenge. Remove it now since the challenge was
+                    // canceled and the cookie was never delivered to the browser.
+                    if ($cookieData = $twoFactorState->getRememberMeCookieData()) {
+                        $data = explode('|', $cookieData);
+                        $iv = base64_decode(array_pop($data));
+                        (new RememberMe())->remove(bin2hex($iv));
+                    }
+
                     $session->purge();
                     $this->redirectNow($this->withRedirect('authentication/login'));
                 }

--- a/application/controllers/AuthenticationController.php
+++ b/application/controllers/AuthenticationController.php
@@ -103,7 +103,7 @@ class AuthenticationController extends CompatController
                     $this->httpBadRequest('Redirect to an external host is not allowed');
                 }
             } else {
-                $redirectUrl = $form->createRedirectUrl();
+                $redirectUrl = Url::fromPath(LoginForm::REDIRECT_URL);
             }
 
             $this->redirectNow($redirectUrl);

--- a/application/controllers/AuthenticationController.php
+++ b/application/controllers/AuthenticationController.php
@@ -12,11 +12,14 @@ use Icinga\Application\Icinga;
 use Icinga\Application\Logger;
 use Icinga\Authentication\LoginButton;
 use Icinga\Authentication\LoginButtonForm;
+use Icinga\Authentication\TwoFactorState;
 use Icinga\Common\Database;
 use Icinga\Exception\AuthenticationException;
 use Icinga\Forms\Authentication\LoginForm;
+use Icinga\Forms\Authentication\TwoFactorChallengeForm;
 use Icinga\Web\Helper\CookieHelper;
 use Icinga\Web\RememberMe;
+use Icinga\Web\Session;
 use Icinga\Web\Url;
 use Icinga\Web\Widget\LoginPage;
 use ipl\Html\Contract\Form;
@@ -47,6 +50,10 @@ class AuthenticationController extends CompatController
      */
     public function loginAction()
     {
+        if ((new TwoFactorState(Session::getSession()))->isChallenged()) {
+            $this->redirectNow($this->withRedirect('authentication/twofactor'));
+        }
+
         $icinga = Icinga::app();
         if (($requiresSetup = $icinga->requiresSetup()) && $icinga->setupTokenExists()) {
             $this->redirectNow(Url::fromPath('setup'));
@@ -139,7 +146,7 @@ class AuthenticationController extends CompatController
             }
         }
 
-        // Suppress the rendering of controls bar
+        // Suppress the rendering of controls bar.
         $this->view->compact = true;
         $this->setTitle($this->translate('Icinga Web 2 Login'));
         $this->addContent(new LoginPage($form, $loginButtons, $requiresSetup));
@@ -170,5 +177,67 @@ class AuthenticationController extends CompatController
 
             $this->redirectToLogin();
         }
+    }
+
+    /**
+     * Render the two-factor authentication challenge page
+     *
+     * @return void
+     */
+    public function twofactorAction(): void
+    {
+        $session = Session::getSession();
+        if (! (new TwoFactorState($session))->isChallenged()) {
+            $this->redirectToLogin();
+        }
+
+        $form = (new TwoFactorChallengeForm())
+            ->setCsrfCounterMeasureId($session->getId())
+            ->setAction(Url::fromRequest()->getAbsoluteUrl())
+            ->on(Form::ON_SUBMIT, function (TwoFactorChallengeForm $form) {
+                if ($redirectUrl = $form->getRedirectUrl()) {
+                    $this->redirectNow($redirectUrl);
+                }
+            })
+            ->on(Form::ON_SENT, function (TwoFactorChallengeForm $form) use ($session) {
+                // ON_SENT because cancel is not the primary submit button and never
+                // triggers ON_SUBMIT. CSRF is checked manually. Without it a forged
+                // request could destroy the session and drop the 2FA challenge.
+                $csrfValid = $form->getElement('CSRFToken')->isValid();
+                $cancelPressed =
+                    $form->getPressedSubmitElement()?->getName() === TwoFactorChallengeForm::SUBMIT_CANCEL;
+
+                if ($csrfValid && $cancelPressed) {
+                    $session->purge();
+                    $this->redirectNow($this->withRedirect('authentication/login'));
+                }
+            })
+            ->handleRequest($this->getServerRequest());
+
+        $this->setTitle($this->translate('Icinga Web 2 Two-Factor Auth'));
+
+        // Suppress the rendering of controls bar.
+        $this->view->compact = true;
+        $this->addContent(new LoginPage($form));
+    }
+
+    /**
+     * Build a URL for the given path that carries forward the redirect destination
+     *
+     * Copies the `redirect` query parameter from the current request, if present, so the
+     * post-authentication destination is not lost during multi-step authentication transitions.
+     *
+     * @param string $path Path to build the URL from
+     *
+     * @return Url
+     */
+    protected function withRedirect(string $path): Url
+    {
+        $url = Url::fromPath($path);
+        if ($redirect = $this->params->get('redirect')) {
+            $url->setParam('redirect', $redirect);
+        }
+
+        return $url;
     }
 }

--- a/application/controllers/MyDevicesController.php
+++ b/application/controllers/MyDevicesController.php
@@ -23,30 +23,27 @@ class MyDevicesController extends CompatController
     public function init()
     {
         $this->getTabs()
-            ->add(
-                'account',
-                [
-                    'title' => $this->translate('Update your account'),
-                    'label' => $this->translate('My Account'),
-                    'url'   => 'account'
-                ]
-            )
-            ->add(
-                'navigation',
-                [
-                    'title'     => $this->translate('List and configure your own navigation items'),
-                    'label'     => $this->translate('Navigation'),
-                    'url'       => 'navigation'
-                ]
-            )
-            ->add(
-                'devices',
-                [
-                    'title' => $this->translate('List of devices you are logged in'),
-                    'label' => $this->translate('My Devices'),
-                    'url'   => 'my-devices'
-                ]
-            )->activate('devices');
+            ->add('account', [
+                'title' => $this->translate('Update your account'),
+                'label' => $this->translate('My Account'),
+                'url'   => 'account',
+            ])
+            ->add('navigation', [
+                'title' => $this->translate('List and configure your own navigation items'),
+                'label' => $this->translate('Navigation'),
+                'url'   => 'navigation',
+            ])
+            ->add('devices', [
+                'title' => $this->translate('List of devices you are logged in'),
+                'label' => $this->translate('My Devices'),
+                'url'   => 'my-devices',
+            ])
+            ->add('two-factor', [
+                'title' => $this->translate('Configure two-factor authentication'),
+                'label' => $this->translate('Two-Factor Auth'),
+                'url'   => 'two-factor/config',
+            ])
+            ->activate('devices');
     }
 
     public function indexAction()

--- a/application/controllers/NavigationController.php
+++ b/application/controllers/NavigationController.php
@@ -131,31 +131,28 @@ class NavigationController extends Controller
 
         $this->view->title = $this->translate('Navigation');
         $this->getTabs()
-        ->add(
-            'account',
-            [
+            ->add('account', [
                 'title' => $this->translate('Update your account'),
                 'label' => $this->translate('My Account'),
-                'url'   => 'account'
-            ]
-        )
-        ->add(
-            'navigation',
-            [
-                'active'    => true,
-                'title'     => $this->translate('List and configure your own navigation items'),
-                'label'     => $this->translate('Navigation'),
-                'url'       => 'navigation'
-            ]
-        )
-        ->add(
-            'devices',
-            [
+                'url'   => 'account',
+            ])
+            ->add('navigation', [
+                'active' => true,
+                'title'  => $this->translate('List and configure your own navigation items'),
+                'label'  => $this->translate('Navigation'),
+                'url'    => 'navigation',
+            ])
+            ->add('devices', [
                 'title' => $this->translate('List of devices you are logged in'),
                 'label' => $this->translate('My Devices'),
-                'url'   => 'my-devices'
-            ]
-        );
+                'url'   => 'my-devices',
+            ])
+            ->add('two-factor', [
+                'title' => $this->translate('Configure two-factor authentication'),
+                'label' => $this->translate('Two-Factor Auth'),
+                'url'   => 'two-factor/config',
+            ]);
+
         $this->setupSortControl(
             [
                 'type'  => $this->translate('Type'),

--- a/application/controllers/TwoFactorController.php
+++ b/application/controllers/TwoFactorController.php
@@ -1,0 +1,100 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Icinga\Controllers;
+
+use Icinga\Application\Hook\TwoFactorHook;
+use Icinga\Application\Logger;
+use Icinga\Exception\IcingaException;
+use Icinga\Authentication\Auth;
+use Icinga\Forms\Account\TwoFactorEnrollmentForm;
+use Icinga\Web\Session;
+use ipl\Web\Common\CalloutType;
+use ipl\Web\Widget\Callout;
+use Throwable;
+use ipl\Html\Contract\Form;
+use ipl\Html\HtmlElement;
+use ipl\Html\Text;
+use ipl\Web\Compat\CompatController;
+
+/**
+ * Two-factor authentication configuration
+ */
+class TwoFactorController extends CompatController
+{
+    public function init(): void
+    {
+        $this->getTabs()
+            ->add('account', [
+                'title' => $this->translate('Update your account'),
+                'label' => $this->translate('My Account'),
+                'url'   => 'account',
+            ])
+            ->add('navigation', [
+                'title' => $this->translate('List and configure your own navigation items'),
+                'label' => $this->translate('Navigation'),
+                'url'   => 'navigation',
+            ])
+            ->add('devices', [
+                'title' => $this->translate('List of devices you are logged in'),
+                'label' => $this->translate('My Devices'),
+                'url'   => 'my-devices',
+            ])
+            ->add('two-factor', [
+                'title' => $this->translate('Configure two-factor authentication'),
+                'label' => $this->translate('Two-Factor Auth'),
+                'url'   => 'two-factor/config',
+            ]);
+    }
+
+    /**
+     * Render the two-factor authentication configuration page
+     *
+     * Shows an informational notice when no two-factor method is registered. Otherwise,
+     * renders {@see TwoFactorEnrollmentForm}, letting the user enroll in or unenroll from
+     * registered two-factor methods.
+     *
+     * @return void
+     */
+    public function configAction(): void
+    {
+        $this->getTabs()->activate('two-factor');
+        $this->addContent(HtmlElement::create('h1', null, Text::create($this->translate('Two-Factor Authentication'))));
+
+        if (TwoFactorHook::all() === []) {
+            $this->addContent(new Callout(CalloutType::Info, $this->translate(
+                'No two-factor authentication method is available. Enable a module that provides'
+                . ' an implementation to configure two-factor authentication for your account.',
+            )));
+
+            return;
+        }
+
+        $user = Auth::getInstance()->getUser();
+
+        try {
+            $enrolledMethodName = TwoFactorHook::loadEnrolled($user)?->getName();
+        } catch (Throwable $e) {
+            Logger::error("%s\n%s", $e->getMessage(), IcingaException::getConfidentialTraceAsString($e));
+            $this->addContent(new Callout(CalloutType::Error, sprintf(
+                $this->translate('Two-factor authentication is currently unavailable: %s. Contact your administrator.'),
+                $e->getMessage(),
+            )));
+
+            return;
+        }
+
+        $enrollmentForm = (new TwoFactorEnrollmentForm($user, $enrolledMethodName))
+            ->setCsrfCounterMeasureId(Session::getSession()->getId())
+            ->on(Form::ON_SUBMIT, function (TwoFactorEnrollmentForm $form) {
+                if ($redirectUrl = $form->getRedirectUrl()) {
+                    $this->redirectNow($redirectUrl);
+                }
+            })
+            ->handleRequest($this->getServerRequest());
+
+        $this->addContent($enrollmentForm);
+    }
+}

--- a/application/controllers/TwoFactorController.php
+++ b/application/controllers/TwoFactorController.php
@@ -75,7 +75,7 @@ class TwoFactorController extends CompatController
         $user = Auth::getInstance()->getUser();
 
         try {
-            $enrolledMethodName = TwoFactorHook::loadEnrolled($user)?->getName();
+            $enrolledMethodIdentifier = TwoFactorHook::loadEnrolled($user)?->getCanonicalName();
         } catch (Throwable $e) {
             Logger::error("%s\n%s", $e->getMessage(), IcingaException::getConfidentialTraceAsString($e));
             $this->addContent(new Callout(CalloutType::Error, sprintf(
@@ -86,7 +86,7 @@ class TwoFactorController extends CompatController
             return;
         }
 
-        $enrollmentForm = (new TwoFactorEnrollmentForm($user, $enrolledMethodName))
+        $enrollmentForm = (new TwoFactorEnrollmentForm($user, $enrolledMethodIdentifier))
             ->setCsrfCounterMeasureId(Session::getSession()->getId())
             ->on(Form::ON_SUBMIT, function (TwoFactorEnrollmentForm $form) {
                 if ($redirectUrl = $form->getRedirectUrl()) {

--- a/application/forms/Account/TwoFactorEnrollmentForm.php
+++ b/application/forms/Account/TwoFactorEnrollmentForm.php
@@ -1,0 +1,153 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Icinga\Forms\Account;
+
+use Icinga\Application\Hook\TwoFactorHook;
+use Icinga\User;
+use ipl\Html\FormElement\FieldsetElement;
+use ipl\Web\Common\CsrfCounterMeasure;
+use ipl\Web\Common\FormUid;
+use ipl\Web\Compat\CompatForm;
+use ipl\Web\Url;
+use Throwable;
+
+/**
+ * Form for enrolling in and unenrolling from a two-factor authentication method
+ */
+class TwoFactorEnrollmentForm extends CompatForm
+{
+    use CsrfCounterMeasure;
+    use FormUid;
+
+    /** @var string Form field name for the selected 2FA method */
+    public const METHOD = 'twofactor_method';
+
+    /** @var string The submit button to enroll into a 2FA method */
+    protected const SUBMIT_ENROLL = 'submit_twofactor_enroll';
+
+    /** @var string The submit button to unenroll from a 2FA method */
+    protected const SUBMIT_UNENROLL = 'submit_twofactor_unenroll';
+
+    /** @var bool Whether the user is already enrolled in a 2FA method */
+    protected bool $enrolled;
+
+    /**
+     * Create a new TwoFactorEnrollmentForm
+     *
+     * @param User $user The user to enroll
+     * @param ?string $enrolledMethodName The canonical name of the method the user is
+     *   currently enrolled in
+     */
+    public function __construct(
+        protected User $user,
+        ?string $enrolledMethodName = null,
+    ) {
+        $this->enrolled = $enrolledMethodName !== null;
+
+        $this->setAttribute('name', 'form_twofactor_enrollment');
+        $this->populate([static::METHOD => $enrolledMethodName]);
+    }
+
+    protected function assemble(): void
+    {
+        $this->addCsrfCounterMeasure();
+        $this->addElement($this->createUidElement());
+
+        $methods = iterator_to_array(TwoFactorHook::yieldMethods());
+        $this->addElement('select', static::METHOD, [
+            'label'        => $this->translate('2FA Method'),
+            'class'        => 'autosubmit',
+            'disabled'     => $this->enrolled,
+            'options'      => $methods,
+            'pleaseChoose' => true,
+            'required'     => true,
+        ]);
+
+        if ($this->enrolled) {
+            $this->addElement('submit', static::SUBMIT_UNENROLL, [
+                'label'               => $this->translate('Unenroll'),
+                'data-progress-label' => $this->translate('Unenrolling'),
+            ]);
+
+            return;
+        }
+
+        $method = $this->getPopulatedValue(static::METHOD);
+
+        // getPopulatedValue() returns the raw "Please choose" value before
+        // the select element normalizes an empty string to null.
+        if ($method === null || $method === '' || ! array_key_exists($method, $methods)) {
+            return;
+        }
+
+        $twoFactor = TwoFactorHook::fromName($method);
+
+        $configFieldset = new FieldsetElement($twoFactor->getName());
+        $this->addElement($configFieldset);
+
+        try {
+            $twoFactor->assembleEnrollmentFormElements($this->user, $configFieldset);
+        } catch (Throwable $e) {
+            $this->logAndShowError(
+                $e,
+                $this->translate('Two-factor method "%s" failed to assemble enrollment form elements: {error}'),
+                $twoFactor->getName(),
+            );
+
+            return;
+        }
+
+        $this->addElement('submit', static::SUBMIT_ENROLL, [
+            'label'               => $this->translate('Enroll'),
+            'data-progress-label' => $this->translate('Enrolling'),
+        ]);
+    }
+
+    protected function onSuccess(): void
+    {
+        $twoFactor = TwoFactorHook::fromName($this->getValue(static::METHOD));
+
+        switch ($this->getPressedSubmitElement()?->getName()) {
+            case static::SUBMIT_ENROLL:
+                /** @var FieldsetElement $configFieldset */
+                $configFieldset = $this->getElement($twoFactor->getName());
+                try {
+                    if (! $twoFactor->enroll($this->user, $configFieldset)) {
+                        $this->onError();
+
+                        // Don't redirect in this case, as the user might want to try again.
+                        return;
+                    }
+                } catch (Throwable $e) {
+                    $this->logAndShowError(
+                        $e,
+                        $this->translate('Could not enroll in two-factor method "%s": {error}'),
+                        $twoFactor->getName(),
+                    );
+
+                    return;
+                }
+                $this->setRedirectUrl(Url::fromRequest());
+
+                break;
+            case static::SUBMIT_UNENROLL:
+                try {
+                    $twoFactor->unenroll($this->user);
+                } catch (Throwable $e) {
+                    $this->logAndShowError(
+                        $e,
+                        $this->translate('Could not unenroll from two-factor method "%s": {error}'),
+                        $twoFactor->getName(),
+                    );
+
+                    return;
+                }
+                $this->setRedirectUrl(Url::fromRequest());
+
+                break;
+        }
+    }
+}

--- a/application/forms/Account/TwoFactorEnrollmentForm.php
+++ b/application/forms/Account/TwoFactorEnrollmentForm.php
@@ -7,6 +7,7 @@ namespace Icinga\Forms\Account;
 
 use Icinga\Application\Hook\TwoFactorHook;
 use Icinga\User;
+use Icinga\Web\RememberMe;
 use ipl\Html\FormElement\FieldsetElement;
 use ipl\Web\Common\CsrfCounterMeasure;
 use ipl\Web\Common\FormUid;
@@ -130,7 +131,6 @@ class TwoFactorEnrollmentForm extends CompatForm
 
                     return;
                 }
-                $this->setRedirectUrl(Url::fromRequest());
 
                 break;
             case static::SUBMIT_UNENROLL:
@@ -145,9 +145,17 @@ class TwoFactorEnrollmentForm extends CompatForm
 
                     return;
                 }
-                $this->setRedirectUrl(Url::fromRequest());
 
                 break;
+            default:
+                return;
         }
+
+        // Revoke all remember-me cookies for the current user. On enrollment, existing
+        // cookies would bypass the new 2FA requirement. On unenrollment, cookies issued
+        // during the enrolled period were only granted after a successful 2FA challenge
+        // and should not remain valid.
+        RememberMe::removeAllByUsername($this->user->getUsername());
+        $this->setRedirectUrl(Url::fromRequest());
     }
 }

--- a/application/forms/Account/TwoFactorEnrollmentForm.php
+++ b/application/forms/Account/TwoFactorEnrollmentForm.php
@@ -79,17 +79,17 @@ class TwoFactorEnrollmentForm extends CompatForm
             return;
         }
 
-        $method = $this->getPopulatedValue(static::METHOD);
+        $methodIdentifier = $this->getPopulatedValue(static::METHOD);
 
         // getPopulatedValue() returns the raw "Please choose" value before
         // the select element normalizes an empty string to null.
-        if ($method === null || $method === '' || ! array_key_exists($method, $methods)) {
+        if ($methodIdentifier === null || $methodIdentifier === '' || ! array_key_exists($methodIdentifier, $methods)) {
             return;
         }
 
-        $twoFactor = TwoFactorHook::fromName($method);
+        $twoFactor = TwoFactorHook::fromCanonicalName($methodIdentifier);
 
-        $configFieldset = new FieldsetElement($twoFactor->getName());
+        $configFieldset = new FieldsetElement($methodIdentifier);
         $this->addElement($configFieldset);
 
         try {
@@ -98,18 +98,18 @@ class TwoFactorEnrollmentForm extends CompatForm
             $this->logAndShowError(
                 $e,
                 $this->translate('Two-factor method "%s" failed to assemble enrollment form elements: {error}'),
-                $twoFactor->getName(),
+                $methodIdentifier,
             );
 
             return;
         }
 
-        if ($configFieldset->getName() !== $twoFactor->getName()) {
+        if ($configFieldset->getName() !== $methodIdentifier) {
             throw new LogicException(sprintf(
                 '%s::assembleEnrollmentFormElements() must not rename the fieldset. The name "%s" is used'
                 . ' as the element key in onSuccess() to retrieve the fieldset, but it was changed to "%s".',
                 $twoFactor::class,
-                $twoFactor->getName(),
+                $methodIdentifier,
                 $configFieldset->getName(),
             ));
         }
@@ -126,12 +126,13 @@ class TwoFactorEnrollmentForm extends CompatForm
 
     protected function onSuccess(): void
     {
-        $twoFactor = TwoFactorHook::fromName($this->getValue(static::METHOD));
+        $methodIdentifier = $this->getValue(static::METHOD);
+        $twoFactor = TwoFactorHook::fromCanonicalName($methodIdentifier);
 
         switch ($this->getPressedSubmitElement()?->getName()) {
             case static::SUBMIT_ENROLL:
                 /** @var FieldsetElement $configFieldset */
-                $configFieldset = $this->getElement($twoFactor->getName());
+                $configFieldset = $this->getElement($methodIdentifier);
                 try {
                     if (! $twoFactor->enroll($this->user, $configFieldset)) {
                         $this->onError();
@@ -143,7 +144,7 @@ class TwoFactorEnrollmentForm extends CompatForm
                     $this->logAndShowError(
                         $e,
                         $this->translate('Could not enroll in two-factor method "%s": {error}'),
-                        $twoFactor->getName(),
+                        $methodIdentifier,
                     );
 
                     return;
@@ -157,7 +158,7 @@ class TwoFactorEnrollmentForm extends CompatForm
                     $this->logAndShowError(
                         $e,
                         $this->translate('Could not unenroll from two-factor method "%s": {error}'),
-                        $twoFactor->getName(),
+                        $methodIdentifier,
                     );
 
                     return;

--- a/application/forms/Account/TwoFactorEnrollmentForm.php
+++ b/application/forms/Account/TwoFactorEnrollmentForm.php
@@ -5,14 +5,17 @@
 
 namespace Icinga\Forms\Account;
 
+use Icinga\Application\ClassLoader;
 use Icinga\Application\Hook\TwoFactorHook;
 use Icinga\User;
 use Icinga\Web\RememberMe;
+use ipl\Html\Attributes;
 use ipl\Html\FormElement\FieldsetElement;
 use ipl\Web\Common\CsrfCounterMeasure;
 use ipl\Web\Common\FormUid;
 use ipl\Web\Compat\CompatForm;
 use ipl\Web\Url;
+use LogicException;
 use Throwable;
 
 /**
@@ -100,6 +103,20 @@ class TwoFactorEnrollmentForm extends CompatForm
 
             return;
         }
+
+        if ($configFieldset->getName() !== $twoFactor->getName()) {
+            throw new LogicException(sprintf(
+                '%s::assembleEnrollmentFormElements() must not rename the fieldset. The name "%s" is used'
+                . ' as the element key in onSuccess() to retrieve the fieldset, but it was changed to "%s".',
+                $twoFactor::class,
+                $twoFactor->getName(),
+                $configFieldset->getName(),
+            ));
+        }
+
+        $configFieldset->addAttributes(Attributes::create([
+            'class' => 'icinga-module module-' . ClassLoader::extractModuleName($twoFactor::class),
+        ]));
 
         $this->addElement('submit', static::SUBMIT_ENROLL, [
             'label'               => $this->translate('Enroll'),

--- a/application/forms/Authentication/LoginForm.php
+++ b/application/forms/Authentication/LoginForm.php
@@ -14,8 +14,8 @@ use Icinga\Application\Logger;
 use Icinga\Authentication\Auth;
 use Icinga\Authentication\TwoFactorState;
 use Icinga\Authentication\User\ExternalBackend;
-use Icinga\Exception\Http\HttpBadRequestException;
 use Icinga\User;
+use Icinga\Web\Form\Element\LoginRedirect;
 use Icinga\Web\RememberMe;
 use Icinga\Web\Session;
 use Icinga\Web\Url;
@@ -102,33 +102,7 @@ class LoginForm extends CompatForm
             'label'               => $this->translate('Login')
         ]);
 
-        $this->addElement('hidden', 'redirect', ['value' => Url::fromRequest()->getParam('redirect')]);
-    }
-
-    /**
-     * Compute the post-login redirect URL
-     *
-     * @return Url
-     *
-     * @throws HttpBadRequestException If the redirect url is external
-     */
-    public function createRedirectUrl(): Url
-    {
-        $redirect = null;
-        if ($this->hasBeenAssembled) {
-            $redirect = $this->getElement('redirect')->getValue();
-        }
-
-        if (empty($redirect) || str_contains($redirect, 'authentication/logout')) {
-            $redirect = static::REDIRECT_URL;
-        }
-
-        $redirectUrl = Url::fromPath($redirect);
-        if ($redirectUrl->isExternal()) {
-            throw new HttpBadRequestException('Redirect to an external host is not allowed');
-        }
-
-        return $redirectUrl;
+        $this->addElement(new LoginRedirect('redirect', ['value' => Url::fromRequest()->getParam('redirect')]));
     }
 
     /**
@@ -141,7 +115,7 @@ class LoginForm extends CompatForm
      * RememberMe record at this point so it can be issued after the challenge
      * succeeds. On full success, persists the RememberMe cookie when requested,
      * triggers registered {@see AuthenticationHook}s, and redirects to the URL
-     * returned by {@see createRedirectUrl()}. On failure, adds an appropriate
+     * returned by {@see LoginRedirect::getUrl()}. On failure, adds an appropriate
      * error message to the form and calls {@see onError()}.
      *
      * @return void
@@ -212,7 +186,9 @@ class LoginForm extends CompatForm
             AuthenticationHook::triggerLogin($user);
 
             $response->setRerenderLayout();
-            $this->setRedirectUrl($this->createRedirectUrl());
+            /** @var LoginRedirect $redirectElement */
+            $redirectElement = $this->getElement('redirect');
+            $this->setRedirectUrl($redirectElement->getUrl());
 
             return;
         }

--- a/application/forms/Authentication/LoginForm.php
+++ b/application/forms/Authentication/LoginForm.php
@@ -8,9 +8,11 @@ namespace Icinga\Forms\Authentication;
 use Exception;
 use Icinga\Application\Config;
 use Icinga\Application\Hook\AuthenticationHook;
+use Icinga\Application\Hook\TwoFactorHook;
 use Icinga\Application\Icinga;
 use Icinga\Application\Logger;
 use Icinga\Authentication\Auth;
+use Icinga\Authentication\TwoFactorState;
 use Icinga\Authentication\User\ExternalBackend;
 use Icinga\Exception\Http\HttpBadRequestException;
 use Icinga\User;
@@ -26,6 +28,7 @@ use ipl\Web\Common\FormUid;
 use ipl\Web\Compat\CompatForm;
 use ipl\Web\Compat\FormDecorator\CheckboxDecorator;
 use ipl\Web\Compat\FormDecorator\DescriptionDecorator;
+use Throwable;
 
 /**
  * Form for user authentication
@@ -132,10 +135,14 @@ class LoginForm extends CompatForm
      * Authenticate the user and redirect on success, or display an error message on failure
      *
      * Skips external backends and applies the configured default domain when the
-     * username contains no domain. On success, persists the RememberMe cookie when
-     * requested, triggers registered {@see AuthenticationHook}s, and redirects to
-     * the URL returned by {@see createRedirectUrl()}. On failure, adds an
-     * appropriate error message to the form and calls {@see onError()}.
+     * username contains no domain. If the user is enrolled in a two-factor method,
+     * stores the challenge in the session and redirects to the two-factor challenge
+     * page instead of completing login immediately; optionally persists the
+     * RememberMe record at this point so it can be issued after the challenge
+     * succeeds. On full success, persists the RememberMe cookie when requested,
+     * triggers registered {@see AuthenticationHook}s, and redirects to the URL
+     * returned by {@see createRedirectUrl()}. On failure, adds an appropriate
+     * error message to the form and calls {@see onError()}.
      *
      * @return void
      */
@@ -151,6 +158,44 @@ class LoginForm extends CompatForm
         $password = $this->getElement('password')->getValue();
         $authenticated = $authChain->authenticate($user, $password);
         if ($authenticated) {
+            try {
+                $twoFactor = TwoFactorHook::loadEnrolled($user);
+            } catch (Throwable $e) {
+                $this->logAndShowError($e, $this->translate(
+                    'Two-factor authentication is currently unavailable: {error}. Contact your administrator.',
+                ));
+
+                return;
+            }
+
+            if ($twoFactor !== null) {
+                $twoFactorState = new TwoFactorState(Session::getSession());
+                $twoFactorState->challenge($user);
+                Logger::info(
+                    'User "%s" has been challenged for two-factor verification using method "%s"',
+                    $user->getUsername(),
+                    $twoFactor->getName(),
+                );
+
+                if ($this->getElement('rememberme')->isChecked()) {
+                    try {
+                        $rememberMe = RememberMe::fromCredentials($user->getUsername(), $password);
+                        $twoFactorState->setRememberMeCookie($rememberMe);
+                    } catch (Throwable $e) {
+                        Logger::error('Failed to let user "%s" stay logged in: %s', $user->getUsername(), $e);
+                    }
+                }
+
+                $redirectUrl = Url::fromPath('authentication/twofactor');
+                if ($redirect = Url::fromRequest()->getParam('redirect')) {
+                    $redirectUrl->setParam('redirect', $redirect);
+                }
+
+                $this->setRedirectUrl($redirectUrl);
+
+                return;
+            }
+
             $auth->setAuthenticated($user);
             $response = Icinga::app()->getResponse();
             if ($this->getElement('rememberme')->isChecked()) {

--- a/application/forms/Authentication/LoginForm.php
+++ b/application/forms/Authentication/LoginForm.php
@@ -164,6 +164,8 @@ class LoginForm extends CompatForm
                     }
                 }
 
+                Session::getSession()->refreshId();
+
                 $redirectUrl = Url::fromPath('authentication/twofactor');
                 if ($redirect = Url::fromRequest()->getParam('redirect')) {
                     $redirectUrl->setParam('redirect', $redirect);

--- a/application/forms/Authentication/LoginForm.php
+++ b/application/forms/Authentication/LoginForm.php
@@ -47,6 +47,9 @@ class LoginForm extends CompatForm
     public function __construct()
     {
         $this->setAttribute('name', 'form_login');
+        // Use a unique id so loader.js doesn't restore focus to the submit button
+        // of a subsequently rendered form that would match the same selector.
+        $this->setAttribute('id', 'login-form');
     }
 
     protected function assemble(): void

--- a/application/forms/Authentication/LoginForm.php
+++ b/application/forms/Authentication/LoginForm.php
@@ -151,7 +151,7 @@ class LoginForm extends CompatForm
                 Logger::info(
                     'User "%s" has been challenged for two-factor verification using method "%s"',
                     $user->getUsername(),
-                    $twoFactor->getName(),
+                    $twoFactor->getCanonicalName(),
                 );
 
                 if ($this->getElement('rememberme')->isChecked()) {

--- a/application/forms/Authentication/LoginForm.php
+++ b/application/forms/Authentication/LoginForm.php
@@ -154,7 +154,8 @@ class LoginForm extends CompatForm
                 if ($this->getElement('rememberme')->isChecked()) {
                     try {
                         $rememberMe = RememberMe::fromCredentials($user->getUsername(), $password);
-                        $twoFactorState->setRememberMeCookie($rememberMe);
+                        $rememberMe->persist();
+                        $twoFactorState->setRememberMeCookieData($rememberMe->getCookie()->getValue());
                     } catch (Throwable $e) {
                         Logger::error('Failed to let user "%s" stay logged in: %s', $user->getUsername(), $e);
                     }
@@ -175,8 +176,8 @@ class LoginForm extends CompatForm
             if ($this->getElement('rememberme')->isChecked()) {
                 try {
                     $rememberMe = RememberMe::fromCredentials($user->getUsername(), $password);
-                    $response->setCookie($rememberMe->getCookie());
                     $rememberMe->persist();
+                    $response->setCookie($rememberMe->getCookie());
                 } catch (Exception $e) {
                     Logger::error('Failed to let user "%s" stay logged in: %s', $user->getUsername(), $e);
                 }

--- a/application/forms/Authentication/TwoFactorChallengeForm.php
+++ b/application/forms/Authentication/TwoFactorChallengeForm.php
@@ -51,6 +51,9 @@ class TwoFactorChallengeForm extends CompatForm
     public function __construct()
     {
         $this->setAttribute('name', 'form_twofactor_challenge');
+        // Use a unique id so loader.js doesn't restore focus to the submit button
+        // of a subsequently rendered form that would match the same selector.
+        $this->setAttribute('id', 'twofactor-challenge-form');
     }
 
     protected function assemble(): void

--- a/application/forms/Authentication/TwoFactorChallengeForm.php
+++ b/application/forms/Authentication/TwoFactorChallengeForm.php
@@ -12,7 +12,7 @@ use Icinga\Application\Icinga;
 use Icinga\Application\Logger;
 use Icinga\Authentication\Auth;
 use Icinga\Authentication\TwoFactorState;
-use Icinga\Exception\Http\HttpBadRequestException;
+use Icinga\Web\Form\Element\LoginRedirect;
 use Icinga\Web\Session;
 use Icinga\Web\Url;
 use ipl\Html\Attributes;
@@ -84,7 +84,7 @@ class TwoFactorChallengeForm extends CompatForm
             ],
         ]);
 
-        $this->addElement('hidden', 'redirect', ['value' => Url::fromRequest()->getParam('redirect')]);
+        $this->addElement(new LoginRedirect('redirect', ['value' => Url::fromRequest()->getParam('redirect')]));
     }
 
     /**
@@ -173,7 +173,9 @@ class TwoFactorChallengeForm extends CompatForm
             AuthenticationHook::triggerLogin($user);
 
             $response->setRerenderLayout();
-            $this->setRedirectUrl($this->createRedirectUrl());
+            /** @var LoginRedirect $redirect */
+            $redirect = $this->getElement('redirect');
+            $this->setRedirectUrl($redirect->getUrl());
 
             return;
         }
@@ -184,29 +186,5 @@ class TwoFactorChallengeForm extends CompatForm
             $twoFactor->getName(),
         );
         $this->getElement(static::TOKEN)->addMessage($this->translate('Token is invalid!'));
-    }
-
-    /**
-     * @return Url
-     *
-     * @throws HttpBadRequestException
-     */
-    public function createRedirectUrl(): Url
-    {
-        $redirect = null;
-        if ($this->hasBeenAssembled) {
-            $redirect = $this->getElement('redirect')->getValue();
-        }
-
-        if (empty($redirect) || str_contains($redirect, 'authentication/logout')) {
-            $redirect = LoginForm::REDIRECT_URL;
-        }
-
-        $redirectUrl = Url::fromPath($redirect);
-        if ($redirectUrl->isExternal()) {
-            throw new HttpBadRequestException('nope');
-        }
-
-        return $redirectUrl;
     }
 }

--- a/application/forms/Authentication/TwoFactorChallengeForm.php
+++ b/application/forms/Authentication/TwoFactorChallengeForm.php
@@ -156,7 +156,7 @@ class TwoFactorChallengeForm extends CompatForm
             Logger::info(
                 'User "%s" passed two-factor verification using method "%s"',
                 $user->getUsername(),
-                $twoFactor->getName(),
+                $twoFactor->getCanonicalName(),
             );
             Auth::getInstance()->setAuthenticated($user);
 
@@ -187,7 +187,7 @@ class TwoFactorChallengeForm extends CompatForm
         Logger::warning(
             'Two-factor verification failed for user "%s" using method "%s"',
             $user->getUsername(),
-            $twoFactor->getName(),
+            $twoFactor->getCanonicalName(),
         );
         $this->getElement(static::TOKEN)->addMessage($this->translate('Token is invalid!'));
     }

--- a/application/forms/Authentication/TwoFactorChallengeForm.php
+++ b/application/forms/Authentication/TwoFactorChallengeForm.php
@@ -1,0 +1,212 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Icinga\Forms\Authentication;
+
+use Exception;
+use Icinga\Application\Hook\AuthenticationHook;
+use Icinga\Application\Hook\TwoFactorHook;
+use Icinga\Application\Icinga;
+use Icinga\Application\Logger;
+use Icinga\Authentication\Auth;
+use Icinga\Authentication\TwoFactorState;
+use Icinga\Exception\Http\HttpBadRequestException;
+use Icinga\Web\Session;
+use Icinga\Web\Url;
+use ipl\Html\Attributes;
+use ipl\Html\FormDecoration\ErrorsDecorator;
+use ipl\Html\FormDecoration\HtmlTagDecorator;
+use ipl\Html\FormDecoration\RenderElementDecorator;
+use ipl\Html\HtmlElement;
+use ipl\Html\Text;
+use ipl\Web\Common\CsrfCounterMeasure;
+use ipl\Web\Common\FormUid;
+use ipl\Web\Compat\CompatForm;
+use ipl\Web\Widget\Icon;
+use Throwable;
+
+/**
+ * Form for the two-factor authentication challenge
+ */
+class TwoFactorChallengeForm extends CompatForm
+{
+    use CsrfCounterMeasure;
+    use FormUid;
+
+    /** @var string Name of the token text input in the verification form */
+    public const TOKEN = 'twofactor_token';
+
+    /** @var string Name of the verify submit button in the verification form */
+    public const SUBMIT_VERIFY = 'submit_twofactor_verify';
+
+    /** @var string Name of the cancel submit button in the verification form */
+    public const SUBMIT_CANCEL = 'submit_twofactor_cancel';
+
+    /**
+     * Create a new TwoFactorChallengeForm
+     */
+    public function __construct()
+    {
+        $this->setAttribute('name', 'form_twofactor_challenge');
+    }
+
+    protected function assemble(): void
+    {
+        $this->addCsrfCounterMeasure();
+        $this->addElement($this->createUidElement());
+
+        $this->addElement('text', static::TOKEN, [
+            'autocomplete' => 'off',
+            'autofocus'    => '',
+            'class'        => 'content-centered',
+            'decorators'   => [
+                'RenderElement' => new RenderElementDecorator(),
+                'Errors'        => (new ErrorsDecorator())->setClass('errors'),
+                'ControlGroup'  => (new HtmlTagDecorator())->setTag('div')->setClass('control-group'),
+            ],
+            'placeholder'  => $this->translate('Please enter your 2FA token'),
+            'required'     => true,
+        ]);
+
+        $this->addElement('submit', static::SUBMIT_VERIFY, [
+            'data-progress-label' => $this->translate('Verifying'),
+            'label'               => $this->translate('Verify'),
+        ]);
+
+        $this->addElement('submitButton', static::SUBMIT_CANCEL, [
+            'class'          => 'btn-back-to-login-link',
+            'formnovalidate' => true,
+            'label'          => [
+                new Icon('arrow-left'),
+                HtmlElement::create('span', Attributes::create(), Text::create($this->translate('Back to login'))),
+            ],
+        ]);
+
+        $this->addElement('hidden', 'redirect', ['value' => Url::fromRequest()->getParam('redirect')]);
+    }
+
+    /**
+     * Verify the submitted two-factor token and complete login on success
+     *
+     * Retrieves the challenged user from the session and the enrolled 2FA method.
+     * If the enrolled method is no longer available, adds an error message and
+     * calls {@see onError()}. On a valid token, authenticates the user, optionally
+     * issues the remember-me cookie stored in the challenge state, clears the
+     * pending challenge from the session, triggers registered
+     * {@see AuthenticationHook}s, and sets the post-login redirect URL. On an
+     * invalid token, adds a validation error to the token field.
+     *
+     * @return void
+     */
+    protected function onSuccess(): void
+    {
+        $twoFactorState = new TwoFactorState(Session::getSession());
+        $user = $twoFactorState->getChallengedUser();
+        if ($user === null) {
+            $this->logAndShowError(
+                $this->translate('Session changed mid-request, challenged user no longer available'),
+                $this->translate(
+                    'Two-factor authentication is currently unavailable: {error}. Contact your administrator.',
+                ),
+            );
+
+            return;
+        }
+
+        try {
+            $twoFactor = TwoFactorHook::loadEnrolled($user);
+        } catch (Throwable $e) {
+            $this->logAndShowError($e, $this->translate(
+                'Two-factor authentication is currently unavailable: {error}. Contact your administrator.',
+            ));
+
+            return;
+        }
+
+        if ($twoFactor === null) {
+            // This can happen when another user disables the module that provides the 2FA method,
+            // while the current user is still on the 2FA challenge form.
+            $this->addMessage($this->translate(
+                'Your two-factor authentication method is no longer available.'
+                . ' If this is unexpected, contact your administrator.'
+                . ' Otherwise use \'Back to login\'. You will not be prompted for a second factor.',
+            ));
+            $this->onError();
+
+            return;
+        }
+
+        try {
+            $verified = $twoFactor->verify($user, $this->getValue(static::TOKEN));
+        } catch (Throwable $e) {
+            $this->logAndShowError($e, $this->translate(
+                'Two-factor verification is currently unavailable: {error}. Contact your administrator.',
+            ));
+
+            return;
+        }
+
+        if ($verified) {
+            Logger::info(
+                'User "%s" passed two-factor verification using method "%s"',
+                $user->getUsername(),
+                $twoFactor->getName(),
+            );
+            Auth::getInstance()->setAuthenticated($user);
+
+            $response = Icinga::app()->getResponse();
+
+            if ($rememberMe = $twoFactorState->getRememberMeCookie()) {
+                try {
+                    $response->setCookie($rememberMe->getCookie());
+                    $rememberMe->persist();
+                } catch (Exception $e) {
+                    Logger::error('Failed to let user "%s" stay logged in: %s', $user->getUsername(), $e);
+                }
+            }
+
+            $twoFactorState->completeChallenge();
+
+            // Call provided AuthenticationHook(s) after successful login.
+            AuthenticationHook::triggerLogin($user);
+
+            $response->setRerenderLayout();
+            $this->setRedirectUrl($this->createRedirectUrl());
+
+            return;
+        }
+
+        Logger::warning(
+            'Two-factor verification failed for user "%s" using method "%s"',
+            $user->getUsername(),
+            $twoFactor->getName(),
+        );
+        $this->getElement(static::TOKEN)->addMessage($this->translate('Token is invalid!'));
+    }
+
+    /**
+     * @return Url
+     *
+     * @throws HttpBadRequestException
+     */
+    public function createRedirectUrl(): Url
+    {
+        $redirect = null;
+        if ($this->hasBeenAssembled) {
+            $redirect = $this->getElement('redirect')->getValue();
+        }
+
+        if (empty($redirect) || str_contains($redirect, 'authentication/logout')) {
+            $redirect = LoginForm::REDIRECT_URL;
+        }
+
+        $redirectUrl = Url::fromPath($redirect);
+        if ($redirectUrl->isExternal()) {
+            throw new HttpBadRequestException('nope');
+        }
+
+        return $redirectUrl;
+    }
+}

--- a/application/forms/Authentication/TwoFactorChallengeForm.php
+++ b/application/forms/Authentication/TwoFactorChallengeForm.php
@@ -13,6 +13,7 @@ use Icinga\Application\Logger;
 use Icinga\Authentication\Auth;
 use Icinga\Authentication\TwoFactorState;
 use Icinga\Web\Form\Element\LoginRedirect;
+use Icinga\Web\RememberMe;
 use Icinga\Web\Session;
 use Icinga\Web\Url;
 use ipl\Html\Attributes;
@@ -158,10 +159,10 @@ class TwoFactorChallengeForm extends CompatForm
 
             $response = Icinga::app()->getResponse();
 
-            if ($rememberMe = $twoFactorState->getRememberMeCookie()) {
+            if ($cookieData = $twoFactorState->getRememberMeCookieData()) {
                 try {
+                    $rememberMe = RememberMe::fromCookieData($cookieData);
                     $response->setCookie($rememberMe->getCookie());
-                    $rememberMe->persist();
                 } catch (Exception $e) {
                     Logger::error('Failed to let user "%s" stay logged in: %s', $user->getUsername(), $e);
                 }

--- a/doc/05-Authentication.md
+++ b/doc/05-Authentication.md
@@ -291,3 +291,46 @@ asks that backend to authenticate the user with the sAMAccountName "jdoe".
 When the user "jdoe@icinga.com" logs in, Icinga Web 2 walks through all configured authentication backends until it
 finds one which is responsible for that user -- e.g. a MariaDB or MySQL backend (SQL database backends aren't domain-aware). Then
 Icinga Web 2 asks that backend to authenticate the user with the username "jdoe@icinga.com".
+
+## Two-Factor Authentication <a id="two-factor-authentication"></a>
+
+Icinga Web supports two-factor authentication (2FA) through an implementable hook. When a module that provides a
+`TwoFactor` hook implementation is enabled, users can enroll their accounts. After a successful password authentication,
+enrolled users must complete a second verification step before the session is established.
+
+2FA enforcement depends on the applicable hooks provided. If the module that provides an enrolled method is disabled or
+otherwise unavailable, Icinga Web cannot load that method and cannot enforce its challenge.
+
+### Enrolling in 2FA <a id="two-factor-authentication-enrolling"></a>
+
+Open your account settings and switch to the **Two-Factor Auth** tab. Select a 2FA method from the dropdown, follow the
+method-specific steps to set up your credential, and click **Enroll**.
+
+Make sure to store any recovery information (e.g. a secret key or backup codes) provided during enrollment on a separate
+device. If you lose access to your 2FA credential, an administrator must remove your enrollment. You will not be able
+to do this by yourself because the login requires a valid token.
+
+### Logging in with 2FA <a id="two-factor-authentication-login"></a>
+
+After entering your username and password you are redirected to a second page. Enter your credential and click
+**Verify**. Use **Back to login** to cancel and return to the password step.
+
+Valid remember-me cookies act as trusted-device sessions and do not trigger a fresh 2FA challenge until the cookie is
+revoked or expires. Enrolling in or unenrolling from 2FA revokes existing remember-me cookies for the user.
+
+Sessions established by an external authentication backend remain governed by that backend. The Icinga Web login form
+2FA challenge is not applied to external authentication sessions.
+
+HTTP Basic authentication for API requests cannot complete an interactive 2FA challenge. If an API request authenticates
+with HTTP Basic credentials for a user enrolled in a currently registered 2FA method, Icinga Web rejects the request
+with HTTP status `403`.
+
+### Unenrolling from 2FA <a id="two-factor-authentication-unenrolling"></a>
+
+Open the **Two-Factor Auth** tab in your account settings and click **Unenroll**. This removes your stored credential
+immediately.
+
+### Replacing your 2FA credential <a id="two-factor-authentication-replacing"></a>
+
+To replace your credential, for example because it was compromised, click **Unenroll** first, then follow the
+enrollment steps again with the new credential.

--- a/library/Icinga/Application/Hook/TwoFactorHook.php
+++ b/library/Icinga/Application/Hook/TwoFactorHook.php
@@ -61,24 +61,24 @@ abstract class TwoFactorHook implements TwoFactor
     }
 
     /**
-     * Get the implementation with the given name
+     * Get the implementation with the given canonical name
      *
-     * @param string $name The machine-readable name of the desired implementation,
-     *   as returned by {@see TwoFactor::getName()}
+     * @param string $canonicalName The globally unique identifier of the desired implementation,
+     *   as returned by {@see getCanonicalName()}
      *
      * @return TwoFactorHook The matching implementation
      *
      * @throws RuntimeException If no such implementation is registered
      */
-    public static function fromName(string $name): self
+    public static function fromCanonicalName(string $canonicalName): self
     {
         foreach (self::all() as $method) {
-            if ($method->getName() === $name) {
+            if ($method->getCanonicalName() === $canonicalName) {
                 return $method;
             }
         }
 
-        throw new RuntimeException(sprintf('No two-factor method found with name "%s"', $name));
+        throw new RuntimeException(sprintf('No two-factor method found with name "%s"', $canonicalName));
     }
 
     /**
@@ -117,14 +117,33 @@ abstract class TwoFactorHook implements TwoFactor
     }
 
     /**
-     * Yield display names indexed by machine-readable method name
+     * Yield display names indexed by the globally unique method identifier
      *
      * @return Generator<string, string>
      */
     public static function yieldMethods(): Generator
     {
         foreach (self::all() as $method) {
-            yield $method->getName() => $method->getDisplayName();
+            yield $method->getCanonicalName() => $method->getDisplayName();
         }
+    }
+
+    /**
+     * Get the globally unique identifier for this 2FA method
+     *
+     * Combines the providing module's name with {@see getName()}, e.g. 'mymodule/totp',
+     * so that two modules may register a method using the same {@see getName()} without
+     * colliding. Falls back to the plain {@see getName()} for hook classes that are not
+     * part of a module namespace.
+     *
+     * @return string
+     */
+    final public function getCanonicalName(): string
+    {
+        if ($module = $this->getModule()?->getName()) {
+            return sprintf('%s/%s', $module, $this->getName());
+        }
+
+        return $this->getName();
     }
 }

--- a/library/Icinga/Application/Hook/TwoFactorHook.php
+++ b/library/Icinga/Application/Hook/TwoFactorHook.php
@@ -22,12 +22,12 @@ abstract class TwoFactorHook implements TwoFactor
         all as private essentialsAll;
     }
 
-    protected static function getHookName(): string
+    final protected static function getHookName(): string
     {
         return 'TwoFactor';
     }
 
-    protected static function isAlwaysRun(): bool
+    final protected static function isAlwaysRun(): bool
     {
         return true;
     }
@@ -37,7 +37,7 @@ abstract class TwoFactorHook implements TwoFactor
      *
      * @return list<TwoFactorHook>
      */
-    public static function all(): array
+    final public static function all(): array
     {
         $methods = [];
         foreach (self::essentialsAll() as $method) {
@@ -70,7 +70,7 @@ abstract class TwoFactorHook implements TwoFactor
      *
      * @throws RuntimeException If no such implementation is registered
      */
-    public static function fromCanonicalName(string $canonicalName): self
+    final public static function fromCanonicalName(string $canonicalName): self
     {
         foreach (self::all() as $method) {
             if ($method->getCanonicalName() === $canonicalName) {
@@ -97,7 +97,7 @@ abstract class TwoFactorHook implements TwoFactor
      *
      * @throws Throwable If any registered implementation's {@see TwoFactor::isEnrolled()} throws
      */
-    public static function loadEnrolled(User $user): ?self
+    final public static function loadEnrolled(User $user): ?self
     {
         foreach (self::all() as $method) {
             try {
@@ -121,7 +121,7 @@ abstract class TwoFactorHook implements TwoFactor
      *
      * @return Generator<string, string>
      */
-    public static function yieldMethods(): Generator
+    final public static function yieldMethods(): Generator
     {
         foreach (self::all() as $method) {
             yield $method->getCanonicalName() => $method->getDisplayName();

--- a/library/Icinga/Application/Hook/TwoFactorHook.php
+++ b/library/Icinga/Application/Hook/TwoFactorHook.php
@@ -1,0 +1,130 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Icinga\Application\Hook;
+
+use Generator;
+use Icinga\Application\Logger;
+use Icinga\Authentication\TwoFactor;
+use Icinga\Exception\IcingaException;
+use Icinga\User;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Abstract base class for two-factor authentication hook implementations
+ */
+abstract class TwoFactorHook implements TwoFactor
+{
+    use HookEssentials {
+        all as private essentialsAll;
+    }
+
+    protected static function getHookName(): string
+    {
+        return 'TwoFactor';
+    }
+
+    protected static function isAlwaysRun(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get all registered implementations sorted alphabetically by their display name
+     *
+     * @return list<TwoFactorHook>
+     */
+    public static function all(): array
+    {
+        $methods = [];
+        foreach (self::essentialsAll() as $method) {
+            if (! ($method instanceof TwoFactor)) {
+                Logger::warning(
+                    'Hook "%s" is registered for "%s" but does not implement %s. Ignoring it.',
+                    $method::class,
+                    self::getHookName(),
+                    TwoFactor::class,
+                );
+
+                continue;
+            }
+
+            $methods[] = $method;
+        }
+
+        usort($methods, fn(TwoFactor $a, TwoFactor $b) => $a->getDisplayName() <=> $b->getDisplayName());
+
+        return $methods;
+    }
+
+    /**
+     * Get the implementation with the given name
+     *
+     * @param string $name The machine-readable name of the desired implementation,
+     *   as returned by {@see TwoFactor::getName()}
+     *
+     * @return TwoFactorHook The matching implementation
+     *
+     * @throws RuntimeException If no such implementation is registered
+     */
+    public static function fromName(string $name): self
+    {
+        foreach (self::all() as $method) {
+            if ($method->getName() === $name) {
+                return $method;
+            }
+        }
+
+        throw new RuntimeException(sprintf('No two-factor method found with name "%s"', $name));
+    }
+
+    /**
+     * Get the implementation a user is enrolled in, or null if they are not enrolled
+     *
+     * Returns null when the user has no active enrollment in any currently registered
+     * method. If the module providing the user's enrolled method is disabled, the
+     * implementation is not registered and this method returns null and login succeeds
+     * without a second factor. This is expected behavior when an administrator disables
+     * a 2FA module.
+     *
+     * @param User $user The user to check for
+     *
+     * @return ?TwoFactorHook The enrolled implementation, or null if the user is not enrolled in
+     *   any registered method
+     *
+     * @throws Throwable If any registered implementation's {@see TwoFactor::isEnrolled()} throws
+     */
+    public static function loadEnrolled(User $user): ?self
+    {
+        foreach (self::all() as $method) {
+            try {
+                $enrolled = $method->isEnrolled($user);
+            } catch (Throwable $e) {
+                Logger::error("%s\n%s", $e->getMessage(), IcingaException::getConfidentialTraceAsString($e));
+
+                throw $e;
+            }
+
+            if ($enrolled) {
+                return $method;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Yield display names indexed by machine-readable method name
+     *
+     * @return Generator<string, string>
+     */
+    public static function yieldMethods(): Generator
+    {
+        foreach (self::all() as $method) {
+            yield $method->getName() => $method->getDisplayName();
+        }
+    }
+}

--- a/library/Icinga/Authentication/Auth.php
+++ b/library/Icinga/Authentication/Auth.php
@@ -10,6 +10,7 @@ use Fiber;
 use Icinga\Application\Config;
 use Icinga\Application\Hook\AuditHook;
 use Icinga\Application\Hook\AuthenticationHook;
+use Icinga\Application\Hook\TwoFactorHook;
 use Icinga\Application\Icinga;
 use Icinga\Application\Logger;
 use Icinga\Authentication\User\ExternalBackend;
@@ -23,6 +24,7 @@ use Icinga\User\Preferences\PreferencesStore;
 use Icinga\Web\Session;
 use Icinga\Web\StyleSheet;
 use LogicException;
+use Throwable;
 
 class Auth
 {
@@ -368,6 +370,27 @@ class Auth
         }
         $password = $credentials[1];
         if ($this->getAuthChain()->setSkipExternalBackends(true)->authenticate($user, $password)) {
+            try {
+                $enrolled = TwoFactorHook::loadEnrolled($user) !== null;
+            } catch (Throwable $e) {
+                Logger::error("%s\n%s", $e->getMessage(), IcingaException::getConfidentialTraceAsString($e));
+                $this->getResponse()->json()
+                    ->setHttpResponseCode(500)
+                    ->setErrorMessage('Two-factor authentication cannot be completed via the API')
+                    ->sendResponse();
+            }
+
+            if ($enrolled) {
+                Logger::warning(
+                    'API request rejected for user "%s": two-factor authentication cannot be completed via the API',
+                    $user->getUsername(),
+                );
+                $this->getResponse()->json()
+                    ->setHttpResponseCode(403)
+                    ->setErrorMessage('Two-factor authentication is required and cannot be completed via the API')
+                    ->sendResponse();
+            }
+
             $this->setAuthenticated($user, false);
             $user->setIsHttpUser(true);
             return true;

--- a/library/Icinga/Authentication/TwoFactor.php
+++ b/library/Icinga/Authentication/TwoFactor.php
@@ -1,0 +1,103 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Icinga\Authentication;
+
+use Icinga\Application\Hook\TwoFactorHook;
+use Icinga\Forms\Account\TwoFactorEnrollmentForm;
+use Icinga\User;
+use ipl\Html\FormElement\FieldsetElement;
+
+/**
+ * Contract for a two-factor authentication method
+ */
+interface TwoFactor
+{
+    /**
+     * Get the unique machine-readable identifier for this 2FA method
+     *
+     * Used as a stable key to look up the implementation by name, e.g. via
+     * {@see TwoFactorHook::fromName()}.
+     *
+     * @return string Lowercase identifier for this method, e.g. 'totp'. Must be globally
+     *   unique across all registered implementations. A duplicate logs a warning and
+     *   overwrites the earlier registration. Must be a valid HTML `name` attribute value,
+     *   because it's used as the fieldset name in the enrollment form.
+     */
+    public function getName(): string;
+
+    /**
+     * Get the human-readable name for this 2FA method shown in the UI
+     *
+     * @return string Human-readable name for this method, e.g. 'TOTP'
+     */
+    public function getDisplayName(): string;
+
+    /**
+     * Check whether a user is enrolled in this 2FA method
+     *
+     * Implementations typically query the database for a stored credential (secret, key, ...).
+     *
+     * @param User $user The user to check for
+     *
+     * @return bool True if enrolled, false otherwise
+     */
+    public function isEnrolled(User $user): bool;
+
+    /**
+     * Verify a 2FA token provided by the user
+     *
+     * Called during login to verify the two-factor challenge against the credential
+     * already stored for the user.
+     *
+     * @param User $user The user whose stored credential is checked
+     * @param string $token The raw token string entered by the user, e.g. a 6-digit TOTP code
+     *
+     * @return bool True if the token is valid, false otherwise
+     */
+    public function verify(User $user, string $token): bool;
+
+    /**
+     * Verify the submitted credential and persist it for the given user
+     *
+     * Called from {@see TwoFactorEnrollmentForm::onSuccess()} when the enroll button
+     * is pressed. Reads the method-specific values from $fieldset, verifies that the
+     * credential works, and stores it on success.
+     *
+     * @param User $user The user to enroll
+     * @param FieldsetElement $fieldset The method-specific fieldset containing the
+     *   submitted credential elements
+     *
+     * @return bool True if the credential was verified and stored, false if verification
+     *   failed. On failure, attach a user-visible error to the relevant element in
+     *   $fieldset via {@see FieldsetElement::addMessage()}.
+     */
+    public function enroll(User $user, FieldsetElement $fieldset): bool;
+
+    /**
+     * Remove the stored credential for the given user
+     *
+     * Called from {@see TwoFactorEnrollmentForm::onSuccess()} when the unenroll button is pressed.
+     *
+     * @param User $user The user to unenroll
+     *
+     * @return void
+     */
+    public function unenroll(User $user): void;
+
+    /**
+     * Add the method-specific elements to the enrollment config fieldset
+     *
+     * Called from {@see TwoFactorEnrollmentForm::assemble()}.
+     *
+     * @param User $user The user being enrolled
+     * @param FieldsetElement $fieldset The method-specific fieldset to add elements to.
+     *   Implementations must not rename this element. Its name must equal {@see getName()}
+     *   or a {@see LogicException} is thrown by {@see TwoFactorEnrollmentForm}.
+     *
+     * @return void
+     */
+    public function assembleEnrollmentFormElements(User $user, FieldsetElement $fieldset): void;
+}

--- a/library/Icinga/Authentication/TwoFactor.php
+++ b/library/Icinga/Authentication/TwoFactor.php
@@ -16,15 +16,15 @@ use ipl\Html\FormElement\FieldsetElement;
 interface TwoFactor
 {
     /**
-     * Get the unique machine-readable identifier for this 2FA method
+     * Get the machine-readable identifier for this 2FA method
      *
-     * Used as a stable key to look up the implementation by name, e.g. via
-     * {@see TwoFactorHook::fromName()}.
+     * Combined with the providing module's name to form the globally unique identifier
+     * returned by {@see TwoFactorHook::getCanonicalName()}.
      *
-     * @return string Lowercase identifier for this method, e.g. 'totp'. Must be globally
-     *   unique across all registered implementations. A duplicate logs a warning and
-     *   overwrites the earlier registration. Must be a valid HTML `name` attribute value,
-     *   because it's used as the fieldset name in the enrollment form.
+     * @return string Lowercase identifier for this method, e.g. 'totp'. Must only be
+     *   unique among the methods registered by the same module. Must be a valid HTML
+     *   `name` attribute value, because it is part of the fieldset name in
+     *   {@see TwoFactorEnrollmentForm} via {@see TwoFactorHook::getCanonicalName()}.
      */
     public function getName(): string;
 
@@ -94,8 +94,9 @@ interface TwoFactor
      *
      * @param User $user The user being enrolled
      * @param FieldsetElement $fieldset The method-specific fieldset to add elements to.
-     *   Implementations must not rename this element. Its name must equal {@see getName()}
-     *   or a {@see LogicException} is thrown by {@see TwoFactorEnrollmentForm}.
+     *   Implementations must not rename this element. Its name must equal
+     *   {@see TwoFactorHook::getCanonicalName()} or a {@see LogicException} is thrown by
+     *   {@see TwoFactorEnrollmentForm}.
      *
      * @return void
      */

--- a/library/Icinga/Authentication/TwoFactorState.php
+++ b/library/Icinga/Authentication/TwoFactorState.php
@@ -1,0 +1,106 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Icinga\Authentication;
+
+use Icinga\User;
+use Icinga\Web\RememberMe;
+use Icinga\Web\Session\Session;
+use Icinga\Web\Session\SessionNamespace;
+
+/**
+ * In-session state for a pending two-factor authentication challenge
+ */
+class TwoFactorState
+{
+    /** @var string Session namespace name to isolate all 2FA state */
+    protected const SESSION_NAMESPACE = 'twofactor';
+
+    /** @var string Session key storing the challenged User */
+    protected const SESSION_CHALLENGED_USER = 'challenged_user';
+
+    /** @var string Session key storing the temporary {@see RememberMe} instance */
+    protected const SESSION_REMEMBER_ME_COOKIE = 'remember_me_cookie';
+
+    /** @var SessionNamespace Session namespace scoping the challenge state */
+    protected SessionNamespace $session;
+
+    /**
+     * Create a new TwoFactorState
+     *
+     * @param Session $session
+     */
+    public function __construct(Session $session)
+    {
+        $this->session = $session->getNamespace(static::SESSION_NAMESPACE);
+    }
+
+    /**
+     * Store the user for whom two-factor verification was challenged
+     *
+     * @param User $user
+     *
+     * @return void
+     */
+    public function challenge(User $user): void
+    {
+        $this->session->set(static::SESSION_CHALLENGED_USER, $user);
+    }
+
+    /**
+     * Clear all challenge state from the session
+     *
+     * Call after successful verification.
+     *
+     * @return void
+     */
+    public function completeChallenge(): void
+    {
+        $this->session->delete(static::SESSION_CHALLENGED_USER);
+        $this->session->delete(static::SESSION_REMEMBER_ME_COOKIE);
+    }
+
+    /**
+     * Check whether a two-factor challenge is pending
+     *
+     * @return bool
+     */
+    public function isChallenged(): bool
+    {
+        return $this->getChallengedUser() !== null;
+    }
+
+    /**
+     * Set the remember-me instance to issue after a successful challenge
+     *
+     * @param RememberMe $cookie Temporary remember-me instance
+     *
+     * @return void
+     */
+    public function setRememberMeCookie(RememberMe $cookie): void
+    {
+        $this->session->set(static::SESSION_REMEMBER_ME_COOKIE, $cookie);
+    }
+
+    /**
+     * Get the stored remember-me instance
+     *
+     * @return ?RememberMe
+     */
+    public function getRememberMeCookie(): ?RememberMe
+    {
+        return $this->session->get(static::SESSION_REMEMBER_ME_COOKIE);
+    }
+
+    /**
+     * Get the user for whom two-factor verification was challenged
+     *
+     * @return ?User null if no challenge is active
+     */
+    public function getChallengedUser(): ?User
+    {
+        return $this->session->get(static::SESSION_CHALLENGED_USER);
+    }
+}

--- a/library/Icinga/Authentication/TwoFactorState.php
+++ b/library/Icinga/Authentication/TwoFactorState.php
@@ -6,7 +6,6 @@
 namespace Icinga\Authentication;
 
 use Icinga\User;
-use Icinga\Web\RememberMe;
 use Icinga\Web\Session\Session;
 use Icinga\Web\Session\SessionNamespace;
 
@@ -21,8 +20,8 @@ class TwoFactorState
     /** @var string Session key storing the challenged User */
     protected const SESSION_CHALLENGED_USER = 'challenged_user';
 
-    /** @var string Session key storing the temporary {@see RememberMe} instance */
-    protected const SESSION_REMEMBER_ME_COOKIE = 'remember_me_cookie';
+    /** @var string Session key storing the raw remember-me cookie */
+    protected const SESSION_REMEMBER_ME_COOKIE_DATA = 'remember_me_cookie_data';
 
     /** @var SessionNamespace Session namespace scoping the challenge state */
     protected SessionNamespace $session;
@@ -59,7 +58,7 @@ class TwoFactorState
     public function completeChallenge(): void
     {
         $this->session->delete(static::SESSION_CHALLENGED_USER);
-        $this->session->delete(static::SESSION_REMEMBER_ME_COOKIE);
+        $this->session->delete(static::SESSION_REMEMBER_ME_COOKIE_DATA);
     }
 
     /**
@@ -73,25 +72,25 @@ class TwoFactorState
     }
 
     /**
-     * Set the remember-me instance to issue after a successful challenge
+     * Set the remember-me cookie value to issue after a successful challenge
      *
-     * @param RememberMe $cookie Temporary remember-me instance
+     * @param string $cookieData
      *
      * @return void
      */
-    public function setRememberMeCookie(RememberMe $cookie): void
+    public function setRememberMeCookieData(string $cookieData): void
     {
-        $this->session->set(static::SESSION_REMEMBER_ME_COOKIE, $cookie);
+        $this->session->set(static::SESSION_REMEMBER_ME_COOKIE_DATA, $cookieData);
     }
 
     /**
-     * Get the stored remember-me instance
+     * Get the stored remember-me cookie value
      *
-     * @return ?RememberMe
+     * @return ?string null if no value was set
      */
-    public function getRememberMeCookie(): ?RememberMe
+    public function getRememberMeCookieData(): ?string
     {
-        return $this->session->get(static::SESSION_REMEMBER_ME_COOKIE);
+        return $this->session->get(static::SESSION_REMEMBER_ME_COOKIE_DATA);
     }
 
     /**

--- a/library/Icinga/Web/Form/Element/LoginRedirect.php
+++ b/library/Icinga/Web/Form/Element/LoginRedirect.php
@@ -1,0 +1,43 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Icinga\Web\Form\Element;
+
+use Icinga\Exception\Http\HttpBadRequestException;
+use Icinga\Forms\Authentication\LoginForm;
+use Icinga\Web\Url;
+use ipl\Html\FormElement\HiddenElement;
+
+/**
+ * Hidden form element holding the post-login redirect URL
+ */
+class LoginRedirect extends HiddenElement
+{
+    /**
+     * Return the redirect target for a successful login as a validated, internal Url
+     *
+     * Falls back to {@see LoginForm::REDIRECT_URL} when the stored value is empty or
+     * points to the logout action.
+     *
+     * @return Url
+     *
+     * @throws HttpBadRequestException If the redirect URL is external
+     */
+    public function getUrl(): Url
+    {
+        $redirect = parent::getValue();
+
+        if (empty($redirect) || str_contains($redirect, 'authentication/logout')) {
+            $redirect = LoginForm::REDIRECT_URL;
+        }
+
+        $url = Url::fromPath($redirect);
+        if ($url->isExternal()) {
+            throw new HttpBadRequestException('Redirect to an external URL is not allowed');
+        }
+
+        return $url;
+    }
+}

--- a/library/Icinga/Web/RememberMe.php
+++ b/library/Icinga/Web/RememberMe.php
@@ -299,6 +299,23 @@ class RememberMe
     }
 
     /**
+     * Remove all remember me entries for the given user from the database
+     *
+     * @param string $username
+     *
+     * @return void
+     */
+    public static function removeAllByUsername(string $username): void
+    {
+        $rememberMe = new static();
+        if (! $rememberMe->hasDb()) {
+            return;
+        }
+
+        $rememberMe->getDb()->delete(static::TABLE, ['username = ?' => $username]);
+    }
+
+    /**
      * Create renewed remember me cookie
      *
      * @return static New remember me cookie which has to be sent to the client

--- a/library/Icinga/Web/RememberMe.php
+++ b/library/Icinga/Web/RememberMe.php
@@ -98,9 +98,21 @@ class RememberMe
      *
      * @return static
      */
-    public static function fromCookie()
+    public static function fromCookie(): static
     {
-        $data = explode('|', $_COOKIE[static::COOKIE]);
+        return static::fromCookieData($_COOKIE[static::COOKIE]);
+    }
+
+    /**
+     * Create the remember me component from cookie data
+     *
+     * @param string $data The cookie data
+     *
+     * @return static
+     */
+    public static function fromCookieData(string $data): static
+    {
+        $data = explode('|', $data);
         $iv = base64_decode(array_pop($data));
 
         $select = (new Select())
@@ -135,6 +147,7 @@ class RememberMe
 
         $rememberMe->username = $rs->username;
         $rememberMe->encryptedPassword = $data[0];
+        $rememberMe->expiresAt = strtotime($rs->expires_at);
 
         return $rememberMe;
     }

--- a/library/Icinga/Web/Widget/LoginPage.php
+++ b/library/Icinga/Web/Widget/LoginPage.php
@@ -18,7 +18,9 @@ use ipl\Web\Url;
 /**
  * Login page with logo, footer, social links, and decorative orbs
  *
- * Wraps a login form in the standard login page structure.
+ * Wraps any form content in the standard login page structure. Used for
+ * both the login form and the 2FA challenge form so the visual chrome is
+ * defined in one place.
  *
  * Extends `HtmlDocument` rather than `BaseHtmlElement` because the login
  * page emits `#login` and seven `.orb` sibling divs at the top level —

--- a/public/css/icinga/login.less
+++ b/public/css/icinga/login.less
@@ -109,6 +109,26 @@
     &:hover {
       background-color: @icinga-secondary-dark;
     }
+
+    &.btn-back-to-login-link {
+      width: fit-content;
+      height: fit-content;
+      margin: 0 auto;
+      padding: 0;
+      background: none;
+
+      p {
+        margin: 0;
+      }
+
+      &:hover {
+        opacity: 0.8;
+
+        span {
+          text-decoration: underline;
+        }
+      }
+    }
   }
 
   .config-note {


### PR DESCRIPTION
Introduce a `TwoFactor` interface and `TwoFactorHook` abstract base class that modules can extend to provide 2FA methods. The core handles the full flow around them:

- **Login**: after password auth, users enrolled in a registered method are redirected to a token challenge page before the session is established
- **Enrollment**: a new "Two-Factor Auth" tab in account settings lets users enroll in or unenroll from any registered method
- **API**: HTTP Basic auth requests are rejected with 403 when the user has a 2FA credential, since the token step cannot be completed over Basic auth for now
- **Remember me**: cookies are revoked on enrollment and unenrollment. During a pending challenge the AES key is kept in the database and only the ciphertext is stored in the session, so the two halves are never co-located.

To provide a 2FA method, a module extends `TwoFactorHook`, implements the `TwoFactor` interface, and calls `TwoFactorHook::register()` in the `run.php`.

require https://github.com/Icinga/ipl-web/pull/393