### PR TITLE
Fix config form value & Simplify CspConfigForm

### DIFF
--- a/application/controllers/ConfigController.php
+++ b/application/controllers/ConfigController.php
@@ -133,25 +133,14 @@ class ConfigController extends Controller
 
         $this->view->title = $this->translate('Security');
 
-        $config = Config::app();
-        $cspForm = new CspConfigForm($config);
-        $cspForm->setCsrfCounterMeasureId(Session::getSession()->getId());
-        // Keep the auto-generation options off by default for installations that already
-        // had CSP enabled, so their existing behavior isn't changed. For installations
-        // enabling CSP for the first time, default them on as the recommended setting.
-        $defaultValue = $cspForm->isCspEnabled() ? '0' : '1';
-        $cspForm->populate([
-            'security__csp_enable_modules'    => $config->get('security', 'csp_enable_modules', $defaultValue),
-            'security__csp_enable_dashboards' => $config->get('security', 'csp_enable_dashboards', $defaultValue),
-            'security__csp_enable_navigation' => $config->get('security', 'csp_enable_navigation', $defaultValue),
-        ]);
-
-        $cspForm->on(ContractForm::ON_SUBMIT, function (CspConfigForm $form) {
-            if ($form->hasConfigChanged()) {
-                $this->getResponse()->setReloadWindow(true);
-            }
-        });
-        $cspForm->handleRequest(ServerRequest::fromGlobals());
+        $cspForm = (new CspConfigForm(Config::app()))
+            ->setCsrfCounterMeasureId(Session::getSession()->getId())
+            ->on(ContractForm::ON_SUBMIT, function (CspConfigForm $form) {
+                if ($form->hasConfigChanged()) {
+                    $this->getResponse()->setReloadWindow(true);
+                }
+            })
+            ->handleRequest(ServerRequest::fromGlobals());
         $this->view->cspForm = $cspForm;
         $this->createApplicationTabs()->activate('security');
     }

--- a/application/forms/Config/Security/CspConfigForm.php
+++ b/application/forms/Config/Security/CspConfigForm.php
@@ -163,186 +163,188 @@ class CspConfigForm extends ConfigForm
             $this->addElement('hidden', 'security__csp_enable_modules');
             $this->addElement('hidden', 'security__csp_enable_dashboards');
             $this->addElement('hidden', 'security__csp_enable_navigation');
