### PR TITLE
Documentation updates

### DIFF
--- a/doc/03-Configuration.md
+++ b/doc/03-Configuration.md
@@ -66,7 +66,7 @@ file = "/usr/share/icingaweb2/log/icingaweb2.log"
 
 Option                   | Description
 -------------------------|-----------------------------------------------
-default                  | **Optional.** Choose the default theme. Can be set to `Icinga`, `high-contrast`, `Winter`, 'colorblind' or your own installed theme. Defaults to `Icinga`. Note that this setting is case-sensitive because it refers to the filename of the theme.
+default                  | **Optional.** Choose the default theme. Can be set to `Icinga`, `high-contrast`, `Winter`, `colorblind` or your own installed theme. Defaults to `Icinga`. Note that this setting is case-sensitive because it refers to the filename of the theme.
 disabled                 | **Optional.** Set this to `1` if users should not be allowed to change their theme. Defaults to `0`.
 default_mode             | **Optional.** Choose the default theme mode. Can be set to `system`, `light` or `none` for the dark theme mode. Defaults to `none`.
 

--- a/doc/03-Configuration.md
+++ b/doc/03-Configuration.md
@@ -25,11 +25,12 @@ This configuration is stored in the `config.ini` file in `/etc/icingaweb2`.
 ### Global Configuration <a id="configuration-general-global"></a>
 
 
