### PR TITLE
Modernize repository form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ Please make sure to always read our [Upgrading](doc/80-Upgrading.md) documentati
 
 ## What's New
 
+### What's New in Version 2.14.1
+
+#### CompatForm-based Repository Form
+
+`Icinga\Web\Form\RepositoryForm` is a new `CompatForm`-based base class for
+forms that work with extensible, updatable, and reducible repositories.
+It supersedes `Icinga\Forms\RepositoryForm`, which will be deprecated in version
+2.15. Relevant for developers: it's no drop-in replacement! The constructor
+signature, assembly method names, notification ownership, and submit controls
+all differ and have to be adjusted when migrating.
+
 ### What's New in Version 2.14.0
 
 You can find all issues related to this release on our

--- a/library/Icinga/Repository/RepositoryMode.php
+++ b/library/Icinga/Repository/RepositoryMode.php
@@ -1,0 +1,53 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Icinga\Repository;
+
+use Icinga\Data\Extensible;
+use Icinga\Data\Reducible;
+use Icinga\Data\Updatable;
+
+/**
+ * Operating mode for a {@see \Icinga\Web\Form\RepositoryForm}
+ */
+enum RepositoryMode
+{
+    /** Create a new repository entry */
+    case Insert;
+
+    /** Modify an existing repository entry */
+    case Update;
+
+    /** Remove an existing repository entry */
+    case Delete;
+
+    /**
+     * Get the interface required for the respective mode
+     *
+     * @return class-string
+     */
+    public function getRequiredInterface(): string
+    {
+        return match ($this) {
+            RepositoryMode::Insert => Extensible::class,
+            RepositoryMode::Update => Updatable::class,
+            RepositoryMode::Delete => Reducible::class,
+        };
+    }
+
+    /**
+     * Check whether the mode requires an identifier
+     *
+     * @return bool
+     */
+    public function requiresIdentifier(): bool
+    {
+        return match ($this) {
+            RepositoryMode::Insert => false,
+            RepositoryMode::Update,
+            RepositoryMode::Delete => true,
+        };
+    }
+}

