### PR TITLE
js: Consider forms changed that don't close the modal

### DIFF
--- a/public/js/icinga/behavior/modal.js
+++ b/public/js/icinga/behavior/modal.js
@@ -145,6 +145,10 @@
 
             if (req.getResponseHeader('X-Icinga-Redirect')) {
                 _this.hide($modal);
+            } else {
+                // Validation error, structural changes or whatever, the form is presented again
+                // so we can assume the user should not accidentally close the modal
+                _this.hasChanges = true;
             }
         }).always(function () {
             delete $modal[0].dataset.noIcingaAjax;


### PR DESCRIPTION
Submitting the form by a button isn't detected as change like that to any other input. The form may also be presented again in case the input doesn't constrain to requirements made. In any case, the modal doesn't know the actual reason and has to assume that any form that doesn't close it displays new content the user doesn't want to loose.

closes #5513