-        } else {
-            $this->addHtml((new DisplayFormElement(
-                HtmlElement::create('div', null, [
-                    HtmlElement::create('h3', ['class' => $formHintClassList], $this->translate('Allowed Sources')),
-                    HtmlElement::create('p', ['class' => $formHintClassList], $this->translate(
-                        'Sources that are used in the generation of the CSP header.',
-                    )),
-                    HtmlElement::create('h4', ['class' => $formHintClassList], $this->translate('System')),
-                ]),
-            ))->addAttributes(Attributes::create(['class' => 'csp-control-group'])));
 
-            $this->addDirectiveContentElement(
-                [Csp::getSystemCsp()],
-                [$this->translate('Directive'), $this->translate('Value')],
-                function (StaticCspReason $reason, string $directive, string $expression) {
-                    return Table::tr([Table::td($directive), $this->buildExpression($directive, $expression)]);
-                },
-                ! $useCustomCsp,
-                $this->translate('No system policies defined.'),
-            );
-
-            $this->addDirectiveCheckboxElement(
-                $this->translate('Enable Modules'),
-                $this->translate(
-                    'Should module defined CSP directives be enabled?'
-                    . ' Modules can define or change csp directives at any point.',
-                ),
-                'csp_enable_modules',
-                ! $useCustomCsp,
-            );
-
-            $this->addDirectiveContentElement(
-                (new ModuleCspLoader())->loadForAllUsers(),
-                [$this->translate('Module'), $this->translate('Directive'), $this->translate('Value')],
-                function (ModuleCspReason $reason, string $directive, string $expression) {
-                    return Table::tr([
-                        Table::td($reason->module),
-                        Table::td($directive),
-                        $this->buildExpression($directive, $expression),
-                    ]);
-                },
-                ! $useCustomCsp && $this->getValue('security__csp_enable_modules') === '1',
-                $this->translate('No module policies defined.'),
-            );
-
-            $this->addDirectiveCheckboxElement(
-                $this->translate('Enable Dashboards'),
-                $this->translate(
-                    'Enable user defined dashboards. This table contains all dashboards for all users. The actual'
-                    . ' header that is sent to the user will only contain the subset of directives that actually'
-                    . ' matters to them.',
-                ),
-                'csp_enable_dashboards',
-                ! $useCustomCsp,
-            );
-
-            $this->addDirectiveContentElement(
-                (new DashboardCspLoader())->loadForAllUsers(),
-                [
-                    $this->translate('Dashboard'),
-                    $this->translate('Dashlet'),
-                    $this->translate('User'),
-                    $this->translate('Directive'),
-                    $this->translate('Value'),
-                ],
-                function (DashboardCspReason $reason, string $directive, string $expression) {
-                    return Table::tr([
-                        Table::td($reason->pane->getName()),
-                        Table::td($reason->dashlet->getName()),
-                        Table::td($reason->dashboard->getUser()->getUsername()),
-                        Table::td($directive),
-                        $this->buildExpression($directive, $expression),
-                    ]);
-                },
-                ! $useCustomCsp && $this->getValue('security__csp_enable_dashboards') === '1',
-                $this->translate('No dashboard policies found.'),
-            );
-
-            $this->addDirectiveCheckboxElement(
-                $this->translate('Enable Navigation Items'),
-                $this->translate(
-                    'Enable user defined navigation items. This table contains all navigation items for'
-                    . ' all users. The actual header that is sent to the user will only contain the subset of'
-                    . ' directives that actually matters to them.',
-                ),
-                'csp_enable_navigation',
-                ! $useCustomCsp,
-            );
-
-            $this->addDirectiveContentElement(
-                (new NavigationCspLoader())->loadForAllUsers(),
-                [
-                    $this->translate('Navigation'),
-                    $this->translate('Parent'),
-                    $this->translate('Name'),
-                    $this->translate('User'),
-                    $this->translate('Directive'),
-                    $this->translate('Value'),
-                ],
-                function (NavigationCspReason $reason, string $directive, string $expression) {
-                    $parentCell = $reason->parent === null
-                        ? Table::td($this->translate('None'))->setAttribute('class', 'empty-state')
-                        : Table::td($reason->parent);
-
-                    $sharedIcon = match ($reason->isShared) {
-                        true  => new Icon('share', [
-                            'class' => 'shared-item',
-                            'title' => $this->translate('Shared item. Displayed user is owner.'),
-                        ]),
-                        false => null,
-                    };
-
-                    $userCell = $reason->username === null
-                        ? Table::td([$sharedIcon, $this->translate('Unknown')])->setAttribute('class', 'empty-state')
-                        : Table::td([$sharedIcon, $reason->username]);
-
-                    return Table::tr([
-                        Table::td($reason->typeConfiguration['label'] ?? $reason->type),
-                        $parentCell,
-                        Table::td($reason->name),
-                        $userCell,
-                        Table::td($directive),
-                        $this->buildExpression($directive, $expression),
-                    ]);
-                },
-                ! $useCustomCsp && $this->getValue('security__csp_enable_navigation') === '1',
-                $this->translate('No navigation policies found.'),
-            );
-
-            $this->addElement('checkbox', 'security__use_custom_csp', [
-                'label'          => $this->translate('Enable Custom CSP'),
-                'description'    => $this->translate(
-                    'Specify whether to use a custom, user-provided string as the CSP header.',
-                ),
-                'class'          => 'autosubmit csp-form-content-aligned csp-label-header-h3 csp-form-header',
-                'checkedValue'   => '1',
-                'uncheckedValue' => '0',
-                'value'          => '0',
-            ]);
-
-            if ($this->isCustomCspEnabled()) {
-                $this->add(new DisplayFormElement(new Callout(
-                    CalloutType::Warning,
-                    $this->translate(
-                        'Be aware that the custom CSP header completely overrides the automatically generated one.'
-                        . ' This means that you are solely responsible for keeping the custom CSP header up to date'
-                        . ' and secure.',
-                    ),
-                    $this->translate('Warning: Use at your own risk!'),
-                )));
-            }
-
-            $this->addElement('textarea', 'security__custom_csp', [
-                'label'       => '',
-                'description' => $this->translate(
-                    'Set a custom CSP header. This completely overrides the automatically generated one.'
-                    . ' Use the placeholder {style_nonce} to insert the automatically generated style nonce.',
-                ),
-                'rows'        => static::TEXTAREA_ROWS,
-                'disabled'    => ! $this->isCustomCspEnabled(),
-                'required'    => $this->isCustomCspEnabled(),
-                'validators'  => [
-                    new CallbackValidator(function ($value, CallbackValidator $validator) {
-                        if (empty($value) || ! $this->isCustomCspEnabled()) {
-                            return true;
-                        }
-
-                        try {
-                            CspInstance::fromString(str_replace('{style_nonce}', "'nonce-validation'", $value));
-                        } catch (Exception $e) {
-                            $validator->addMessage($e->getMessage());
-
-                            return false;
-                        }
-
-                        return true;
-                    }),
-                ],
-            ]);
+            return;
         }