--- a/library/Icinga/Web/Form/RepositoryForm.php
+++ b/library/Icinga/Web/Form/RepositoryForm.php
@@ -1,0 +1,337 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Icinga\Web\Form;
+
+use Icinga\Data\Extensible;
+use Icinga\Data\Filter\Filter;
+use Icinga\Data\Reducible;
+use Icinga\Data\Updatable;
+use Icinga\Exception\NotFoundError;
+use Icinga\Repository\Repository;
+use Icinga\Repository\RepositoryMode;
+use InvalidArgumentException;
+use ipl\Html\Contract\Form;
+use ipl\Web\Common\CsrfCounterMeasure;
+use ipl\Web\Common\FormUid;
+use ipl\Web\Compat\CompatForm;
+use Psr\Http\Message\ServerRequestInterface;
+use Stringable;
+
+/**
+ * Form base-class providing standard functionality for extensible, updatable and
+ * reducible repositories
+ *
+ * CSRF protection is enabled by default. Call {@see setCsrfCounterMeasureId()}
+ * to set the CSRF form element id or {@see disableCsrfCounterMeasure()}
+ * to opt out. The form UID element requires a form name. Set one via the
+ * `name` attribute before assembling.
+ */
+abstract class RepositoryForm extends CompatForm
+{
+    use CsrfCounterMeasure;
+    use FormUid;
+
+    /** @var ?array<string, mixed> The data of the entry to pre-populate the form with */
+    protected ?array $data = null;
+
+    /**
+     * Create a new repository form
+     *
+     * Applies the default element decorators and calls the mode-appropriate
+     * {@see onInsertRequest()}, {@see onUpdateRequest()}, or {@see onDeleteRequest()}
+     * when the form receives a request. $repository must implement the correct
+     * interface for the respective $mode:
+     *
+     * - {@see Extensible} for {@see RepositoryMode::Insert}
+     * - {@see Updatable} for {@see RepositoryMode::Update}
+     * - {@see Reducible} for {@see RepositoryMode::Delete}
+     *
+     * @param Repository $repository The repository to work with
+     * @param RepositoryMode $mode How to interact with the repository
+     * @param string|Stringable|int|null $identifier The identifier of the entry to handle.
+     *   Required for {@see RepositoryMode::Update} and {@see RepositoryMode::Delete}.
+     *
+     * @throws InvalidArgumentException If $repository does not implement the interface
+     *   required by $mode, or if $identifier does not match $mode's requirements
+     */
+    public function __construct(
+        protected Repository $repository,
+        protected RepositoryMode $mode,
+        protected string|Stringable|int|null $identifier = null,
+    ) {
+        $requiredInterface = $this->mode->getRequiredInterface();
+
+        if (! $this->repository instanceof $requiredInterface) {
+            throw new InvalidArgumentException(sprintf(
+                'Repository "%s" does not implement %s, which is required for %s mode',
+                $this->repository::class,
+                $requiredInterface,
+                $this->mode->name
+            ));
+        }
+
+        if ($this->mode->requiresIdentifier() && $this->identifier === null) {
+            throw new InvalidArgumentException(sprintf('An identifier is required for %s mode', $this->mode->name));
+        }
+
+        $this->applyDefaultElementDecorators();
+
+        $this->on(Form::ON_REQUEST, function (ServerRequestInterface $_, RepositoryForm $form): void {
+            match ($this->mode) {
+                RepositoryMode::Insert => $form->onInsertRequest(),
+                RepositoryMode::Update => $form->onUpdateRequest(),
+                RepositoryMode::Delete => $form->onDeleteRequest(),
+            };
+        });
+    }
+
+    /**
+     * Create and add elements to this form
+     *
+     * @return void
+     */
+    protected function assemble(): void
+    {
+        $this->addCsrfCounterMeasure();
+        $this->addElement($this->createUidElement());
+
+        match ($this->mode) {
+            RepositoryMode::Insert => $this->assembleInsertElements(),
+            RepositoryMode::Update => $this->assembleUpdateElements(),
+            RepositoryMode::Delete => $this->assembleDeleteElements(),
+        };
+    }
+
+    /**
+     * Apply the requested mode on the repository
+     *
+     * @return void
+     */
+    protected function onSuccess(): void
+    {
+        match ($this->mode) {
+            RepositoryMode::Insert => $this->insertEntry(),
+            RepositoryMode::Update => $this->updateEntry(),
+            RepositoryMode::Delete => $this->deleteEntry(),
+        };
+    }
+
+    /**
+     * Get the name of the entry to handle
+     *
+     * @return string|Stringable|int|null
+     */
+    public function getIdentifier(): string|Stringable|int|null
+    {
+        return $this->identifier;
+    }
+
+    /**
+     * Set the current data of the entry being handled
+     *
+     * In case of {@see RepositoryMode::Insert} the data will be used as default values.
+     * In case of {@see RepositoryMode::Update} the data is the current entry's values.
+     *
+     * @param array<string, mixed> $data Entry data or default values
+     *
+     * @return $this
+     */
+    public function setData(array $data): static
+    {
+        $this->data = $data;
+
+        return $this;
+    }
+
+    /**
+     * Get the extensible repository
+     *
+     * @return Repository&Extensible
+     */
+    protected function getExtensibleRepository(): Repository&Extensible
+    {
+        /** @var Repository&Extensible $repo */
+        $repo = $this->repository;
+
+        return $repo;
+    }
+
+    /**
+     * Get the updatable repository
+     *
+     * @return Repository&Updatable
+     */
+    protected function getUpdatableRepository(): Repository&Updatable
+    {
+        /** @var Repository&Updatable $repo */
+        $repo = $this->repository;
+
+        return $repo;
+    }
+
+    /**
+     * Get the reducible repository
+     *
+     * @return Repository&Reducible
+     */
+    protected function getReducibleRepository(): Repository&Reducible
+    {
+        /** @var Repository&Reducible $repo */
+        $repo = $this->repository;
+
+        return $repo;
+    }
+
+    /**
+     * Fetch and return the entry to pre-populate the form with when in mode update
+     *
+     * @return object|false False in case of no result
+     */
+    protected function fetchEntry(): object|false
+    {
+        return $this->repository
+            ->select()
+            ->addFilter($this->createFilter())
+            ->fetchRow();
+    }
+
+    /**
+     * Whether the entry supposed to be removed exists
+     *
+     * @return bool
+     */
+    protected function entryExists(): bool
+    {
+        $count = $this->repository
+            ->select()
+            ->addFilter($this->createFilter())
+            ->count();
+
+        return $count > 0;
+    }
+
+    /**
+     * Insert the new entry
+     *
+     * @return void
+     */
+    protected function insertEntry(): void
+    {
+        $repo = $this->getExtensibleRepository();
+        $repo->insert($repo->getBaseTable(), $this->getValues());
+    }
+
+    /**
+     * Update the entry
+     *
+     * @return void
+     */
+    protected function updateEntry(): void
+    {
+        $repo = $this->getUpdatableRepository();
+        $repo->update($repo->getBaseTable(), $this->getValues(), $this->createFilter());
+    }
+
+    /**
+     * Delete the entry
+     *
+     * @return void
+     */
+    protected function deleteEntry(): void
+    {
+        $repo = $this->getReducibleRepository();
+        $repo->delete($repo->getBaseTable(), $this->createFilter());
+    }
+
+    /**
+     * Prepare the form for mode insert
+     *
+     * Populates the form with the data passed to setData().
+     *
+     * @return void
+     */
+    protected function onInsertRequest(): void
+    {
+        if (! empty($this->data)) {
+            $this->populate($this->data);
+        }
+    }
+
+    /**
+     * Prepare the form for mode update
+     *
+     * Populates the form with either the data passed to setData() or tries to fetch it
+     * from the repository.
+     *
+     * @return void
+     *
+     * @throws NotFoundError In case the entry to update cannot be found
+     */
+    protected function onUpdateRequest(): void
+    {
+        $data = $this->data;
+        if ($data === null) {
+            $row = $this->fetchEntry();
+            if ($row === false) {
+                throw new NotFoundError('Entry "%s" not found', $this->getIdentifier());
+            }
+
+            $data = get_object_vars($row);
+        }
+
+        $this->populate($data);
+    }
+
+    /**
+     * Prepare the form for mode delete
+     *
+     * Verifies that the repository contains the entry to delete.
+     *
+     * @return void
+     *
+     * @throws NotFoundError In case the entry to delete cannot be found
+     */
+    protected function onDeleteRequest(): void
+    {
+        if (! $this->entryExists()) {
+            throw new NotFoundError('Entry "%s" not found', $this->getIdentifier());
+        }
+    }
+
+    /**
+     * Add elements to this form to insert an entry
+     *
+     * @return void
+     */
+    abstract protected function assembleInsertElements(): void;
+
+    /**
+     * Add elements to this form to update an entry
+     *
+     * Calls {@see assembleInsertElements()} by default. Overwrite this to add different
+     * elements when in mode update.
+     *
+     * @return void
+     */
+    protected function assembleUpdateElements(): void
+    {
+        $this->assembleInsertElements();
+    }
+
+    /**
+     * Add elements to this form to delete an entry
+     *
+     * @return void
+     */
+    abstract protected function assembleDeleteElements(): void;
+
+    /**
+     * Create a filter to use when selecting, updating or deleting an entry
+     *
+     * @return Filter
+     */
+    abstract protected function createFilter(): Filter;
+}

