### PR TITLE
Reload on timezone/locale preference changes and after authentication

### DIFF
--- a/application/forms/PreferenceForm.php
+++ b/application/forms/PreferenceForm.php
@@ -98,7 +98,7 @@ class PreferenceForm extends Form
         $currentPreferences = $this->Auth()->getUser()->getPreferences();
         $oldTheme = $currentPreferences->getValue('icingaweb', 'theme');
         $oldMode = $currentPreferences->getValue('icingaweb', 'theme_mode');
-        $oldLocale = $currentPreferences->getValue('icingaweb', 'language');
+        $oldLocale = $currentPreferences->getValue('icingaweb', 'language', 'autodetect');
         $oldTimezone = $currentPreferences->getValue('icingaweb', 'timezone', 'autodetect');
         $defaultTheme = Config::app()->get('themes', 'default', StyleSheet::DEFAULT_THEME);
 
@@ -129,14 +129,9 @@ class PreferenceForm extends Form
             $this->getResponse()->setReloadCss(true);
         }
 
-        if (($locale = $this->getElement('language')) !== null
-            && $locale->getValue() !== 'autodetect'
-            && $locale->getValue() !== $oldLocale
+        if ((($locale = $this->getElement('language')) !== null && $locale->getValue() !== $oldLocale)
+            || (($timezone = $this->getElement('timezone')) !== null && $timezone->getValue() !== $oldTimezone)
         ) {
-            $this->getResponse()->setHeader('X-Icinga-Redirect-Http', 'yes');
-        }
-
-        if (($timezone = $this->getElement('timezone')) !== null && $timezone->getValue() !== $oldTimezone) {
             $this->getResponse()->setHeader('X-Icinga-Redirect-Http', 'yes', true);
         }
 

--- a/application/forms/PreferenceForm.php
+++ b/application/forms/PreferenceForm.php
@@ -99,6 +99,7 @@ class PreferenceForm extends Form
         $oldTheme = $currentPreferences->getValue('icingaweb', 'theme');
         $oldMode = $currentPreferences->getValue('icingaweb', 'theme_mode');
         $oldLocale = $currentPreferences->getValue('icingaweb', 'language');
+        $oldTimezone = $currentPreferences->getValue('icingaweb', 'timezone', 'autodetect');
         $defaultTheme = Config::app()->get('themes', 'default', StyleSheet::DEFAULT_THEME);
 
         $this->preferences = new Preferences($this->store ? $this->store->load() : []);
@@ -133,6 +134,10 @@ class PreferenceForm extends Form
             && $locale->getValue() !== $oldLocale
         ) {
             $this->getResponse()->setHeader('X-Icinga-Redirect-Http', 'yes');
+        }
+
+        if (($timezone = $this->getElement('timezone')) !== null && $timezone->getValue() !== $oldTimezone) {
+            $this->getResponse()->setHeader('X-Icinga-Redirect-Http', 'yes', true);
         }
 
         try {

--- a/library/Icinga/Authentication/Auth.php
+++ b/library/Icinga/Authentication/Auth.php
@@ -22,7 +22,6 @@ use Icinga\User;
 use Icinga\User\Preferences;
 use Icinga\User\Preferences\PreferencesStore;
 use Icinga\Web\Session;
-use Icinga\Web\StyleSheet;
 use LogicException;
 use Throwable;
 
@@ -135,28 +134,7 @@ class Auth
     {
         $this->setupUser($user);
 
-        // Reload CSS if the theme changed
-        $themingConfig = Icinga::app()->getConfig()->getSection('themes');
-        $userTheme = $user->getPreferences()->getValue('icingaweb', 'theme');
-        if (! (bool) $themingConfig->get('disabled', false) && $userTheme !== null) {
-            $defaultTheme = $themingConfig->get('default', StyleSheet::DEFAULT_THEME);
-            if ($userTheme !== $defaultTheme) {
-                $this->getResponse()->setReloadCss(true);
-            }
-        }
-
-        // Also reload CSS if the theme mode changed
-        $themeMode = $user->getPreferences()->getValue('icingaweb', 'theme_mode');
-        if ($themeMode && $themeMode !== StyleSheet::DEFAULT_MODE) {
-            $this->getResponse()->setReloadCss(true);
-        }
-
-        // Reload entire layout if the locale changed
-        if (($locale = $user->getPreferences()->getValue('icingaweb', 'language')) !== null) {
-            if (setlocale(LC_ALL, 0) !== $locale && $this->getRequest()->isXmlHttpRequest()) {
-                $this->getResponse()->setHeader('X-Icinga-Redirect-Http', 'yes');
-            }
-        }
+        $this->getResponse()->setHeader('X-Icinga-Redirect-Http', 'yes', true);
 
         $this->setUser($user);
         if ($persist) {


### PR DESCRIPTION
This PR improves the page reload behavior when user preferences change and after authentication.

**Reload after authentication**:

The layout is now always reloaded via the `X-Icinga-Redirect-Http` header after a user logs in. The previous approach conditionally reloaded based on whether the user's stored theme or locale differed from the current state. A full reload is the correct behavior here since the authenticated session may differ from the guest state in multiple ways. This also allows `bootstrap.js` to create a new `Icinga` instance with updated dataset values.

**Reload on timezone change**:

Changing the timezone preference now triggers a full page reload, the same way a locale change does. Without this, time-dependent UI would display stale data until the user manually reloaded.

**Fix locale change detection when no preference is stored**:

When a user had no stored language preference, `getValue('icingaweb', 'language')` returned null, causing the comparison against the submitted value to behave incorrectly. The fix passes 'autodetect' as the default for both language and timezone, which matches the sentinel value the form uses when no explicit preference is selected. This ensures switching away from the implicit default is detected correctly.

fixes #5535