+
+        $this->addHtml((new DisplayFormElement(
+            HtmlElement::create('div', null, [
+                HtmlElement::create('h3', ['class' => $formHintClassList], $this->translate('Allowed Sources')),
+                HtmlElement::create('p', ['class' => $formHintClassList], $this->translate(
+                    'Sources that are used in the generation of the CSP header.',
+                )),
+                HtmlElement::create('h4', ['class' => $formHintClassList], $this->translate('System')),
+            ]),
+        ))->addAttributes(Attributes::create(['class' => 'csp-control-group'])));
+
+        $this->addDirectiveContentElement(
+            [Csp::getSystemCsp()],
+            [$this->translate('Directive'), $this->translate('Value')],
+            function (StaticCspReason $reason, string $directive, string $expression) {
+                return Table::tr([Table::td($directive), $this->buildExpression($directive, $expression)]);
+            },
+            ! $useCustomCsp,
+            $this->translate('No system policies defined.'),
+        );
+
+        $this->addDirectiveCheckboxElement(
+            $this->translate('Enable Modules'),
+            $this->translate(
+                'Should module defined CSP directives be enabled?'
+                . ' Modules can define or change csp directives at any point.',
+            ),
+            'csp_enable_modules',
+            ! $useCustomCsp,
+        );
+
+        $this->addDirectiveContentElement(
+            (new ModuleCspLoader())->loadForAllUsers(),
+            [$this->translate('Module'), $this->translate('Directive'), $this->translate('Value')],
+            function (ModuleCspReason $reason, string $directive, string $expression) {
+                return Table::tr([
+                    Table::td($reason->module),
+                    Table::td($directive),
+                    $this->buildExpression($directive, $expression),
+                ]);
+            },
+            ! $useCustomCsp && $this->getValue('security__csp_enable_modules') === '1',
+            $this->translate('No module policies defined.'),
+        );
+
+        $this->addDirectiveCheckboxElement(
+            $this->translate('Enable Dashboards'),
+            $this->translate(
+                'Enable user defined dashboards. This table contains all dashboards for all users. The actual'
+                . ' header that is sent to the user will only contain the subset of directives that actually'
+                . ' matters to them.',
+            ),
+            'csp_enable_dashboards',
+            ! $useCustomCsp,
+        );
+
+        $this->addDirectiveContentElement(
+            (new DashboardCspLoader())->loadForAllUsers(),
+            [
+                $this->translate('Dashboard'),
+                $this->translate('Dashlet'),
+                $this->translate('User'),
+                $this->translate('Directive'),
+                $this->translate('Value'),
+            ],
+            function (DashboardCspReason $reason, string $directive, string $expression) {
+                return Table::tr([
+                    Table::td($reason->pane->getName()),
+                    Table::td($reason->dashlet->getName()),
+                    Table::td($reason->dashboard->getUser()->getUsername()),
+                    Table::td($directive),
+                    $this->buildExpression($directive, $expression),
+                ]);
+            },
+            ! $useCustomCsp && $this->getValue('security__csp_enable_dashboards') === '1',
+            $this->translate('No dashboard policies found.'),
+        );
+
+        $this->addDirectiveCheckboxElement(
+            $this->translate('Enable Navigation Items'),
+            $this->translate(
+                'Enable user defined navigation items. This table contains all navigation items for'
+                . ' all users. The actual header that is sent to the user will only contain the subset of'
+                . ' directives that actually matters to them.',
+            ),
+            'csp_enable_navigation',
+            ! $useCustomCsp,
+        );
+
+        $this->addDirectiveContentElement(
+            (new NavigationCspLoader())->loadForAllUsers(),
+            [
+                $this->translate('Navigation'),
+                $this->translate('Parent'),
+                $this->translate('Name'),
+                $this->translate('User'),
+                $this->translate('Directive'),
+                $this->translate('Value'),
+            ],
+            function (NavigationCspReason $reason, string $directive, string $expression) {
+                $parentCell = $reason->parent === null
+                    ? Table::td($this->translate('None'))->setAttribute('class', 'empty-state')
+                    : Table::td($reason->parent);
+
+                $sharedIcon = match ($reason->isShared) {
+                    true  => new Icon('share', [
+                        'class' => 'shared-item',
+                        'title' => $this->translate('Shared item. Displayed user is owner.'),
+                    ]),
+                    false => null,
+                };
+
+                $userCell = $reason->username === null
+                    ? Table::td([$sharedIcon, $this->translate('Unknown')])->setAttribute('class', 'empty-state')
+                    : Table::td([$sharedIcon, $reason->username]);
+
+                return Table::tr([
+                    Table::td($reason->typeConfiguration['label'] ?? $reason->type),
+                    $parentCell,
+                    Table::td($reason->name),
+                    $userCell,
+                    Table::td($directive),
+                    $this->buildExpression($directive, $expression),
+                ]);
+            },
+            ! $useCustomCsp && $this->getValue('security__csp_enable_navigation') === '1',
+            $this->translate('No navigation policies found.'),
+        );
+
+        $this->addElement('checkbox', 'security__use_custom_csp', [
+            'label'          => $this->translate('Enable Custom CSP'),
+            'description'    => $this->translate(
+                'Specify whether to use a custom, user-provided string as the CSP header.',
+            ),
+            'class'          => 'autosubmit csp-form-content-aligned csp-label-header-h3 csp-form-header',
+            'checkedValue'   => '1',
+            'uncheckedValue' => '0',
+            'value'          => '0',
+        ]);
+
+        if ($this->isCustomCspEnabled()) {
+            $this->add(new DisplayFormElement(new Callout(
+                CalloutType::Warning,
+                $this->translate(
+                    'Be aware that the custom CSP header completely overrides the automatically generated one.'
+                    . ' This means that you are solely responsible for keeping the custom CSP header up to date'
+                    . ' and secure.',
+                ),
+                $this->translate('Warning: Use at your own risk!'),
+            )));
+        }
+
+        $this->addElement('textarea', 'security__custom_csp', [
+            'label'       => '',
+            'description' => $this->translate(
+                'Set a custom CSP header. This completely overrides the automatically generated one.'
+                . ' Use the placeholder {style_nonce} to insert the automatically generated style nonce.',
+            ),
+            'rows'        => static::TEXTAREA_ROWS,
+            'disabled'    => ! $this->isCustomCspEnabled(),
+            'required'    => $this->isCustomCspEnabled(),
+            'validators'  => [
+                new CallbackValidator(function ($value, CallbackValidator $validator) {
+                    if (empty($value) || ! $this->isCustomCspEnabled()) {
+                        return true;
+                    }
+
+                    try {
+                        CspInstance::fromString(str_replace('{style_nonce}', "'nonce-validation'", $value));
+                    } catch (Exception $e) {
+                        $validator->addMessage($e->getMessage());
+
+                        return false;
+                    }
+
+                    return true;
+                }),
+            ],
+        ]);
     }
 
     protected function onSuccess(): void

--- a/application/forms/Config/Security/CspConfigForm.php
+++ b/application/forms/Config/Security/CspConfigForm.php
@@ -303,6 +303,7 @@ class CspConfigForm extends ConfigForm
                     'class'          => 'autosubmit csp-form-content-aligned csp-label-header-h3 csp-form-header',
                     'checkedValue'   => '1',
                     'uncheckedValue' => '0',
+                    'value'          => '0',
                 ],
             );
 

--- a/application/forms/Config/Security/CspConfigForm.php
+++ b/application/forms/Config/Security/CspConfigForm.php
@@ -22,6 +22,7 @@ use ipl\Html\BaseHtmlElement;
 use ipl\Html\HtmlElement;
 use ipl\Html\Table;
 use ipl\Html\Text;
