### PR TITLE
css; fix the negative margin for .control-group

### DIFF
--- a/public/css/icinga/forms.less
+++ b/public/css/icinga/forms.less
@@ -21,9 +21,7 @@ form.icinga-form {
     flex-wrap: wrap;
     align-items: flex-start;
 
-    // Negative margin-right because every child gets 1em right but we can't exclude
-    // the last element as it's impossible to identify the last *visible* element
-    margin: 1em -1em 1em 0;
+    margin: 1em 0;
 
     > fieldset {
       > .control-group:first-of-type {


### PR DESCRIPTION
Replaces `margin: 1em -1em 1em 0` with `margin: 1em 0em` for consistent spacing and no negative margin for both better practice and future features.