### PR TITLE
Fix DB privilege check for database names containing `_` or `%`

### DIFF
--- a/modules/setup/library/Setup/Utils/DbTool.php
+++ b/modules/setup/library/Setup/Utils/DbTool.php
@@ -776,7 +776,7 @@ EOD;
 
                 $dbAndTableQuery = $this->query(
                     sprintf($queryString, join(',', array_map(array($this, 'quote'), $dbPrivileges))),
-                    array(':grantee' => $grantee, ':dbname' => $this->escapeTableWildcards($this->config['dbname']))
+                    array(':grantee' => $grantee, ':dbname' => $this->config['dbname'])
                 );
                 $grantedDbAndTablePrivileges = (int) $dbAndTableQuery->fetchObject()->matches;
                 if ($grantedDbAndTablePrivileges === count($dbPrivileges)) {
@@ -793,7 +793,7 @@ EOD;
                             sprintf($queryString, join(',', array_map(array($this, 'quote'), $dbExclusivePrivileges))),
                             array(
                                 ':grantee'  => $grantee,
-                                ':dbname'   => $this->escapeTableWildcards($this->config['dbname'])
+                                ':dbname'   => $this->config['dbname']
                             )
                         );
                         $dbPrivilegesGranted = (int) $dbExclusiveQuery->fetchObject()->matches === count(


### PR DESCRIPTION
Fixes the DB privilege check failing for database names with _ or %. The schema_privileges queries escaped the db name (_ → \_) before an = comparison — escaping only works with LIKE, so it
  never matched. Bind the raw name instead, consistent with the table_privileges query right below.

refs #5521