+use ipl\Stdlib\Str;
 use ipl\Validator\CallbackValidator;
 use ipl\Web\Common\CalloutType;
 use ipl\Web\Common\Csp as CspInstance;
@@ -189,7 +190,7 @@ class CspConfigForm extends ConfigForm
                     'Should module defined CSP directives be enabled?'
                     . ' Modules can define or change csp directives at any point.',
                 ),
-                'security__csp_enable_modules',
+                'csp_enable_modules',
                 ! $useCustomCsp,
             );
 
@@ -214,7 +215,7 @@ class CspConfigForm extends ConfigForm
                     . ' header that is sent to the user will only contain the subset of directives that actually'
                     . ' matters to them.',
                 ),
-                'security__csp_enable_dashboards',
+                'csp_enable_dashboards',
                 ! $useCustomCsp,
             );
 
@@ -247,7 +248,7 @@ class CspConfigForm extends ConfigForm
                     . ' all users. The actual header that is sent to the user will only contain the subset of'
                     . ' directives that actually matters to them.',
                 ),
-                'security__csp_enable_navigation',
+                'csp_enable_navigation',
                 ! $useCustomCsp,
             );
 
@@ -394,7 +395,7 @@ class CspConfigForm extends ConfigForm
      *
      * @param string $label The label of the checkbox
      * @param string $description The description of the checkbox
-     * @param string $field The name of the checkbox field
+     * @param string $key The key of the checkbox field in the config
      * @param bool $enabled Whether the checkbox should be checked and enabled
      *
      * @return void
@@ -402,7 +403,7 @@ class CspConfigForm extends ConfigForm
     protected function addDirectiveCheckboxElement(
         string $label,
         string $description,
-        string $field,
+        string $key,
         bool $enabled,
     ): void {
         $classList = [
@@ -415,6 +416,17 @@ class CspConfigForm extends ConfigForm
             $classList[] = 'csp-disabled';
         }
 
+        $field = 'security' . $this->sectionKeyDelimiter . $key;
+
+        // Keep the auto-generation options off by default for installations that already
+        // had CSP enabled, so their existing behavior isn't changed. For installations
+        // enabling CSP for the first time, default them on as the recommended setting.
+        $cspWasEnabled = $this->config->get('security', 'use_strict_csp') === '1';
+        $defaultValue = $cspWasEnabled ? '0' : '1';
+        if (Str::isEmpty($this->getPopulatedValue($field)) && $this->config->get('security', $key) === null) {
+            $this->populate([$field => $defaultValue]);
+        }
+
         $this->addElement('checkbox', $field, [
             'label'          => $label,
             'description'    => $description,
@@ -422,7 +434,6 @@ class CspConfigForm extends ConfigForm
             'checkedValue'   => '1',
             'uncheckedValue' => '0',
             'disabled'       => ! $enabled,
-            'value'          => $this->getPopulatedValue($field),
         ]);
     }
 

--- a/application/forms/Config/Security/CspConfigForm.php
+++ b/application/forms/Config/Security/CspConfigForm.php
@@ -292,20 +292,16 @@ class CspConfigForm extends ConfigForm
                 $this->translate('No navigation policies found.'),
             );
 