-Option                   | Description
--------------------------|-----------------------------------------------
-show\_stacktraces        | **Optional.** Set to `1` to show debug stacktraces. Defaults to `1`.
-module\_path             | **Optional.** Specifies the directories where modules can be installed. Multiple directories must be separated with colons.
-config\_resource         | **Required.** Specify a defined [resource](04-Resources.md#resources-configuration-database) name.
+Option                             | Description
+-----------------------------------|-----------------------------------------------
+show\_stacktraces                  | **Optional.** Set to `1` to show debug stacktraces. Defaults to `1`.
+show\_application\_state\_messages | **Optional.** Set to `1` to show application state messages. Defaults to `1`.
+module\_path                       | **Optional.** Specifies the directories where modules can be installed. Multiple directories must be separated with colons.
+config\_resource                   | **Required.** Specify a defined [resource](04-Resources.md#resources-configuration-database) name.
 
 
 Example for storing the user preferences in the database resource `icingaweb_db`:
@@ -37,6 +38,7 @@ Example for storing the user preferences in the database resource `icingaweb_db`
 ```
 [global]
 show_stacktraces = "1"
+show_application_state_messages = "1"
 config_resource = "icingaweb_db"
 module_path = "/usr/share/icingaweb2/modules"
 ```

--- a/doc/03-Configuration.md
+++ b/doc/03-Configuration.md
@@ -79,6 +79,19 @@ default = "Icinga"
 default_mode = "light"
 ```
 
+### Authentication Configuration <a id="configuration-general-authentication"></a>
+
+Option                   | Description
+-------------------------|-----------------------------------------------
+default\_domain          | **Optional.** Domain assumed when users log in without specifying a domain. It must match an LDAP backend's configured domain or the domain suffix stored in another backend's usernames, e.g. `icinga.com`.
+
+Example:
+
+```
+[authentication]
+default_domain = "icinga.com"
+```
+
 ## Security Configuration <a id="configuration-security"></a>
 
 Navigate into **Configuration > Application > Security**.

--- a/doc/03-Configuration.md
+++ b/doc/03-Configuration.md
@@ -115,19 +115,6 @@ Navigate into **Configuration > Application > Security**.
 
 This configuration is stored in the `config.ini` file in `/etc/icingaweb2`.
 
-### Password Policy Configuration <a id="configuration-security-password-policy"></a>
-
-Option            | Description
-------------------|-----------------------------------
-password\_policy  | **Optional.** Canonical name of the [password policy](05-Authentication.md#authentication-password-policy) to enforce. Defaults to `any` (None).
-
-Example:
-
-```
-[security]
-password_policy = "common"
-```
-
 ### Content Security Policy Configuration <a id="configuration-security-csp"></a>
 
 Option                  | Description

--- a/doc/03-Configuration.md
+++ b/doc/03-Configuration.md
@@ -48,9 +48,9 @@ module_path = "/usr/share/icingaweb2/modules"
 Option                   | Description
 -------------------------|-----------------------------------------------
 log                      | **Optional.** Specifies the logging type. Can be set to `syslog`, `file`, `php` (web server's error log) or `none`.
-level                    | **Optional.** Specifies the logging level. Can be set to `ERROR`, `WARNING`, `INFORMATION` or `DEBUG`.
+level                    | **Optional.** Specifies the logging level. Can be set to `ERROR`, `WARNING`, `INFO` or `DEBUG`.
 file                     | **Optional.** Specifies the log file path if `log` is set to `file`.
-application              | **Optional.** Specifies the application name if `log` is set to `syslog`.
+application              | **Optional.** Specifies the application name if `log` is set to `syslog` or `php`. Defaults to `icingaweb2`.
 facility                 | **Optional.** Specifies the syslog facility if `log` is set to `syslog`. Can be set to `user`, `local0` to `local7`. Defaults to `user`.
 
 Example for more verbose debug logging into a file:

--- a/doc/03-Configuration.md
+++ b/doc/03-Configuration.md
@@ -27,7 +27,7 @@ This configuration is stored in the `config.ini` file in `/etc/icingaweb2`.
 
 Option                   | Description
 -------------------------|-----------------------------------------------
-show\_stacktraces        | **Optional.** Whether to show debug stacktraces. Defaults to `0`.
+show\_stacktraces        | **Optional.** Set to `1` to show debug stacktraces. Defaults to `1`.
 module\_path             | **Optional.** Specifies the directories where modules can be installed. Multiple directories must be separated with colons.
 config\_resource         | **Required.** Specify a defined [resource](04-Resources.md#resources-configuration-database) name.
 
@@ -36,7 +36,7 @@ Example for storing the user preferences in the database resource `icingaweb_db`
 
 ```
 [global]
-show_stacktraces = "0"
+show_stacktraces = "1"
 config_resource = "icingaweb_db"
 module_path = "/usr/share/icingaweb2/modules"
 ```

--- a/doc/03-Configuration.md
+++ b/doc/03-Configuration.md
@@ -135,9 +135,11 @@ Option                  | Description
 use\_strict\_csp        | **Optional.** Set this to `1` to enable strict [Content Security Policy](20-Advanced-Topics.md#advanced-topics-csp). Defaults to `0`.
 use\_custom\_csp        | **Optional.** Set this to `1` to use the user-defined Content Security Policy. Defaults to `0`.
 custom\_csp             | **Optional.** Specifies the user defined Content Security Policy. Overrides the automatically generated one. Only used if `use_custom_csp` is set to `1`.
-csp\_enable\_modules    | **Optional.** Specifies if modules should be included in the generated Content Security Policy. Defaults to `1`.
-csp\_enable\_dashboards | **Optional.** Specifies if dashboards should be included in the generated Content Security Policy. Defaults to `1`.
-csp\_enable\_navigation | **Optional.** Specifies if navigation menu items should be included in the generated Content Security Policy. Defaults to `1`.
+csp\_enable\_modules    | **Optional.** Specifies if modules should be included in the generated Content Security Policy. Defaults to `0`.
+csp\_enable\_dashboards | **Optional.** Specifies if dashboards should be included in the generated Content Security Policy. Defaults to `0`.
+csp\_enable\_navigation | **Optional.** Specifies if navigation menu items should be included in the generated Content Security Policy. Defaults to `0`.
+
+When strict CSP is enabled through the Security page for the first time, the `csp_enable_*` options are enabled by default.
 
 Example:
 

--- a/doc/03-Configuration.md
+++ b/doc/03-Configuration.md
@@ -29,7 +29,7 @@ Option                             | Description
 -----------------------------------|-----------------------------------------------
 show\_stacktraces                  | **Optional.** Set to `1` to show debug stacktraces. Defaults to `1`.
 show\_application\_state\_messages | **Optional.** Set to `1` to show application state messages. Defaults to `1`.
-module\_path                       | **Optional.** Specifies the directories where modules can be installed. Multiple directories must be separated with colons.
+module\_path                       | **Optional.** Specifies the directories where modules can be installed. Multiple directories must be separated with the platform path separator (`:` on Unix-like systems).
 config\_resource                   | **Required.** Specify a defined [resource](04-Resources.md#resources-configuration-database) name.
 
 

--- a/doc/03-Configuration.md
+++ b/doc/03-Configuration.md
@@ -92,6 +92,23 @@ Example:
 default_domain = "icinga.com"
 ```
 
+### Cookie Configuration <a id="configuration-general-cookie"></a>
+
+Option                   | Description
+-------------------------|-----------------------------------------------
+domain                   | **Optional.** Domain attribute for cookies, e.g. `.example.com`.
+path                     | **Optional.** Path attribute for cookies, e.g. `/icingaweb2/`. Defaults to the Icinga Web base URL.
+secure                   | **Optional.** Set to `1` to send cookies only over HTTPS. Defaults to the current request scheme.
+
+Example:
+
+```
+[cookie]
+domain = ".example.com"
+path = "/icingaweb2/"
+secure = "1"
+```
+
 ## Security Configuration <a id="configuration-security"></a>
 
 Navigate into **Configuration > Application > Security**.

--- a/doc/03-Configuration.md
+++ b/doc/03-Configuration.md
@@ -115,16 +115,29 @@ Navigate into **Configuration > Application > Security**.
 
 This configuration is stored in the `config.ini` file in `/etc/icingaweb2`.
 
+### Password Policy Configuration <a id="configuration-security-password-policy"></a>
+
+Option            | Description
+------------------|-----------------------------------
+password\_policy  | **Optional.** Canonical name of the [password policy](05-Authentication.md#authentication-password-policy) to enforce. Defaults to `any` (None).
+
+Example:
+
+```
+[security]
+password_policy = "common"
+```
+
 ### Content Security Policy Configuration <a id="configuration-security-csp"></a>
 
-| Option                  | Description                                                                                                                                               |
-|-------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| use\_strict\_csp        | **Optional.** Set this to `1` to enable strict [Content Security Policy](20-Advanced-Topics.md#advanced-topics-csp). Defaults to `0`.                     |
-| use\_custom\_csp        | **Optional.** Set this to `1` to enable the use of the user defined Content Security Policy. Defaults to `0`.                                             |
-| custom\_csp             | **Optional.** Specifies the user defined Content Security Policy. Overrides the automatically generated one. Only used if `use_custom_csp` is set to `1`. |
-| csp\_enable\_modules    | **Optional.** Specifies if modules should be included in the generated Content Security Policy. Defaults to `1`.                                          |
-| csp\_enable\_dashboards | **Optional.** Specifies if dashboards should be included in the generated Content Security Policy. Defaults to `1`.                                       |
-| csp\_enable\_navigation | **Optional.** Specifies if navigation menu items should be included in the generated Content Security Policy. Defaults to `1`.                            |
+Option                  | Description
+------------------------|------------------------------
+use\_strict\_csp        | **Optional.** Set this to `1` to enable strict [Content Security Policy](20-Advanced-Topics.md#advanced-topics-csp). Defaults to `0`.
+use\_custom\_csp        | **Optional.** Set this to `1` to use the user-defined Content Security Policy. Defaults to `0`.
+custom\_csp             | **Optional.** Specifies the user defined Content Security Policy. Overrides the automatically generated one. Only used if `use_custom_csp` is set to `1`.
+csp\_enable\_modules    | **Optional.** Specifies if modules should be included in the generated Content Security Policy. Defaults to `1`.
+csp\_enable\_dashboards | **Optional.** Specifies if dashboards should be included in the generated Content Security Policy. Defaults to `1`.
+csp\_enable\_navigation | **Optional.** Specifies if navigation menu items should be included in the generated Content Security Policy. Defaults to `1`.
 
 Example:
 

--- a/doc/05-Authentication.md
+++ b/doc/05-Authentication.md
@@ -375,7 +375,8 @@ converted to "rroe@EXAMPLE" as soon as the user logs in.
 
 ### Default Domain <a id="default-auth-domain"></a>
 
-For the sake of simplicity a default domain can be configured (in `config.ini`).
+For the sake of simplicity a default domain can be configured in
+[config.ini](03-Configuration.md#configuration-general-authentication).
 
 **Example:**
 

--- a/doc/06-Security.md
+++ b/doc/06-Security.md
@@ -115,6 +115,8 @@ Name                         | Permits
 \*                           | allow everything, including module-specific permissions
 application/announcements    | allow to manage announcements
 application/log              | allow to view the application log
+application/migrations       | allow to apply pending application migrations
+application/sessions         | allow to manage user sessions
 config/\*                    | allow full config access
 config/access-control/\*     | allow to fully manage access control
 config/access-control/groups | allow to manage groups
@@ -124,6 +126,7 @@ config/general               | allow to adjust the general configuration
 config/modules               | allow to enable/disable and configure modules
 config/navigation            | allow to view and adjust shared navigation items
 config/resources             | allow to manage resources
+config/security              | allow to adjust the security configuration
 user/\*                      | allow all account related functionalities
 user/application/stacktraces | allow to adjust in the preferences whether to show stacktraces
 user/password-change         | allow password changes in the account preferences

--- a/doc/20-Advanced-Topics.md
+++ b/doc/20-Advanced-Topics.md
@@ -127,7 +127,8 @@ the Icinga Web modules. Icinga Web and all its components listed below, on the o
 that's not the case, please submit an issue on GitHub in the respective repositories.
 
 To enable the strict content security policy, navigate to **Configuration > Application > Security** and toggle
-"Send CSP header", or set `use_strict_csp` in the `config.ini`.
+"Send CSP header", or set `use_strict_csp` in
+[config.ini](03-Configuration.md#configuration-security-csp).
 
 Icinga does its best to support user-defined content like navigation items and dashboard dashlets. If that behavior is
 not desired, you can disable both by disabling the corresponding feature in the **Security page** at

--- a/doc/60-Hooks.md
+++ b/doc/60-Hooks.md
@@ -158,3 +158,95 @@ class Csp extends CspHook
     }
 }
 ```
+
+## TwoFactorHook <a id="hooks-two-factor"></a>
+
+The `TwoFactorHook` allows modules to provide a two-factor authentication method,
+such as TOTP or email token. Icinga Web asks every registered method whether a user
+is enrolled, and if so, requires the second factor after the primary login succeeds.
+This hook always runs, regardless of the `module/<module-name>` permission.
+
+Icinga Web derives a **canonical name** in the format `<module>/<name>`
+(e.g. `mymodule/totp`) from the providing module and `getName()`, so two modules
+may register a method using the same `getName()` without colliding.
+
+If the module providing a user's enrolled method is disabled, that method is no
+longer registered. The user's enrollment is then ignored and they log in without
+a second factor. This is expected when an administrator disables a 2FA module.
+
+The example below calls `loadSecret()`, `checkToken()`, `generateSecret()`,
+`storeSecret()`, and `deleteSecret()`. These are placeholders that neither
+`TwoFactorHook` nor this example provides. A real implementation must supply
+them, including secure secret generation, token verification, and protected
+persistent storage of the per-user secret.
+
+Hook example:
+
+```php
+<?php
+
+namespace Icinga\Module\Mymodule\ProvidedHook;
+
+use Icinga\Application\Hook\TwoFactorHook;
+use Icinga\User;
+use ipl\Html\FormElement\FieldsetElement;
+use ipl\I18n\Translation;
+use SensitiveParameter;
+
+class TotpTwoFactor extends TwoFactorHook
+{
+    use Translation;
+
+    public function getName(): string
+    {
+        return 'totp';
+    }
+
+    public function getDisplayName(): string
+    {
+        return $this->translate('TOTP');
+    }
+
+    public function isEnrolled(User $user): bool
+    {
+        return $this->loadSecret($user) !== null;
+    }
+
+    public function verify(User $user, #[SensitiveParameter] string $token): bool
+    {
+        return $this->checkToken($this->loadSecret($user), $token);
+    }
+
+    public function assembleEnrollmentFormElements(User $user, FieldsetElement $fieldset): void
+    {
+        $fieldset->addElement('text', 'secret', [
+            'readonly' => true,
+            'value'    => $this->generateSecret(),
+        ]);
+
+        $fieldset->addElement('text', 'token', [
+            'label'    => $this->translate('Verification Code'),
+            'required' => true,
+        ]);
+    }
+
+    public function enroll(User $user, FieldsetElement $fieldset): bool
+    {
+        $secret = $fieldset->getValue('secret');
+        if (! $this->checkToken($secret, $fieldset->getValue('token'))) {
+            $fieldset->getElement('token')->addMessage($this->translate('Invalid code'));
+
+            return false;
+        }
+
+        $this->storeSecret($user, $secret);
+
+        return true;
+    }
+
+    public function unenroll(User $user): void
+    {
+        $this->deleteSecret($user);
+    }
+}
+```

--- a/doc/60-Hooks.md
+++ b/doc/60-Hooks.md
@@ -17,6 +17,58 @@ use Icinga\Module\Acme\ProvidedHook\MyHook;
 MyHook::register();
 ```
 
+## Writing a Hook <a id="hooks-writing-hook"></a>
+
+Modules can define their own hook types for other modules to implement. The abstract base class goes in
+`library/<ModuleName>/Hook/<HookName>.php`. Use the `HookEssentials` trait and implement `getHookName()`,
+which returns a string that uniquely identifies the hook type:
+
+```php
+<?php
+
+namespace Icinga\Module\Acme\Hook;
+
+use Icinga\Application\Hook\HookEssentials;
+
+abstract class TicketHook
+{
+    use HookEssentials;
+
+    protected static function getHookName(): string
+    {
+        return 'Acme/Ticket';
+    }
+
+    abstract public function createTicket(string $title): string;
+}
+```
+
+The trait provides `all()` and `first()` for retrieving registered implementations,
+`isRegistered()` to check if a hook of this type is already registered, and `register()`
+for implementors to register themselves.
+
+By default, an implementation is skipped for users without the `module/<module-name>` permission of the
+providing module. Override `isAlwaysRun()` to return `true` if the hook should run regardless:
+
+```php
+protected static function isAlwaysRun(): bool
+{
+    return true;
+}
+```
+
+### Implement the new Hook <a id="hooks-implement-new-hook"></a>
+
+Other modules can now provide implementations of the hook. Registration works
+as described earlier, but the class goes in a subnamespace of the implementing
+module's `ProvidedHook` namespace:
+
+```
+library/<ModuleName>/ProvidedHook/Acme/<HookName>.php
+```
+
+Don't forget to register the hook in the `run.php`.
+
 ## ConfigFormEventsHook
 
 The `ConfigFormEventsHook` allows developers to hook into the handling of configuration forms. It provides three methods:

--- a/doc/60-Hooks.md
+++ b/doc/60-Hooks.md
@@ -1,5 +1,22 @@
 # Hooks
 
+Modules provide hook implementations by extending one of the base classes in
+`Icinga\Application\Hook\`. The class goes in the module's `ProvidedHook` namespace:
+
+```
+library/<ModuleName>/ProvidedHook/<HookName>.php
+```
+
+For Icinga Web to call a hook, it needs to be registered. This happens in the module's `run.php`:
+
+```php
+<?php
+
+use Icinga\Module\Acme\ProvidedHook\MyHook;
+
+MyHook::register();
+```
+
 ## ConfigFormEventsHook
 
 The `ConfigFormEventsHook` allows developers to hook into the handling of configuration forms. It provides three methods:


### PR DESCRIPTION
- Add a general introduction to the hooks chapter explaining how to implement and register a hook, and how to define a new hook type using `HookEssentials`
- Add missing `config/security` permission to the permissions table in the security chapter