### PR TITLE
Replace form notification rendering with Callout widget

### DIFF
--- a/library/Icinga/Web/Form/Decorator/FormNotifications.php
+++ b/library/Icinga/Web/Form/Decorator/FormNotifications.php
@@ -36,11 +36,6 @@ class FormNotifications extends Zend_Form_Decorator_Abstract
             return $content;
         }
 
-        $view = $form->getView();
-        if ($view === null) {
-            return $content;
-        }
-
         $notifications = $this->recurseForm($form);
         if (empty($notifications)) {
             return $content;
@@ -51,12 +46,7 @@ class FormNotifications extends Zend_Form_Decorator_Abstract
             if (isset($notifications[$type])) {
                 $messages = [];
                 foreach ($notifications[$type] as $message) {
-                    if (is_array($message)) {
-                        [$message, $properties] = $message;
-                        $messages[] = HtmlElement::create('li', $properties, $message);
-                    } else {
-                        $messages[] = HtmlElement::create('li', [], $message);
-                    }
+                    $messages[] = HtmlElement::create('li', [], $message);
                 }
 
                 $count = count($messages);
@@ -64,6 +54,7 @@ class FormNotifications extends Zend_Form_Decorator_Abstract
                     $document = HtmlElement::create('ul', null, $messages);
                 } else {
                     $document = new HtmlDocument();
+                    // Single message: unwrap <li> so the callout renders plain content, not a list.
                     $document->add($messages[0]->getContent());
                 }
 
@@ -128,6 +119,7 @@ class FormNotifications extends Zend_Form_Decorator_Abstract
      * @param int $count Number of notifications of the given type
      *
      * @return string
+     *
      * @throws LogicException In case the given type is invalid
      */
     protected function getCalloutTitle(int $type, int $count): string
@@ -135,7 +127,7 @@ class FormNotifications extends Zend_Form_Decorator_Abstract
         return match ($type) {
             Form::NOTIFICATION_ERROR => $this->translatePlural('Error', 'Errors', $count),
             Form::NOTIFICATION_WARNING => $this->translatePlural('Warning', 'Warnings', $count),
-            Form::NOTIFICATION_INFO => $this->translatePlural('Info', 'Infos', $count),
+            Form::NOTIFICATION_INFO => $this->translatePlural('Info', 'Info', $count),
             default => throw new LogicException(sprintf('Invalid notification type "%s" provided', $type)),
         };
     }

--- a/library/Icinga/Web/Form/Decorator/FormNotifications.php
+++ b/library/Icinga/Web/Form/Decorator/FormNotifications.php
@@ -5,9 +5,14 @@
 
 namespace Icinga\Web\Form\Decorator;
 
-use Icinga\Application\Icinga;
-use Icinga\Exception\ProgrammingError;
 use Icinga\Web\Form;