-            $this->addElement(
-                'checkbox',
-                'security__use_custom_csp',
-                [
-                    'label'          => $this->translate('Enable Custom CSP'),
-                    'description'    => $this->translate(
-                        'Specify whether to use a custom, user-provided string as the CSP header.',
-                    ),
-                    'class'          => 'autosubmit csp-form-content-aligned csp-label-header-h3 csp-form-header',
-                    'checkedValue'   => '1',
-                    'uncheckedValue' => '0',
-                    'value'          => '0',
-                ],
-            );
+            $this->addElement('checkbox', 'security__use_custom_csp', [
+                'label'          => $this->translate('Enable Custom CSP'),
+                'description'    => $this->translate(
+                    'Specify whether to use a custom, user-provided string as the CSP header.',
+                ),
+                'class'          => 'autosubmit csp-form-content-aligned csp-label-header-h3 csp-form-header',
+                'checkedValue'   => '1',
+                'uncheckedValue' => '0',
+                'value'          => '0',
+            ]);
 
             if ($this->isCustomCspEnabled()) {
                 $this->add(new DisplayFormElement(new Callout(
@@ -544,7 +540,7 @@ class CspConfigForm extends ConfigForm
             if (in_array($directive, static::CRITICAL_DATA_DIRECTIVES)) {
                 return 'critical';
             }
-    
+
             if (in_array($directive, static::WARNING_DATA_DIRECTIVES)) {
                 return 'warning';
             }

--- a/library/Icinga/Web/Form/ConfigForm.php
+++ b/library/Icinga/Web/Form/ConfigForm.php
@@ -8,7 +8,6 @@ namespace Icinga\Web\Form;
 use Exception;
 use Icinga\Application\Config;
 use ipl\Html\Contract\FormElement;
-use ipl\Html\Contract\ValueCandidates;
 use ipl\Html\HtmlElement;
 use ipl\Html\ValidHtml;
 use ipl\Stdlib\Str;
@@ -57,38 +56,35 @@ class ConfigForm extends CompatForm
     public function __construct(
         protected Config $config,
     ) {
-        $this->on(static::ON_ELEMENT_REGISTERED, function (FormElement $element) {
-            [$section, $key] = Str::symmetricSplit($element->getName(), $this->sectionKeyDelimiter, 2);
-            if ($key === null || $element->hasValue()) {
-                return;
-            }
-
-            $configValue = $this->config->get($section, $key);
-            if ($configValue === null) {
-                return;
-            }
-
-            if (! ($element instanceof ValueCandidates)) {
-                $element->setValue($configValue);
-
-                return;
-            }
-
-            $candidates = $element->getValueCandidates();
-            if (empty($candidates)) {
-                // Initial render: no prior submission, set value and seed candidates
-                $element->setValue($configValue);
-                $element->setValueCandidates([$configValue]);
-            } else {
-                // POST: candidates were set by registerElement; append config value so
-                // PasswordElement's (count > 1) condition resolves DUMMYPASSWORD on re-render
-                $element->setValueCandidates(array_merge($candidates, [$configValue]));
-            }
-        });
-
         $this->on(static::ON_ASSEMBLED, function (ConfigForm $form) {
             $form->addRequiredElements();
         });
+    }
+
+    /**
+     * Register the given element, seeding it with its configuration value first
+     *
+     * @param FormElement $element
+     *
+     * @return $this
+     */
+    public function registerElement(FormElement $element): static
+    {
+        $name = $element->getName();
+        [$section, $key] = Str::symmetricSplit($name, $this->sectionKeyDelimiter, 2);
+        if ($key !== null) {
+            $configValue = $this->config->get($section, $key);
+            if ($configValue !== null) {
+                $populatedValues = $this->getPopulatedValues($name);
+                $this->clearPopulatedValue($name);
+                $this->populate([$name => $configValue]);
+                foreach ($populatedValues as $value) {
+                    $this->populate([$name => $value]);
+                }
+            }
+        }
+
+        return parent::registerElement($element);
     }
 
     /**

--- a/library/Icinga/Web/Form/ConfigForm.php
+++ b/library/Icinga/Web/Form/ConfigForm.php
@@ -16,6 +16,7 @@ use ipl\Web\Compat\CompatForm;
 use ipl\Web\Compat\DisplayFormElement;
 use ipl\Web\Widget\CopyToClipboard;
 use LogicException;
+use stdClass;
 
 /**
  * Form base-class providing standard functionality for configuration forms
@@ -49,6 +50,16 @@ class ConfigForm extends CompatForm
     protected string $sectionKeyDelimiter = '__';
 
     /**
+     * The original values of the form elements
+     *
+     * This is used to determine whether an element's submitted value differs from
+     * the original value.
+     *
+     * @var array<string, mixed>
+     */
+    protected array $originalValues = [];
+
+    /**
      * Create a new configuration form
      *
      * @param Config $config The ini file configuration object to use for the form
@@ -73,8 +84,11 @@ class ConfigForm extends CompatForm
         $name = $element->getName();
         [$section, $key] = Str::symmetricSplit($name, $this->sectionKeyDelimiter, 2);
         if ($key !== null) {
-            $configValue = $this->config->get($section, $key);
-            if ($configValue !== null) {
+            $this->originalValues[$name] = $element->getValue();
+
+            $sentinel = new stdClass();
+            $configValue = $this->config->getSection($section)->get($key, $this->originalValues[$name] ?? $sentinel);
+            if ($configValue !== $sentinel) {
                 $populatedValues = $this->getPopulatedValues($name);
                 $this->clearPopulatedValue($name);
                 $this->populate([$name => $configValue]);

--- a/library/Icinga/Web/Form/ConfigForm.php
+++ b/library/Icinga/Web/Form/ConfigForm.php
@@ -166,8 +166,11 @@ class ConfigForm extends CompatForm
                 throw new LogicException(sprintf('Cannot save element "%s": array values are not supported', $element));
             }
 
+            $originalValue = $this->originalValues[$element] ?? '';
             $configSection = $this->config->getSection($section);
-            if (Str::isEmpty($value)) {
+            if ($originalValue !== '' && Str::isEmpty($value)) {
+                $configSection[$key] = '';
+            } elseif ($originalValue === $value || Str::isEmpty($value)) {
                 unset($configSection[$key]);
             } else {
                 $configSection[$key] = $value;

--- a/test/php/application/forms/Config/Security/CspConfigFormTest.php
+++ b/test/php/application/forms/Config/Security/CspConfigFormTest.php
@@ -1,0 +1,80 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Tests\Icinga\Forms\Config\Security;
+
+use Icinga\Application\Config;
+use Icinga\Forms\Config\Security\CspConfigForm;
+use Icinga\Test\BaseTestCase;
+
+class CspConfigFormTest extends BaseTestCase
+{
+    public function testDirectiveCheckboxesDefaultOnWhenStrictCspIsUnconfigured(): void
+    {
+        $this->assertDirectiveDefaults([], '1');
+    }
+
+    public function testDirectiveCheckboxesDefaultOnWhenStrictCspWasDisabled(): void
+    {
+        $this->assertDirectiveDefaults(['security' => ['use_strict_csp' => '0']], '1');
+    }
+
+    public function testDirectiveCheckboxesDefaultOffWhenStrictCspWasEnabled(): void
+    {
+        $this->assertDirectiveDefaults(['security' => ['use_strict_csp' => '1']], '0');
+    }
+
+    public function testConfiguredDirectiveCheckboxValuesOverrideDefaults(): void
+    {
+        $form = $this->createDirectiveForm([
+            'security' => [
+                'use_strict_csp'        => '1',
+                'csp_enable_modules'    => '1',
+                'csp_enable_dashboards' => '1',
+                'csp_enable_navigation' => '1',
+            ],
+        ]);
+
+        $this->assertSame('1', $form->getValue('security__csp_enable_modules'));
+        $this->assertSame('1', $form->getValue('security__csp_enable_dashboards'));
+        $this->assertSame('1', $form->getValue('security__csp_enable_navigation'));
+    }
+
+/**
+ * @param array{security?: array<string, string>} $configData
+ */
+private function assertDirectiveDefaults(array $configData, string $expected): void
+    {
+        $form = $this->createDirectiveForm($configData);
+
+        foreach (['csp_enable_modules', 'csp_enable_dashboards', 'csp_enable_navigation'] as $key) {
+            $this->assertSame($expected, $form->getValue('security__' . $key), $key);
+        }
+    }
+
+/**
+ * @param array{security?: array<string, string>} $configData
+ */
+private function createDirectiveForm(array $configData): CspConfigForm
+    {
+        $form = new class (Config::fromArray($configData)) extends CspConfigForm {
+            protected function assemble(): void
+            {
+            }
+
+            public function addDirectiveCheckboxForTest(string $key): void
+            {
+                $this->addDirectiveCheckboxElement($key, $key, $key, true);
+            }
+        };
+        $form->disableCsrfCounterMeasure();
+
+        foreach (['csp_enable_modules', 'csp_enable_dashboards', 'csp_enable_navigation'] as $key) {
+            $form->addDirectiveCheckboxForTest($key);
+        }
+
+        return $form;
+    }
+}

--- a/test/php/library/Icinga/Web/Form/ConfigFormTest.php
+++ b/test/php/library/Icinga/Web/Form/ConfigFormTest.php
@@ -12,6 +12,7 @@ use Icinga\Test\BaseTestCase;
 use Icinga\Web\Form\ConfigForm;
 use ipl\Html\FormElement\PasswordElement;
 use LogicException;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ConfigFormTest extends BaseTestCase
 {
@@ -89,7 +90,8 @@ class ConfigFormTest extends BaseTestCase
         $this->assertSame($csrfElement, $form->getElement('CSRFToken'));
     }
 
-    public function testSaveThrowsForArrayElementValue(): void
+    #[DataProvider('populationTimings')]
+    public function testSaveThrowsForArrayElementValue(bool $populateBeforeAssembly): void
     {
         $this->expectException(LogicException::class);
 
@@ -112,12 +114,12 @@ class ConfigFormTest extends BaseTestCase
             }
         };
         $form->disableCsrfCounterMeasure();
-        $form->ensureAssembled();
-        $form->populate(['mysection__key' => ['a', 'b']]);
+        $this->populateAroundAssembly($form, [['mysection__key' => ['a', 'b']]], $populateBeforeAssembly);
         $form->exposeSave();
     }
 
-    public function testUnchangedPasswordElementRetainsConfigValueOnSave(): void
+    #[DataProvider('populationTimings')]
+    public function testUnchangedPasswordElementRetainsConfigValueOnSave(bool $populateBeforeAssembly): void
     {
         $config = new class(new ConfigObject(['mysection' => ['password' => 'secret']])) extends Config {
             public function saveIni($filePath = null, $fileMode = 0660): void {}
@@ -135,14 +137,33 @@ class ConfigFormTest extends BaseTestCase
             }
         };
         $form->disableCsrfCounterMeasure();
-        $form->populate(['mysection__password' => PasswordElement::DUMMYPASSWORD]);
-        $form->ensureAssembled();
+        $this->populateAroundAssembly(
+            $form,
+            [['mysection__password' => PasswordElement::DUMMYPASSWORD]],
+            $populateBeforeAssembly,
+        );
         $form->exposeSave();
 
         $this->assertSame('secret', $config->get('mysection', 'password'));
     }
 