--- a/test/php/library/Icinga/Web/Form/RepositoryFormTest.php
+++ b/test/php/library/Icinga/Web/Form/RepositoryFormTest.php
@@ -1,0 +1,733 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Tests\Icinga\Web\Form;
+
+use Icinga\Data\Extensible;
+use Icinga\Data\Filter\Filter;
+use Icinga\Data\Reducible;
+use Icinga\Data\Updatable;
+use Icinga\Exception\NotFoundError;
+use Icinga\Repository\Repository;
+use Icinga\Repository\RepositoryMode;
+use Icinga\Test\BaseTestCase;
+use Icinga\Web\Form\RepositoryForm;
+use InvalidArgumentException;
+
+/**
+ * Tests for {@see RepositoryForm}
+ */
+class RepositoryFormTest extends BaseTestCase
+{
+    private function makeExtensibleRepository(): Repository&Extensible
+    {
+        /** @var Repository&Extensible $repository */
+        $repository = new class () extends Repository implements Extensible {
+            /** @var list<array{target: string, data: array<string, mixed>}> */
+            public array $insertCalls = [];
+
+            public function __construct()
+            {
+                // Bypass the parent constructor: unit tests need no datasource.
+            }
+
+            public function getBaseTable(): string
+            {
+                return 'test_table';
+            }
+
+            public function insert($target, array $data): void
+            {
+                $this->insertCalls[] = ['target' => $target, 'data' => $data];
+            }
+        };
+
+        return $repository;
+    }
+
+    private function makeUpdatableRepository(): Repository&Updatable
+    {
+        /** @var Repository&Updatable $repository */
+        $repository = new class () extends Repository implements Updatable {
+            /** @var list<array{target: string, data: array<string, mixed>, filter: ?Filter}> */
+            public array $updateCalls = [];
+
+            public function __construct()
+            {
+                // Bypass the parent constructor: unit tests need no datasource.
+            }
+
+            public function getBaseTable(): string
+            {
+                return 'test_table';
+            }
+
+            public function update($target, array $data, ?Filter $filter = null): void
+            {
+                $this->updateCalls[] = ['target' => $target, 'data' => $data, 'filter' => $filter];
+            }
+        };
+
+        return $repository;
+    }
+
+    private function makeReducibleRepository(): Repository&Reducible
+    {
+        /** @var Repository&Reducible $repository */
+        $repository = new class () extends Repository implements Reducible {
+            /** @var list<array{target: string, filter: ?Filter}> */
+            public array $deleteCalls = [];
+
+            public function __construct()
+            {
+                // Bypass the parent constructor: unit tests need no datasource.
+            }
+
+            public function getBaseTable(): string
+            {
+                return 'test_table';
+            }
+
+            public function delete($target, ?Filter $filter = null): void
+            {
+                $this->deleteCalls[] = ['target' => $target, 'filter' => $filter];
+            }
+        };
+
+        return $repository;
+    }
+
+    public function testInsertModeRequiresAnExtensibleRepository(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $repo = $this->makeUpdatableRepository(); // Updatable, not Extensible
+        new class ($repo, RepositoryMode::Insert) extends RepositoryForm {
+            protected function assembleInsertElements(): void
+            {
+            }
+
+            protected function assembleDeleteElements(): void
+            {
+            }
+
+            protected function createFilter(): Filter
+            {
+                return Filter::where('username', $this->getIdentifier());
+            }
+        };
+    }
+
+    public function testUpdateModeRequiresAnUpdatableRepository(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $repo = $this->makeExtensibleRepository(); // Extensible, not Updatable
+        new class ($repo, RepositoryMode::Update, '1') extends RepositoryForm {
+            protected function assembleInsertElements(): void
+            {
+            }
+
+            protected function assembleDeleteElements(): void
+            {
+            }
+
+            protected function createFilter(): Filter
+            {
+                return Filter::where('username', $this->getIdentifier());
+            }
+        };
+    }
+
+    public function testDeleteModeRequiresAReducibleRepository(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $repo = $this->makeExtensibleRepository(); // Extensible, not Reducible
+        new class ($repo, RepositoryMode::Delete, '1') extends RepositoryForm {
+            protected function assembleInsertElements(): void
+            {
+            }
+
+            protected function assembleDeleteElements(): void
+            {
+            }
+
+            protected function createFilter(): Filter
+            {
+                return Filter::where('username', $this->getIdentifier());
+            }
+        };
+    }
+
+    public function testUpdateModeRequiresAnIdentifier(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new class ($this->makeUpdatableRepository(), RepositoryMode::Update) extends RepositoryForm {
+            protected function assembleInsertElements(): void
+            {
+            }
+
+            protected function assembleDeleteElements(): void
+            {
+            }
+
+            protected function createFilter(): Filter
+            {
+                return Filter::where('username', $this->getIdentifier());
+            }
+        };
+    }
+
+    public function testDeleteModeRequiresAnIdentifier(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new class ($this->makeReducibleRepository(), RepositoryMode::Delete) extends RepositoryForm {
+            protected function assembleInsertElements(): void
+            {
+            }
+
+            protected function assembleDeleteElements(): void
+            {
+            }
+
+            protected function createFilter(): Filter
+            {
+                return Filter::where('username', $this->getIdentifier());
+            }
+        };
+    }
+
+    public function testInsertModeCallsAssembleInsertElements(): void
+    {
+        $form = new class ($this->makeExtensibleRepository(), RepositoryMode::Insert) extends RepositoryForm {
+            protected function assembleInsertElements(): void
+            {
+                $this->addElement('text', 'insert_marker');
+            }
+
+            protected function assembleDeleteElements(): void
+            {
+            }
+
+            protected function createFilter(): Filter
+            {
+                return Filter::where('username', $this->getIdentifier());
+            }
+        };
+        $form->disableCsrfCounterMeasure();
+        $form->ensureAssembled();
+
+        $this->assertTrue($form->hasElement('insert_marker'));
+    }
+
+    public function testUpdateModeCallsAssembleUpdateElements(): void
+    {
+        $form = new class ($this->makeUpdatableRepository(), RepositoryMode::Update, 'id') extends RepositoryForm {
+            protected function assembleInsertElements(): void
+            {
+            }
+
+            protected function assembleUpdateElements(): void
+            {
+                $this->addElement('text', 'update_marker');
+            }
+
+            protected function assembleDeleteElements(): void
+            {
+            }
+
+            protected function createFilter(): Filter
+            {
+                return Filter::where('username', $this->getIdentifier());
+            }
+        };
+        $form->disableCsrfCounterMeasure();
+        $form->ensureAssembled();
+
+        $this->assertTrue($form->hasElement('update_marker'));
+    }
+
+    public function testDeleteModeCallsAssembleDeleteElements(): void
+    {
+        $form = new class ($this->makeReducibleRepository(), RepositoryMode::Delete, 'id') extends RepositoryForm {
+            protected function assembleInsertElements(): void
+            {
+            }
+
+            protected function assembleDeleteElements(): void
+            {
+                $this->addElement('text', 'delete_marker');
+            }
+
+            protected function createFilter(): Filter
+            {
+                return Filter::where('username', $this->getIdentifier());
+            }
+        };
+        $form->disableCsrfCounterMeasure();
+        $form->ensureAssembled();
+
+        $this->assertTrue($form->hasElement('delete_marker'));
+    }
+
+    public function testAssembleUpdateElementsFallsBackToAssembleInsertElements(): void
+    {
+        $form = new class ($this->makeUpdatableRepository(), RepositoryMode::Update, 'id') extends RepositoryForm {
+            protected function assembleInsertElements(): void
+            {
+                $this->addElement('text', 'insert_marker');
+            }
+
+            protected function assembleDeleteElements(): void
+            {
+            }
+
+            protected function createFilter(): Filter
+            {
+                return Filter::where('username', $this->getIdentifier());
+            }
+        };
+        $form->disableCsrfCounterMeasure();
+        $form->ensureAssembled();
+
+        $this->assertTrue($form->hasElement('insert_marker'));
+    }
+
+    public function testCsrfElementIsAddedOnAssembly(): void
+    {
+        $form = new class ($this->makeExtensibleRepository(), RepositoryMode::Insert) extends RepositoryForm {
+            protected function assembleInsertElements(): void
+            {
+            }
+
+            protected function assembleDeleteElements(): void
+            {
+            }
+
+            protected function createFilter(): Filter
+            {
+                return Filter::where('username', $this->getIdentifier());
+            }
+        };
+        $form->setCsrfCounterMeasureId('unique-test-id');
+        $form->ensureAssembled();
+
+        $this->assertTrue($form->hasElement('CSRFToken'));
+    }
+
+    public function testCsrfElementCanBeDisabled(): void
+    {
+        $form = new class ($this->makeExtensibleRepository(), RepositoryMode::Insert) extends RepositoryForm {
+            protected function assembleInsertElements(): void
+            {
+            }
+
+            protected function assembleDeleteElements(): void
+            {
+            }
+
+            protected function createFilter(): Filter
+            {
+                return Filter::where('username', $this->getIdentifier());
+            }
+        };
+        $form->disableCsrfCounterMeasure();
+        $form->ensureAssembled();
+
+        $this->assertFalse($form->hasElement('CSRFToken'));
+    }
+
+    public function testUidElementIsAddedOnAssembly(): void
+    {
+        $form = new class ($this->makeExtensibleRepository(), RepositoryMode::Insert) extends RepositoryForm {
+            protected function assembleInsertElements(): void
+            {
+            }
+
+            protected function assembleDeleteElements(): void
+            {
+            }
+
+            protected function createFilter(): Filter
+            {
+                return Filter::where('username', $this->getIdentifier());
+            }
+        };
+        $form->disableCsrfCounterMeasure();
+        $form->ensureAssembled();
+
+        $this->assertTrue($form->hasElement('uid'));
+    }
+
+    public function testOnInsertRequestPopulatesFormWithSetData(): void
+    {
+        $form = new class ($this->makeExtensibleRepository(), RepositoryMode::Insert) extends RepositoryForm {
+            protected function assembleInsertElements(): void
+            {
+                $this->addElement('text', 'username');
+            }
+
+            protected function assembleDeleteElements(): void
+            {
+            }
+
+            protected function createFilter(): Filter
+            {
+                return Filter::where('username', $this->getIdentifier());
+            }
+
+            public function exposeOnInsertRequest(): void
+            {
+                $this->onInsertRequest();
+            }
+        };
+        $form->disableCsrfCounterMeasure();
+        $form->ensureAssembled();
+        $form->setData(['username' => 'alice']);
+        $form->exposeOnInsertRequest();
+
+        $this->assertSame('alice', $form->getElement('username')->getValue());
+    }
+
+    public function testOnInsertRequestSkipsPopulationWhenDataIsEmpty(): void
+    {
+        $form = new class ($this->makeExtensibleRepository(), RepositoryMode::Insert) extends RepositoryForm {
+            protected function assembleInsertElements(): void
+            {
+                $this->addElement('text', 'username');
+            }
+
+            protected function assembleDeleteElements(): void
+            {
+            }
+
+            protected function createFilter(): Filter
+            {
+                return Filter::where('username', $this->getIdentifier());
+            }
+
+            public function exposeOnInsertRequest(): void
+            {
+                $this->onInsertRequest();
+            }
+        };
+        $form->disableCsrfCounterMeasure();
+        $form->ensureAssembled();
+        // No setData call
+        $form->exposeOnInsertRequest();
+
+        $this->assertNull($form->getElement('username')->getValue());
+    }
+
+    public function testOnUpdateRequestPopulatesFormWithSetData(): void
+    {
+        $form = new class ($this->makeUpdatableRepository(), RepositoryMode::Update, 'alice') extends RepositoryForm {
+            protected function assembleInsertElements(): void
+            {
+                $this->addElement('text', 'username');
+            }
+
+            protected function assembleDeleteElements(): void
+            {
+            }
+
+            protected function createFilter(): Filter
+            {
+                return Filter::where('username', $this->getIdentifier());
+            }
+
+            public function exposeOnUpdateRequest(): void
+            {
+                $this->onUpdateRequest();
+            }
+        };
+        $form->disableCsrfCounterMeasure();
+        $form->ensureAssembled();
+        $form->setData(['username' => 'alice-updated']);
+        $form->exposeOnUpdateRequest();
+
+        $this->assertSame('alice-updated', $form->getElement('username')->getValue());
+    }
+
+    public function testOnUpdateRequestFetchesEntryFromRepositoryWhenDataIsNotSet(): void
+    {
+        $form = new class ($this->makeUpdatableRepository(), RepositoryMode::Update, 'alice') extends RepositoryForm {
+            protected function fetchEntry(): object|false
+            {
+                return (object) ['username' => 'fetched-alice'];
+            }
+
+            protected function assembleInsertElements(): void
+            {
+                $this->addElement('text', 'username');
+            }
+
+            protected function assembleDeleteElements(): void
+            {
+            }
+
+            protected function createFilter(): Filter
+            {
+                return Filter::where('username', $this->getIdentifier());
+            }
+
+            public function exposeOnUpdateRequest(): void
+            {
+                $this->onUpdateRequest();
+            }
+        };
+        $form->disableCsrfCounterMeasure();
+        $form->ensureAssembled();
+        // No setData call
+        $form->exposeOnUpdateRequest();
+
+        $this->assertSame('fetched-alice', $form->getElement('username')->getValue());
+    }
+
+    public function testOnUpdateRequestDoesNotFetchEntryFromRepositoryWhenSetDataIsEmpty(): void
+    {
+        $form = new class ($this->makeUpdatableRepository(), RepositoryMode::Update, 'alice') extends RepositoryForm {
+            protected function fetchEntry(): object|false
+            {
+                return (object) ['username' => 'fetched-alice'];
+            }
+
+            protected function assembleInsertElements(): void
+            {
+                $this->addElement('text', 'username');
+            }
+
+            protected function assembleDeleteElements(): void
+            {
+            }
+
+            protected function createFilter(): Filter
+            {
+                return Filter::where('username', $this->getIdentifier());
+            }
+
+            public function exposeOnUpdateRequest(): void
+            {
+                $this->onUpdateRequest();
+            }
+        };
+        $form->disableCsrfCounterMeasure();
+        $form->ensureAssembled();
+        $form->setData([]);
+        $form->exposeOnUpdateRequest();
+
+        $this->assertNull($form->getElement('username')->getValue());
+    }
+
+    public function testOnUpdateRequestThrowsNotFoundErrorWhenEntryIsMissing(): void
+    {
+        $this->expectException(NotFoundError::class);
+
+        $form = new class ($this->makeUpdatableRepository(), RepositoryMode::Update, 'missing') extends RepositoryForm {
+            protected function fetchEntry(): object|false
+            {
+                return false;
+            }
+
+            protected function assembleInsertElements(): void
+            {
+            }
+
+            protected function assembleDeleteElements(): void
+            {
+            }
+
+            protected function createFilter(): Filter
+            {
+                return Filter::where('username', $this->getIdentifier());
+            }
+
+            public function exposeOnUpdateRequest(): void
+            {
+                $this->onUpdateRequest();
+            }
+        };
+        $form->disableCsrfCounterMeasure();
+        $form->ensureAssembled();
+        $form->exposeOnUpdateRequest();
+    }
+
+    public function testOnDeleteRequestThrowsNotFoundErrorWhenEntryIsMissing(): void
+    {
+        $this->expectException(NotFoundError::class);
+
+        $form = new class ($this->makeReducibleRepository(), RepositoryMode::Delete, 'missing') extends RepositoryForm {
+            protected function entryExists(): bool
+            {
+                return false;
+            }
+
+            protected function assembleInsertElements(): void
+            {
+            }
+
+            protected function assembleDeleteElements(): void
+            {
+            }
+
+            protected function createFilter(): Filter
+            {
+                return Filter::where('username', $this->getIdentifier());
+            }
+
+            public function exposeOnDeleteRequest(): void
+            {
+                $this->onDeleteRequest();
+            }
+        };
+        $form->disableCsrfCounterMeasure();
+        $form->ensureAssembled();
+        $form->exposeOnDeleteRequest();
+    }
+
+    public function testOnDeleteRequestSucceedsWhenEntryExists(): void
+    {
+        $form = new class ($this->makeReducibleRepository(), RepositoryMode::Delete, 'alice') extends RepositoryForm {
+            protected function entryExists(): bool
+            {
+                return true;
+            }
+
+            protected function assembleInsertElements(): void
+            {
+            }
+
+            protected function assembleDeleteElements(): void
+            {
+            }
+
+            protected function createFilter(): Filter
+            {
+                return Filter::where('username', $this->getIdentifier());
+            }
+
+            public function exposeOnDeleteRequest(): void
+            {
+                $this->onDeleteRequest();
+            }
+        };
+        $form->disableCsrfCounterMeasure();
+        $form->ensureAssembled();
+        $form->exposeOnDeleteRequest();
+
+        $this->addToAssertionCount(1); // Reached without NotFoundError
+    }
+
+    public function testInsertEntryPassesValuesAndTableToRepository(): void
+    {
+        $repo = $this->makeExtensibleRepository();
+        $form = new class ($repo, RepositoryMode::Insert) extends RepositoryForm {
+            protected function assembleInsertElements(): void
+            {
+                $this->addElement('text', 'username');
+            }
+
+            protected function assembleDeleteElements(): void
+            {
+            }
+
+            protected function createFilter(): Filter
+            {
+                return Filter::where('username', $this->getIdentifier());
+            }
+
+            public function exposeOnSuccess(): void
+            {
+                $this->onSuccess();
+            }
+        };
+        $form->disableCsrfCounterMeasure();
+        $form->ensureAssembled();
+        $form->populate(['username' => 'new-entry']);
+        $form->exposeOnSuccess();
+
+        $this->assertCount(1, $repo->insertCalls);
+        $this->assertSame('test_table', $repo->insertCalls[0]['target']);
+        $this->assertSame('new-entry', $repo->insertCalls[0]['data']['username']);
+    }
+
+    public function testUpdateEntryPassesValuesAndFilterToRepository(): void
+    {
+        $repo = $this->makeUpdatableRepository();
+        $form = new class ($repo, RepositoryMode::Update, 'alice') extends RepositoryForm {
+            protected function assembleInsertElements(): void
+            {
+                $this->addElement('text', 'username');
+            }
+
+            protected function assembleDeleteElements(): void
+            {
+            }
+
+            protected function createFilter(): Filter
+            {
+                return Filter::where('username', $this->getIdentifier());
+            }
+
+            public function exposeOnSuccess(): void
+            {
+                $this->onSuccess();
+            }
+        };
+        $form->disableCsrfCounterMeasure();
+        $form->ensureAssembled();
+        $form->populate(['username' => 'alice-updated']);
+        $form->exposeOnSuccess();
+
+        $this->assertCount(1, $repo->updateCalls);
+        $this->assertEquals(
+            [
+                'target' => 'test_table',
+                'data'   => ['username' => 'alice-updated'],
+                'filter' => Filter::where('username', 'alice')
+            ],
+            $repo->updateCalls[0]
+        );
+    }
+
+    public function testDeleteEntryPassesTableAndFilterToRepository(): void
+    {
+        $repo = $this->makeReducibleRepository();
+        $form = new class ($repo, RepositoryMode::Delete, 'alice') extends RepositoryForm {
+            protected function assembleInsertElements(): void
+            {
+            }
+
+            protected function assembleDeleteElements(): void
+            {
+            }
+
+            protected function createFilter(): Filter
+            {
+                return Filter::where('username', $this->getIdentifier());
+            }
+
+            public function exposeOnSuccess(): void
+            {
+                $this->onSuccess();
+            }
+        };
+        $form->disableCsrfCounterMeasure();
+        $form->ensureAssembled();
+        $form->exposeOnSuccess();
+
+        $this->assertCount(1, $repo->deleteCalls);
+        $this->assertEquals(
+            [
+                'target' => 'test_table',
+                'filter' => Filter::where('username', 'alice')
+            ],
+            $repo->deleteCalls[0]
+        );
+    }
+}


### PR DESCRIPTION
`\Icinga\Forms\RepositoryForm` has been the base class for repository-backed forms. This PR introduces a `CompatForm`-based replacement.

The new `\Icinga\Web\Form\RepositoryForm` takes a `RepositoryMode` enum at construction time, rather than having callers set the mode via `add()`, `edit()`, or `remove()`. The mode controls which elements are assembled, how the form is pre-populated, and which repository operation fires on success. Subclasses implement `assembleInsertElements()`, `assembleDeleteElements()`, and `createFilter()`. `assembleUpdateElements()` falls back to `assembleInsertElements()` by default but can be overridden when the update layout differs. The notification handling is now in the response of the controller.