+use ipl\Html\Attributes;
+use ipl\Html\HtmlDocument;
+use ipl\Html\HtmlElement;
+use ipl\I18n\Translation;
+use ipl\Web\Common\CalloutType;
+use ipl\Web\Widget\Callout;
+use LogicException;
 use Zend_Form_Decorator_Abstract;
 
 /**
@@ -15,6 +20,8 @@ use Zend_Form_Decorator_Abstract;
  */
 class FormNotifications extends Zend_Form_Decorator_Abstract
 {
+    use Translation;
+
     /**
      * Render form notifications
      *
@@ -39,45 +46,38 @@ class FormNotifications extends Zend_Form_Decorator_Abstract
             return $content;
         }
 
-        $html = '<ul class="form-notification-list">';
+        $html = '';
         foreach ([Form::NOTIFICATION_ERROR, Form::NOTIFICATION_WARNING, Form::NOTIFICATION_INFO] as $type) {
             if (isset($notifications[$type])) {
-                $html .= '<li><ul class="notification-' . $this->getNotificationTypeName($type) . '">';
+                $messages = [];
                 foreach ($notifications[$type] as $message) {
                     if (is_array($message)) {
-                        list($message, $properties) = $message;
-                        $html .= '<li' . $view->propertiesToString($properties) . '>'
-                            . $view->escape($message)
-                            . '</li>';
+                        [$message, $properties] = $message;
+                        $messages[] = HtmlElement::create('li', $properties, $message);
                     } else {
-                        $html .= '<li>' . $view->escape($message) . '</li>';
+                        $messages[] = HtmlElement::create('li', [], $message);
                     }
                 }
 
-                $html .= '</ul></li>';
+                $count = count($messages);
+                if ($count > 1) {
+                    $document = HtmlElement::create('ul', null, $messages);
+                } else {
+                    $document = new HtmlDocument();
+                    $document->add($messages[0]->getContent());
+                }
+
+                $html .= (new Callout($this->getCalloutType($type), $document, $this->getCalloutTitle($type, $count)))
+                    ->addAttributes(new Attributes(['class' => 'form-notification']))
+                    ->render();
             }
         }
 
-        if (isset($notifications[Form::NOTIFICATION_ERROR])) {
-            $icon = 'cancel';
-            $class = 'error';
-        } elseif (isset($notifications[Form::NOTIFICATION_WARNING])) {
-            $icon = 'warning-empty';
-            $class = 'warning';
-        } else {
-            $icon = 'info';
-            $class = 'info';
-        }
-
-        $html = "<div class=\"form-notifications $class\">"
-        . Icinga::app()->getViewRenderer()->view->icon($icon, '', ['class' => 'form-notification-icon'])
-        . $html;
-
         switch ($this->getPlacement()) {
             case self::APPEND:
-                return $content . $html . '</ul></div>';
+                return $content . $html;
             case self::PREPEND:
-                return $html . '</ul></div>' . $content;
+                return $html . $content;
         }
     }
 
@@ -103,25 +103,40 @@ class FormNotifications extends Zend_Form_Decorator_Abstract
     }
 
     /**
-     * Return the name for the given notification type
+     * Return the callout type for the given notification type
      *
-     * @param   int     $type
+     * @param int $type Form notification type constants
      *
-     * @return  string
+     * @return CalloutType
      *
-     * @throws  ProgrammingError    In case the given type is invalid
+     * @throws LogicException In case the given type is invalid
      */
-    protected function getNotificationTypeName($type)
+    protected function getCalloutType(int $type): CalloutType
     {
-        switch ($type) {
-            case Form::NOTIFICATION_ERROR:
-                return 'error';
-            case Form::NOTIFICATION_WARNING:
-                return 'warning';
-            case Form::NOTIFICATION_INFO:
-                return 'info';
-            default:
-                throw new ProgrammingError('Invalid notification type "%s" provided', $type);
-        }
+        return match ($type) {
+            Form::NOTIFICATION_ERROR => CalloutType::Error,
+            Form::NOTIFICATION_WARNING => CalloutType::Warning,
+            Form::NOTIFICATION_INFO => CalloutType::Info,
+            default => throw new LogicException(sprintf('Invalid notification type "%s" provided', $type)),
+        };
+    }
+
+    /**
+     * Return the title for the given notification type
+     *
+     * @param int $type Form notification type constants
+     * @param int $count Number of notifications of the given type
+     *
+     * @return string
+     * @throws LogicException In case the given type is invalid
+     */
+    protected function getCalloutTitle(int $type, int $count): string
+    {
+        return match ($type) {
+            Form::NOTIFICATION_ERROR => $this->translatePlural('Error', 'Errors', $count),
+            Form::NOTIFICATION_WARNING => $this->translatePlural('Warning', 'Warnings', $count),
+            Form::NOTIFICATION_INFO => $this->translatePlural('Info', 'Infos', $count),
+            default => throw new LogicException(sprintf('Invalid notification type "%s" provided', $type)),
+        };
     }
 }

--- a/public/css/icinga/base.less
+++ b/public/css/icinga/base.less
@@ -82,10 +82,6 @@
 @menu-flyout-color: @text-color;
 @tab-hover-bg-color: fade(@body-bg-color, 50%);
 
-// Form colors
-@form-info-bg-color: fade(@color-ok, 20%);
-@form-error-bg-color: fade(@color-critical, 30%);
-@form-warning-bg-color: fade(@color-warning, 40%);
 @login-box-background: fade(#0B0B2F, 30%);
 
 // Other colors

--- a/public/css/icinga/forms.less
+++ b/public/css/icinga/forms.less
@@ -475,7 +475,10 @@ form.icinga-form .control-group.disabled .control-label-group {
 // Errors and additional information
 
 form.icinga-form {
-  .form-notifications,
+  .form-notification {
+    margin: 0 0 1em 0;
+  }
+
   .form-description {
     border-radius: .25em;
     display: flex;
@@ -494,26 +497,11 @@ form.icinga-form {
       list-style: none;
     }
 
-    & .form-notification-icon,
     & .form-description-icon {
       font-size: 2em;
       margin-left: .25em;
       opacity: .4;
       align-self: flex-start;
-    }
-  }
-
-  .form-notifications {
-    &.info {
-      background-color: @form-info-bg-color;
-    }
-
-    &.error {
-      background-color: @form-error-bg-color;
-    }
-
-    &.warning {
-      background-color: @form-warning-bg-color;
     }
   }
 


### PR DESCRIPTION
The `FormNotifications` decorator previously rendered notifications as raw HTML strings using a custom `div.form-notifications` wrapper with an icon and severity-specific CSS classes. This replaces that with the `ipl\Web\Widget\Callout` component, which provides consistent styling and accessible structure across the application.

Each notification type now maps to a `CalloutType` and is wrapped in a Callout instance. Multiple notifications of the same type are grouped in a `<ul>` inside the callout, while a single notification renders its message directly. A new `getNotificationTypeTitle()` method provides a translated, pluralized title for each callout.

The corresponding Less rules for `.form-notifications` are removed since the Callout widget handles its own presentation.

requires Icinga/ipl-web#397