-    public function testEmptySectionIsRemovedOnSave(): void
+    public function testConfiguredValueOverridesElementDefault(): void
+    {
+        $form = new class (Config::fromArray(['mysection' => ['key' => 'configured']])) extends ConfigForm {
+            protected function assemble(): void
+            {
+                $this->addElement('text', 'mysection__key', ['value' => 'defaultvalue']);
+            }
+        };
+        $form->disableCsrfCounterMeasure();
+        $form->ensureAssembled();
+
+        $this->assertSame('configured', $form->getValue('mysection__key'));
+        $this->assertSame('configured', $form->getPopulatedValue('mysection__key'));
+    }
+
+    #[DataProvider('populationTimings')]
+    public function testEmptySectionIsRemovedOnSave(bool $populateBeforeAssembly): void
     {
         $config = new class(new ConfigObject(['mysection' => ['key' => 'value']])) extends Config {
             public function saveIni($filePath = null, $fileMode = 0660): void {}
@@ -160,11 +181,62 @@ class ConfigFormTest extends BaseTestCase
             }
         };
         $form->disableCsrfCounterMeasure();
-        $form->ensureAssembled();
-        $form->populate(['mysection__key' => '']);
+        $this->populateAroundAssembly($form, [['mysection__key' => '']], $populateBeforeAssembly);
         $form->exposeSave();
 
         $this->assertFalse($config->hasSection('mysection'));
+    }
+
+    #[DataProvider('populationTimings')]
+    public function testEveryPopulatedValueIsAppliedInOrder(bool $populateBeforeAssembly): void
+    {
+        $config = Config::fromArray(['mysection' => ['key' => 'configured']]);
+        $form = new class ($config) extends ConfigForm {
+            protected function assemble(): void
+            {
+                $this->addElement('text', 'mysection__key');
+            }
+        };
+        $form->disableCsrfCounterMeasure();
+        $this->populateAroundAssembly(
+            $form,
+            [['mysection__key' => ''], ['mysection__key' => '0']],
+            $populateBeforeAssembly,
+        );
+
+        $this->assertSame('0', $form->getValue('mysection__key'));
+        $this->assertSame('0', $form->getPopulatedValue('mysection__key'));
+        $this->assertSame(
+            ['configured', '', '0'],
+            $form->getPopulatedValues('mysection__key'),
+        );
+    }
+
+    /** @return array<string, array{bool}> */
+    public static function populationTimings(): array
+    {
+        return [
+            'before assembly' => [true],
+            'after assembly'  => [false],
+        ];
+    }
+
+    /**
+     * @param list<array<string, mixed>> $populations
+     */
+    private function populateAroundAssembly(ConfigForm $form, array $populations, bool $populateBeforeAssembly): void
+    {
+        if (! $populateBeforeAssembly) {
+            $form->ensureAssembled();
+        }
+
+        foreach ($populations as $values) {
+            $form->populate($values);
+        }
+
+        if ($populateBeforeAssembly) {
+            $form->ensureAssembled();
+        }
     }
 
     private function makeForm(): ConfigForm

