### PR TITLE
`menu.less`: Add style for init setup icon for notifications web

### DIFF
--- a/public/css/icinga/menu.less
+++ b/public/css/icinga/menu.less
@@ -611,3 +611,20 @@ html.no-js  #toggle-sidebar {
     }
   }
 }
+
+#menu .nav-level-1 > .nav-item.module-notifications.initial-setup-required {
+  &.selected i.initial-setup-icon {
+    display: none;
+  }
+
+  i.initial-setup-icon {
+    font-size: 1.5em;
+    color: @color-warning;
+
+    float: right;
+
+    &:focus {
+      display: none;
+    }
+  }
+}


### PR DESCRIPTION
This PR adds style for the menu icon of the icinga-notifications-web module, which appears when the initial setup is required.