### PR TITLE
Check for a preference store before accepting the primary submit button

### DIFF
--- a/application/forms/PreferenceForm.php
+++ b/application/forms/PreferenceForm.php
@@ -441,7 +441,7 @@ class PreferenceForm extends Form
 
     public function isSubmitted()
     {
-        if (parent::isSubmitted()) {
+        if ($this->store !== null && parent::isSubmitted()) {
             return true;
         }
 


### PR DESCRIPTION
Previously, `isSubmitted()` would treat the primary submit button `btn_submit` as a valid submission even when no preference store was configured. Without a store, saving preferences is not possible.

The fix gates the primary submit path on `$this->store !== null`, so only the session-only button `btn_submit_session` remains available when there is no store.

fixes #5424