--- a/test/php/library/Icinga/Web/Form/ConfigFormTest.php
+++ b/test/php/library/Icinga/Web/Form/ConfigFormTest.php
@@ -96,14 +96,16 @@ class ConfigFormTest extends BaseTestCase
         $this->expectException(LogicException::class);
 
         $config = new class(new ConfigObject([])) extends Config {
-            public function saveIni($filePath = null, $fileMode = 0660): void {}
+            public function saveIni($filePath = null, $fileMode = 0660): void
+            {
+            }
         };
 
         $form = new class($config) extends ConfigForm {
             protected function assemble(): void
             {
                 $this->addElement('select', 'mysection__key', [
-                    'options' => ['a' => 'A', 'b' => 'B'],
+                    'options'  => ['a' => 'A', 'b' => 'B'],
                     'multiple' => true,
                 ]);
             }
@@ -122,7 +124,9 @@ class ConfigFormTest extends BaseTestCase
     public function testUnchangedPasswordElementRetainsConfigValueOnSave(bool $populateBeforeAssembly): void
     {
         $config = new class(new ConfigObject(['mysection' => ['password' => 'secret']])) extends Config {
-            public function saveIni($filePath = null, $fileMode = 0660): void {}
+            public function saveIni($filePath = null, $fileMode = 0660): void
+            {
+            }
         };
 
         $form = new class($config) extends ConfigForm {
@@ -279,7 +283,9 @@ class ConfigFormTest extends BaseTestCase
     public function testEmptySectionIsRemovedOnSave(bool $populateBeforeAssembly): void
     {
         $config = new class(new ConfigObject(['mysection' => ['key' => 'value']])) extends Config {
-            public function saveIni($filePath = null, $fileMode = 0660): void {}
+            public function saveIni($filePath = null, $fileMode = 0660): void
+            {
+            }
         };
 
         $form = new class($config) extends ConfigForm {

--- a/test/php/library/Icinga/Web/Form/ConfigFormTest.php
+++ b/test/php/library/Icinga/Web/Form/ConfigFormTest.php
@@ -193,6 +193,89 @@ class ConfigFormTest extends BaseTestCase
     }
 
     #[DataProvider('populationTimings')]
+    public function testElementIsClearedWhenValueIsEmpty(bool $populateBeforeAssembly): void
+    {
+        $config = new class(new ConfigObject(['mysection' => ['key' => 'value']])) extends Config {
+            public function saveIni($filePath = null, $fileMode = 0660): void
+            {
+            }
+        };
+
+        $form = new class($config) extends ConfigForm {
+            protected function assemble(): void
+            {
+                $this->addElement('text', 'mysection__key', []);
+            }
+
+            public function exposeSave(): void
+            {
+                $this->save();
+            }
+        };
+        $form->disableCsrfCounterMeasure();
+        $this->populateAroundAssembly($form, [['mysection__key' => '']], $populateBeforeAssembly);
+        $form->exposeSave();
+
+        $this->assertNull($config->get('mysection', 'key'));
+    }
+
+    #[DataProvider('populationTimings')]
+    public function testElementIsClearedWhenValueIsOriginalValue(bool $populateBeforeAssembly): void
+    {
+        $config = new class(new ConfigObject(['mysection' => ['key' => 'value']])) extends Config {
+            public function saveIni($filePath = null, $fileMode = 0660): void
+            {
+            }
+        };
+
+        $form = new class($config) extends ConfigForm {
+            protected function assemble(): void
+            {
+                $this->addElement('text', 'mysection__key', ['value' => 'value']);
+            }
+
+            public function exposeSave(): void
+            {
+                $this->save();
+            }
+        };
+        $form->disableCsrfCounterMeasure();
+        $this->populateAroundAssembly($form, [['mysection__key' => 'value']], $populateBeforeAssembly);
+        $form->exposeSave();
+
+        $this->assertNull($config->get('mysection', 'key'));
+    }
+
+    #[DataProvider('populationTimings')]
+    public function testClearingFieldWithNonEmptyDefaultWritesEmptyStringToConfig(
+        bool $populateBeforeAssembly,
+    ): void {
+        $config = new class(new ConfigObject(['mysection' => ['key' => 'value']])) extends Config {
+            public function saveIni($filePath = null, $fileMode = 0660): void
+            {
+            }
+        };
+
+        $form = new class($config) extends ConfigForm {
+            protected function assemble(): void
+            {
+                $this->addElement('text', 'mysection__key', ['value' => 'default']);
+            }
+
+            public function exposeSave(): void
+            {
+                $this->save();
+            }
+        };
+        $form->disableCsrfCounterMeasure();
+        $this->populateAroundAssembly($form, [['mysection__key' => '']], $populateBeforeAssembly);
+        $form->exposeSave();
+
+        $this->assertTrue($config->hasSection('mysection'));
+        $this->assertSame('', $config->get('mysection', 'key', 'not-set'));
+    }
+
+    #[DataProvider('populationTimings')]
     public function testEmptySectionIsRemovedOnSave(bool $populateBeforeAssembly): void
     {
         $config = new class(new ConfigObject(['mysection' => ['key' => 'value']])) extends Config {
@@ -218,6 +301,33 @@ class ConfigFormTest extends BaseTestCase
     }
 
     #[DataProvider('populationTimings')]
+    public function testZeroValueIsSaved(bool $populateBeforeAssembly): void
+    {
+        $config = new class (new ConfigObject(['mysection' => ['key' => 'value']])) extends Config {
+            public function saveIni($filePath = null, $fileMode = 0660): void
+            {
+            }
+        };
+
+        $form = new class ($config) extends ConfigForm {
+            protected function assemble(): void
+            {
+                $this->addElement('text', 'mysection__key');
+            }
+
+            public function exposeSave(): void
+            {
+                $this->save();
+            }
+        };
+        $form->disableCsrfCounterMeasure();
+        $this->populateAroundAssembly($form, [['mysection__key' => '0']], $populateBeforeAssembly);
+        $form->exposeSave();
+
+        $this->assertSame('0', $config->get('mysection', 'key'));
+    }
+
+    #[DataProvider('populationTimings')]
     public function testEveryPopulatedValueIsAppliedInOrder(bool $populateBeforeAssembly): void
     {
         $config = Config::fromArray(['mysection' => ['key' => 'configured']]);
@@ -240,6 +350,33 @@ class ConfigFormTest extends BaseTestCase
             ['configured', '', '0'],
             $form->getPopulatedValues('mysection__key'),
         );
+    }
+
+    #[DataProvider('populationTimings')]
+    public function testNullValueClearsElement(bool $populateBeforeAssembly): void
+    {
+        $config = new class (new ConfigObject(['mysection' => ['key' => 'value']])) extends Config {
+            public function saveIni($filePath = null, $fileMode = 0660): void
+            {
+            }
+        };
+
+        $form = new class ($config) extends ConfigForm {
+            protected function assemble(): void
+            {
+                $this->addElement('text', 'mysection__key');
+            }
+
+            public function exposeSave(): void
+            {
+                $this->save();
+            }
+        };
+        $form->disableCsrfCounterMeasure();
+        $this->populateAroundAssembly($form, [['mysection__key' => null]], $populateBeforeAssembly);
+        $form->exposeSave();
+
+        $this->assertNull($config->get('mysection', 'key'));
     }
 
     /** @return array<string, array{bool}> */

--- a/test/php/library/Icinga/Web/Form/ConfigFormTest.php
+++ b/test/php/library/Icinga/Web/Form/ConfigFormTest.php
@@ -147,6 +147,21 @@ class ConfigFormTest extends BaseTestCase
         $this->assertSame('secret', $config->get('mysection', 'password'));
     }
 
+    public function testElementDefaultIsPreservedWhenConfigKeyIsNotSet(): void
+    {
+        $form = new class(Config::fromArray([])) extends ConfigForm {
+            protected function assemble(): void
+            {
+                $this->addElement('text', 'mysection__key', ['value' => 'defaultvalue']);
+            }
+        };
+        $form->disableCsrfCounterMeasure();
+        $form->ensureAssembled();
+
+        $this->assertSame('defaultvalue', $form->getValue('mysection__key'));
+        $this->assertSame('defaultvalue', $form->getPopulatedValue('mysection__key'));
+    }
+
     public function testConfiguredValueOverridesElementDefault(): void
     {
         $form = new class (Config::fromArray(['mysection' => ['key' => 'configured']])) extends ConfigForm {
@@ -160,6 +175,21 @@ class ConfigFormTest extends BaseTestCase
 
         $this->assertSame('configured', $form->getValue('mysection__key'));
         $this->assertSame('configured', $form->getPopulatedValue('mysection__key'));
+    }
+
+    public function testConfiguredNullOverridesNonEmptyElementDefault(): void
+    {
+        $form = new class (Config::fromArray(['mysection' => ['key' => null]])) extends ConfigForm {
+            protected function assemble(): void
+            {
+                $this->addElement('text', 'mysection__key', ['value' => 'defaultvalue']);
+            }
+        };
+        $form->disableCsrfCounterMeasure();
+        $form->ensureAssembled();
+
+        $this->assertNull($form->getValue('mysection__key'));
+        $this->assertNull($form->getPopulatedValue('mysection__key'));
     }
 
     #[DataProvider('populationTimings')]


### PR DESCRIPTION
`ConfigForm`'s `ON_ELEMENT_REGISTERED` handler skipped seeding an element with its config value whenever the element already had a value set (`$element->hasValue()`), even on initial render. When it did seed the value, it called `$element->setValue()` directly instead of `$this->populate()`, so the value was visible on the element but not through `getPopulatedValue()`.

This broke forms that read defaults via `getPopulatedValue()` during rendering, most notably `CspConfigForm`, where checkboxes ended up rendering with the wrong checked state.

## Changes

- `ConfigForm`: replace the `ON_ELEMENT_REGISTERED` handler with an override of `registerElement()`. The config value is populated as the element's base value, so `getPopulatedValue()` reflects it, while any value populated earlier (e.g. a submitted one) still takes precedence.
- `ConfigForm`: remember each element's original (default) value. On save, a key whose submitted value equals its default is unset instead of written, and an element with a non-empty default that is submitted empty is stored as an empty string.
- `CspConfigForm`: move the CSP auto-generation default (off for installations that already had CSP enabled, on for new ones) out of `ConfigController` and into `addDirectiveCheckboxElement()`, which now takes the config key and derives the field name itself.
- `ConfigController`: drop the manual default computation and populate call, and construct the form as a fluent chain.
- Tests for the new population chain and for `CspConfigForm`'s defaults.

require Icinga/ipl-html#205