### PR TITLE
Add configurable default theme mode to theming configuration

### DIFF
--- a/application/forms/Config/General/ThemingConfigForm.php
+++ b/application/forms/Config/General/ThemingConfigForm.php
@@ -60,6 +60,21 @@ class ThemingConfigForm extends Form
             ]
         );
 
+        $this->addElement(
+            'select',
+            'themes_default_mode',
+            [
+                'description'  => $this->translate('The default theme mode', 'Form element description'),
+                'label'        => $this->translate('Default Theme Mode', 'Form element label'),
+                'value'        => StyleSheet::DEFAULT_MODE,
+                'multiOptions' => [
+                    'system' => $this->translate('System'),
+                    'none'   => $this->translate('Dark'),
+                    'light'  => $this->translate('Light'),
+                ],
+            ]
+        );
+
         return $this;
     }
 
@@ -71,6 +86,9 @@ class ThemingConfigForm extends Form
         $values = parent::getValues($suppressArrayNotation);
         if ($values['themes_default'] === '' || $values['themes_default'] === StyleSheet::DEFAULT_THEME) {
             $values['themes_default'] = null;
+        }
+        if ($values['themes_default_mode'] === '' || $values['themes_default_mode'] === StyleSheet::DEFAULT_MODE) {
+            $values['themes_default_mode'] = null;
         }
         if (! $values['themes_disabled']) {
             $values['themes_disabled'] = null;

--- a/library/Icinga/Web/StyleSheet.php
+++ b/library/Icinga/Web/StyleSheet.php
@@ -189,9 +189,10 @@ class StyleSheet
 
         $mode = 'none';
         if ($auth->isAuthenticated()) {
+            $mode = $themingConfig->get('default_mode', static::DEFAULT_MODE);
             $file = $themePath !== null ? @file_get_contents($themePath) : false;
             if (! $file || strpos($file, self::LIGHT_MODE_IDENTIFIER) !== false) {
-                $mode = $auth->getUser()->getPreferences()->getValue('icingaweb', 'theme_mode', self::DEFAULT_MODE);
+                $mode = $auth->getUser()->getPreferences()->getValue('icingaweb', 'theme_mode', $mode);
             }
         }
 


### PR DESCRIPTION
Allow administrators to configure the default theme mode (system, dark, or light) via the theming configuration form. Previously, users without a personal theme mode preference always fell back to the hard-coded DEFAULT_MODE constant. With this change, the configured default is used as the fallback instead, giving administrators control over the out-of-the-box appearance for their users.

resolves #5257