### PR TITLE
Fix callsites to PdfExportHook assume use of HookEssentials

### DIFF
--- a/library/Icinga/File/Pdf.php
+++ b/library/Icinga/File/Pdf.php
@@ -8,6 +8,7 @@ namespace Icinga\File;
 use Dompdf\Dompdf;
 use Dompdf\Options;
 use Exception;
+use Icinga\Application\Hook;
 use Icinga\Application\Hook\PdfexportHook;
 use Icinga\Application\Icinga;
 use Icinga\Exception\ProgrammingError;
@@ -56,7 +57,7 @@ class Pdf
 
         $request = $controller->getRequest();
 
-        if (PdfexportHook::isRegistered()) {
+        if (Hook::has('Pdfexport')) {
             $pdfexport = PdfexportHook::first();
             $pdfexport->streamPdfFromHtml($html, sprintf(
                 '%s-%s-%d',

--- a/library/Icinga/Web/Widget/Tabextension/OutputFormat.php
+++ b/library/Icinga/Web/Widget/Tabextension/OutputFormat.php
@@ -5,7 +5,6 @@
 
 namespace Icinga\Web\Widget\Tabextension;
 
-use Icinga\Application\Hook\PdfexportHook;
 use Icinga\Application\Platform;
 use Icinga\Application\Hook;
 use Icinga\Web\Url;
@@ -85,7 +84,7 @@ class OutputFormat implements Tabextension
     {
         $supportedTypes = array();
 
-        $pdfexport = PdfexportHook::isRegistered();
+        $pdfexport = Hook::has('Pdfexport');
 
         if ($pdfexport || Platform::extensionLoaded('gd')) {
             $supportedTypes[self::TYPE_PDF] = array(


### PR DESCRIPTION
#5474 introduced a set of common methods for hooks, #5491 removed these changes to stay compatible with the original implementation, but failed to change back the call sites.

This PR fixes that.