### PR TITLE
Modernize `RoleForm` to ipl based `RepositoryForm`

### DIFF
--- a/application/controllers/RoleController.php
+++ b/application/controllers/RoleController.php
@@ -15,15 +15,20 @@ use Icinga\Data\Selectable;
 use Icinga\Exception\NotFoundError;
 use Icinga\Forms\Security\RoleForm;
 use Icinga\Repository\Repository;
+use Icinga\Repository\RepositoryMode;
 use Icinga\Security\SecurityException;
 use Icinga\User;
 use Icinga\Web\Controller\AuthBackendController;
+use Icinga\Web\Notification;
+use Icinga\Web\Session;
 use Icinga\Web\View\PrivilegeAudit;
 use Icinga\Web\Widget\SingleValueSearchControl;
+use ipl\Html\Contract\Form;
 use ipl\Html\Html;
 use ipl\Html\HtmlString;
 use ipl\Web\Url;
 use ipl\Web\Widget\Link;
+use Throwable;
 
 /**
  * Manage user permissions and restrictions based on roles
@@ -81,58 +86,78 @@ class RoleController extends AuthBackendController
     /**
      * Create a new role
      */
-    public function addAction()
+    public function addAction(): void
     {
-        $role = new RoleForm();
-        $role->setRedirectUrl('__CLOSE__');
-        $role->setRepository(new RolesConfig());
-        $role->setSubmitLabel($this->translate('Create Role'));
-        $role->add()->handleRequest();
+        $form = (new RoleForm(new RolesConfig(), RepositoryMode::Insert))
+            ->setCsrfCounterMeasureId(Session::getSession()->getId())
+            ->setRedirectUrl(Url::fromPath('role/list'))
+            ->on(Form::ON_SUBMIT, function (RoleForm $form): void {
+                Notification::success($this->translate('Role created'));
+                $this->redirectNow($form->getRedirectUrl());
+            })
+            ->on(Form::ON_ERROR, function (Throwable $_, RoleForm $_form): void {
+                Notification::error($this->translate('Role creation failed'));
+            })
+            ->handleRequest(ServerRequest::fromGlobals());
 
-        $this->renderForm($role, $this->translate('New Role'));
+        $this->addTitleTab($this->translate('New Role'));
+        $this->addContent($form);
     }
 
     /**
      * Update a role
      */
-    public function editAction()
+    public function editAction(): void
     {
-        $name = $this->params->getRequired('role');
-        $role = new RoleForm();
-        $role->setRedirectUrl('__CLOSE__');
-        $role->setRepository(new RolesConfig());
-        $role->setSubmitLabel($this->translate('Update Role'));
-        $role->edit($name);
+        $roleName = $this->params->getRequired('role');
+
+        $form = (new RoleForm(new RolesConfig(), RepositoryMode::Update, $roleName))
+            ->setCsrfCounterMeasureId(Session::getSession()->getId())
+            ->setRedirectUrl(Url::fromPath('role/list'))
+            ->on(Form::ON_SUBMIT, function (RoleForm $form): void {
+                Notification::success(sprintf($this->translate('Role "%s" has been updated'), $form->getIdentifier()));
+                $this->redirectNow($form->getRedirectUrl());
+            })
+            ->on(Form::ON_ERROR, function (Throwable $_, RoleForm $form): void {
+                Notification::error(sprintf($this->translate('Failed to update role "%s"'), $form->getIdentifier()));
+            });
 
         try {
-            $role->handleRequest();
-        } catch (NotFoundError $e) {
-            $this->httpNotFound($this->translate('Role not found'));
+            $form->handleRequest(ServerRequest::fromGlobals());
+        } catch (NotFoundError) {
+            $this->httpNotFound(sprintf($this->translate('Role "%s" not found'), $roleName));
         }
 
-        $this->renderForm($role, $this->translate('Update Role'));
+        $this->addTitleTab($this->translate('Update Role'));
+        $this->addContent($form);
     }
 
     /**
      * Remove a role
      */
-    public function removeAction()
+    public function removeAction(): void
     {
-        $name = $this->params->getRequired('role');
-        $role = new RoleForm();
-        $role->setAttrib('class', 'icinga-controls');
-        $role->setRedirectUrl('__CLOSE__');
-        $role->setRepository(new RolesConfig());
-        $role->setSubmitLabel($this->translate('Confirm Removal'));
-        $role->remove($name);
+        $roleName = $this->params->getRequired('role');
+
+        $form = (new RoleForm(new RolesConfig(), RepositoryMode::Delete, $roleName))
+            ->setCsrfCounterMeasureId(Session::getSession()->getId())
+            ->setRedirectUrl(Url::fromPath('role/list'))
+            ->on(Form::ON_SUBMIT, function (RoleForm $form): void {
+                Notification::success(sprintf($this->translate('Role "%s" has been removed'), $form->getIdentifier()));
+                $this->redirectNow($form->getRedirectUrl());
+            })
+            ->on(Form::ON_ERROR, function (Throwable $_, RoleForm $form): void {
+                Notification::error(sprintf($this->translate('Failed to remove role "%s"'), $form->getIdentifier()));
+            });
 
         try {
-            $role->handleRequest();
-        } catch (NotFoundError $e) {
-            $this->httpNotFound($this->translate('Role not found'));
+            $form->handleRequest(ServerRequest::fromGlobals());
+        } catch (NotFoundError) {
+            $this->httpNotFound(sprintf($this->translate('Role "%s" not found'), $roleName));
         }
 
-        $this->renderForm($role, $this->translate('Remove Role'));
+        $this->addTitleTab($this->translate('Remove Role'));
+        $this->addContent($form);
     }
 
     public function auditAction()

--- a/application/forms/Security/RoleForm.php
+++ b/application/forms/Security/RoleForm.php
@@ -5,15 +5,28 @@
 
 namespace Icinga\Forms\Security;
 
-use Icinga\Application\Hook\ConfigFormEventsHook;
 use Icinga\Application\Icinga;
 use Icinga\Application\Modules\Manager;
+use Icinga\Application\Web;
 use Icinga\Authentication\AdmissionLoader;
 use Icinga\Data\Filter\Filter;
-use Icinga\Forms\ConfigForm;
-use Icinga\Forms\RepositoryForm;
+use Icinga\Data\Updatable;
+use Icinga\Repository\Repository;
+use Icinga\Repository\RepositoryMode;
 use Icinga\Util\StringHelper;
-use Icinga\Web\Notification;
+use Icinga\Web\Form\RepositoryForm;
+use InvalidArgumentException;
+use ipl\Html\Attributes;
+use ipl\Html\Contract\DecorationResult;
+use ipl\Html\Contract\FormElement;
+use ipl\Html\Contract\FormElementDecoration;
+use ipl\Html\FormattedString;
+use ipl\Html\FormElement\CheckboxElement;
+use ipl\Html\FormElement\FieldsetElement;
+use ipl\Html\HtmlDocument;
+use ipl\Html\HtmlElement;
+use ipl\Html\Text;
+use ipl\Stdlib\Str;
 use ipl\Web\Widget\Icon;
 
 /**
@@ -21,109 +34,118 @@ use ipl\Web\Widget\Icon;
  */
 class RoleForm extends RepositoryForm
 {
-    /**
-     * The name to use instead of `*`
-     */
-    const WILDCARD_NAME = 'allAndEverything';
+    /** @var string The name to use instead of `*` */
+    public const WILDCARD_NAME = 'allAndEverything';
 
-    /**
-     * The prefix used to deny a permission
-     */
-    const DENY_PREFIX = 'no-';
+    /** @var string The prefix used to deny a permission */
+    public const DENY_PREFIX = 'no-';
+
+    /** @var string The suffix used for the fieldset names */
+    public const FIELDSET_SUFFIX = '_elements';
 
     /**
      * Provided permissions by currently installed modules
      *
-     * @var array
+     * @var array<string, array<string, array<string, mixed>>>
      */
-    protected $providedPermissions;
+    protected array $providedPermissions;
 
     /**
      * Provided restrictions by currently installed modules
      *
-     * @var array
+     * @var array<string, array<string, array<string, mixed>>>
      */
-    protected $providedRestrictions;
+    protected array $providedRestrictions;
 
-    public function init()
+    /**
+     * Create a new RoleForm
+     *
+     * In addition to the interface {@see RepositoryForm::__construct()}
+     * requires for $mode, the repository must implement {@see Updatable}
+     * when in {@see RepositoryMode::Delete} to clear the parent references
+     * on roles that inherit from the deleted one.
+     *
+     * @param Repository $repository The repository to work with
+     * @param RepositoryMode $mode How to interact with the repository
+     * @param ?string $identifier The identifier of the entry to handle
+     *   Required for {@see RepositoryMode::Update} and {@see RepositoryMode::Delete}.
+     *
+     * @throws InvalidArgumentException If $repository does not meet $mode's
+     *   interface requirements, in particular if it is not also {@see Updatable}
+     *   in {@see RepositoryMode::Delete}
+     */
+    public function __construct(Repository $repository, RepositoryMode $mode, ?string $identifier = null)
     {
-        $this->setAttrib('class', self::DEFAULT_CLASSES . ' role-form');
+        parent::__construct($repository, $mode, $identifier);
 
-        list($this->providedPermissions, $this->providedRestrictions) = static::collectProvidedPrivileges();
+        if ($this->mode === RepositoryMode::Delete && ! ($this->repository instanceof Updatable)) {
+            throw new InvalidArgumentException(sprintf(
+                'Repository "%s" does not implement %s, which RoleForm requires in %s mode',
+                $this->repository::class,
+                Updatable::class,
+                RepositoryMode::Delete->name,
+            ));
+        }
+
+        $this->getAttributes()
+            ->set('name', 'repo_form_role')
+            ->add('class', 'role-form');
+
+        [$this->providedPermissions, $this->providedRestrictions] = static::collectProvidedPrivileges();
     }
 
-    protected function createFilter()
+    protected function createFilter(): Filter
     {
         return Filter::where('name', $this->getIdentifier());
     }
 
-    public function filterName($value, $allowBrackets = false)
+    protected function assembleCommonElements(): void
     {
-        return parent::filterName($value, $allowBrackets) . '_element';
-    }
+        $this->addElement('text', 'name', [
+            'description' => $this->translate('The name of the role'),
+            'label'       => $this->translate('Role Name'),
+            'required'    => true,
+        ]);
 
-    public function createInsertElements(array $formData = [])
-    {
-        $this->addElement(
-            'text',
-            'name',
-            [
-                'required'      => true,
-                'label'         => $this->translate('Role Name'),
-                'description'   => $this->translate('The name of the role')
-            ]
-        );
-        $this->addElement(
-            'select',
-            'parent',
-            [
-                'label'         => $this->translate('Inherit From'),
-                'description'   => $this->translate('Choose a role from which to inherit privileges'),
-                'value'         => '',
-                'multiOptions'  => array_merge(
-                    ['' => $this->translate('None', 'parent role')],
-                    $this->collectRoles()
-                )
-            ]
-        );
-        $this->addElement(
-            'textarea',
-            'users',
-            [
-                'label'         => $this->translate('Users'),
-                'description'   => $this->translate('Comma-separated list of users that are assigned to the role')
-            ]
-        );
-        $this->addElement(
-            'textarea',
-            'groups',
-            [
-                'label'         => $this->translate('Groups'),
-                'description'   => $this->translate('Comma-separated list of groups that are assigned to the role')
-            ]
-        );
-        $this->addElement(
-            'checkbox',
-            self::WILDCARD_NAME,
-            [
-                'autosubmit'    => true,
-                'label'         => $this->translate('Administrative Access'),
-                'description'   => $this->translate('Everything is allowed')
-            ]
-        );
-        $this->addElement(
-            'checkbox',
-            'unrestricted',
-            [
-                'autosubmit'        => true,
-                'uncheckedValue'    => null,
-                'label'             => $this->translate('Unrestricted Access'),
-                'description'       => $this->translate('Access to any data is completely unrestricted')
-            ]
-        );
+        $this->addElement('select', 'parent', [
+            'description'  => $this->translate('Choose a role from which to inherit privileges'),
+            'label'        => $this->translate('Inherit From'),
+            'multiOptions' => array_merge(
+                ['' => $this->translate('None', 'parent role')],
+                $this->collectRoles(),
+            ),
+            'value'        => '',
+        ]);
 
-        $hasAdminPerm = isset($formData[self::WILDCARD_NAME]) && $formData[self::WILDCARD_NAME];
-        $isUnrestricted = isset($formData['unrestricted']) && $formData['unrestricted'];
+        $this->addElement('textarea', 'users', [
+            'description' => $this->translate('Comma-separated list of users that are assigned to the role'),
+            'label'       => $this->translate('Users'),
+            'rows'        => 3,
+        ]);
+
+        $this->addElement('textarea', 'groups', [
+            'description' => $this->translate('Comma-separated list of groups that are assigned to the role'),
+            'label'       => $this->translate('Groups'),
+            'rows'        => 3,
+        ]);
+
+        $this->addElement('checkbox', self::WILDCARD_NAME, [
+            'class'       => 'autosubmit',
+            'description' => $this->translate('Everything is allowed'),
+            'label'       => $this->translate('Administrative Access'),
+        ]);
+
+        $this->addElement('checkbox', 'unrestricted', [
+            'checkedValue'   => '1',
+            'class'          => 'autosubmit',
+            'description'    => $this->translate('Access to any data is completely unrestricted'),
+            'label'          => $this->translate('Unrestricted Access'),
+            'uncheckedValue' => null,
+        ]);
+
+        $hasAdminPerm = $this->getPopulatedValue(self::WILDCARD_NAME) === 'y';
+        $isUnrestricted = $this->getPopulatedValue('unrestricted') === '1';
+
         foreach ($this->providedPermissions as $moduleName => $permissionList) {
             $this->sortPermissions($permissionList);
 
@@ -131,27 +153,37 @@ class RoleForm extends RepositoryForm
             $anythingRefused = false;
             $anythingRestricted = false;
 
-            $elements = [$moduleName . '_header'];
-            // The actual element is added last
+            $fieldset = new FieldsetElement($moduleName . static::FIELDSET_SUFFIX);
 
-            $elements[] = 'permission_header';
-            $this->addElement('note', 'permission_header', [
-                'decorators'    => [['Callback', ['callback' => function () {
-                    return '<h4>' . $this->translate('Permissions') . '</h4>'
-                        . $this->getView()->icon('ok', $this->translate(
-                            'Grant access by toggling a switch below'
-                        ))
-                        . $this->getView()->icon('cancel', $this->translate(
-                            'Deny access by toggling a switch below'
-                        ));
-                }]], ['HtmlTag', ['tag' => 'div']]]
-            ]);
+            // Pass on the form's element decorators to the fieldset
+            $fieldset->setDefaultElementDecorators($this->getDefaultElementDecorators());
+            $fieldset->addElementDecoratorLoaderPaths($this->elementDecoratorLoaderPaths);
+
+            $this->registerElement($fieldset);
+
+            $fieldset->addHtml(new HtmlElement(
+                'div',
+                null,
+                new HtmlElement('h4', null, new Text($this->translate('Permissions'))),
+                new HtmlElement('i', new Attributes([
+                    'aria-label' => $this->translate('Grant access by toggling a switch below'),
+                    'class'      => 'icon-ok',
+                    'title'      => $this->translate('Grant access by toggling a switch below'),
+                    'role'       => 'img',
+                ])),
+                new HtmlElement('i', new Attributes([
+                    'aria-label' => $this->translate('Deny access by toggling a switch below'),
+                    'class'      => 'icon-cancel',
+                    'title'      => $this->translate('Deny access by toggling a switch below'),
+                    'role'       => 'img',
+                ])),
+            ));
 
             $hasFullPerm = false;
             foreach ($permissionList as $name => $spec) {
-                $elementName = $this->filterName($name);
+                $elementName = $this->convertToElementName($name);
 
-                if (isset($formData[$elementName]) && $formData[$elementName]) {
+                if ($fieldset->getPopulatedValue($elementName) === 'y') {
                     $anythingGranted = true;
                 }
 
@@ -160,191 +192,216 @@ class RoleForm extends RepositoryForm
                 }
 
                 $denyCheckbox = null;
-                if (! isset($spec['isFullPerm'])
-                    && substr($name, 0, strlen(self::DENY_PREFIX)) !== self::DENY_PREFIX
-                ) {
-                    $denyCheckbox = $this->createElement('checkbox', $this->filterName(self::DENY_PREFIX . $name), [
-                        'decorators'    => ['ViewHelper']
-                    ]);
-                    $this->addElement($denyCheckbox);
-                    $this->removeFromIteration($denyCheckbox->getName());
+                if (! isset($spec['isFullPerm']) && ! str_starts_with($name, self::DENY_PREFIX)) {
+                    /** @var CheckboxElement $denyCheckbox */
+                    $denyCheckbox = $fieldset->createElement(
+                        'checkbox',
+                        $this->convertToElementName(self::DENY_PREFIX . $name)
+                    );
+                    $fieldset->registerElement($denyCheckbox);
 
-                    if (isset($formData[$denyCheckbox->getName()]) && $formData[$denyCheckbox->getName()]) {
+                    if ($fieldset->getPopulatedValue($denyCheckbox->getName()) === 'y') {
                         $anythingRefused = true;
                     }
                 }
 
-                $elements[] = $elementName;
-                $this->addElement(
-                    'checkbox',
-                    $elementName,
-                    [
-                        'ignore'        => $hasFullPerm || $hasAdminPerm,
-                        'autosubmit'    => isset($spec['isFullPerm']),
-                        'disabled'      => $hasFullPerm || $hasAdminPerm ?: null,
-                        'value'         => $hasFullPerm || $hasAdminPerm,
-                        'label'         => isset($spec['label'])
-                            ? $spec['label']
-                            : join('', iterator_to_array(call_user_func(function ($segments) {
-                                foreach ($segments as $segment) {
-                                    if ($segment[0] === '/') {
-                                        // Adds a zero-width char after each slash to help browsers break onto newlines
-                                        yield '/&#8203;';
-                                        yield '<span class="no-wrap">' . substr($segment, 1) . '</span>';
-                                    } else {
-                                        yield '<em>' . $segment . '</em>';
-                                    }
+                $fieldset->addElement('checkbox', $elementName, [
+                    'class'       => isset($spec['isFullPerm']) ? 'autosubmit' : null,
+                    'description' => $spec['description'] ?? $name,
+                    'disabled'    => $hasFullPerm || $hasAdminPerm,
+                    'ignore'      => $hasFullPerm || $hasAdminPerm,
+                    'label'       => $spec['label'] ?? $this->buildPrivilegeLabel($name),
+                    'checked'     => $hasFullPerm || $hasAdminPerm,
+                ]);
+
+                if ($denyCheckbox !== null) {
+                    /** @var CheckboxElement $checkboxElement */
+                    $checkboxElement = $fieldset->getElement($elementName);
+                    $checkboxElement->getDecorators()
+                        ->addDecorator('DenyToggle', new class ($denyCheckbox) implements FormElementDecoration {
+                            public function __construct(private readonly CheckboxElement $denyCheckbox)
+                            {
+                            }
+
+                            public function decorateFormElement(
+                                DecorationResult $result,
+                                FormElement $formElement,
+                            ): void {
+                                if (! $formElement instanceof CheckboxElement) {
+                                    return;
                                 }
-                            }, preg_split(
-                                '~(/[^/]+)~',
-                                $name,
-                                -1,
-                                PREG_SPLIT_DELIM_CAPTURE|PREG_SPLIT_NO_EMPTY
-                            )))),
-                        'description'   => isset($spec['description']) ? $spec['description'] : $name,
-                        'decorators'    => array_merge(
-                            array_slice(self::$defaultElementDecorators, 0, 3),
-                            [['Callback', ['callback' => function () use ($denyCheckbox) {
-                                return $denyCheckbox ? $denyCheckbox->render() : '';
-                            }]]],
-                            array_slice(self::$defaultElementDecorators, 3)
-                        )
-                    ]
-                )
-                    ->getElement($elementName)
-                    ->getDecorator('Label')
-                    ->setOption('escape', false);
+
+                                /** @var Web $app */
+                                $app = Icinga::app();
+                                $denyId = $app->getRequest()->protectId($this->denyCheckbox->getName());
+                                $this->denyCheckbox->getAttributes()
+                                    ->set('id', $denyId)
+                                    ->add('class', 'sr-only');
+
+                                $classes = ['toggle-switch'];
+                                if ($this->denyCheckbox->getAttributes()->get('disabled')->getValue()) {
+                                    $classes[] = 'disabled';
+                                }
+
+                                /** @var HtmlDocument $wrapper */
+                                $wrapper = $formElement->getWrapper();
+                                $wrapper->addHtml($this->denyCheckbox, new HtmlElement(
+                                    'label',
+                                    new Attributes(['class' => $classes, 'aria-hidden' => 'true', 'for' => $denyId]),
+                                    new HtmlElement('span', new Attributes(['class' => 'toggle-slider'])),
+                                ));
+                            }
+                        });
+                }
 
                 if ($hasFullPerm || $hasAdminPerm) {
                     // Add a hidden element to preserve the configured permission value
-                    $this->addElement('hidden', $this->filterName($name));
+                    $fieldset->addElement('hidden', $this->convertToElementName($name));
                 }
 
                 if (isset($spec['isFullPerm'])) {
-                    $filteredName = $this->filterName($name);
-                    $hasFullPerm = isset($formData[$filteredName]) && $formData[$filteredName];
+                    $hasFullPerm = $fieldset->getPopulatedValue($this->convertToElementName($name)) === 'y';
                 }
             }
 
             if (isset($this->providedRestrictions[$moduleName])) {
-                $elements[] = 'restriction_header';
-                $this->addElement('note', 'restriction_header', [
-                    'value'         => '<h4>' . $this->translate('Restrictions') . '</h4>',
-                    'decorators'    => ['ViewHelper']
-                ]);
+                $fieldset->addHtml(new HtmlElement('h4', null, new Text($this->translate('Restrictions'))));
 
                 foreach ($this->providedRestrictions[$moduleName] as $name => $spec) {
-                    $elementName = $this->filterName($name);
+                    $elementName = $this->convertToElementName($name);
 
-                    if (isset($formData[$elementName]) && $formData[$elementName]) {
+                    if (! Str::isEmpty($fieldset->getPopulatedValue($elementName))) {
                         $anythingRestricted = true;
                     }
 
-                    $elements[] = $elementName;
-                    $this->addElement(
-                        'text',
-                        $elementName,
-                        [
-                            'label'         => isset($spec['label'])
-                                ? $spec['label']
-                                : join('', iterator_to_array(call_user_func(function ($segments) {
-                                    foreach ($segments as $segment) {
-                                        if ($segment[0] === '/') {
-                                            // Add zero-width char after each slash to help browsers break onto newlines
-                                            yield '/&#8203;';
-                                            yield '<span class="no-wrap">' . substr($segment, 1) . '</span>';
-                                        } else {
-                                            yield '<em>' . $segment . '</em>';
-                                        }
-                                    }
-                                }, preg_split(
-                                    '~(/[^/]+)~',
-                                    $name,
-                                    -1,
-                                    PREG_SPLIT_DELIM_CAPTURE|PREG_SPLIT_NO_EMPTY
-                                )))),
-                            'description'   => $spec['description'],
-                            'class'         => $isUnrestricted ? 'unrestricted-role' : '',
-                            'readonly'      => $isUnrestricted ?: null
-                        ]
-                    )
-                        ->getElement($elementName)
-                        ->getDecorator('Label')
-                        ->setOption('escape', false);
+                    $fieldset->addElement('text', $elementName, [
+                        'class'       => $isUnrestricted ? 'unrestricted-role' : '',
+                        'description' => $spec['description'],
+                        'label'       => $spec['label'] ?? $this->buildPrivilegeLabel($name),
+                        'readonly'    => $isUnrestricted ?: null,
+                    ]);
                 }
             }
 
-            $this->addElement(
-                'note',
-                $moduleName . '_header',
-                [
-                    'decorators'    => ['ViewHelper'],
-                    'value'         => '<summary class="collapsible-control">'
-                        . '<span>' . ($moduleName !== 'application'
-                            ? sprintf('%s <em>%s</em>', $moduleName, $this->translate('Module'))
-                            :  'Icinga Web 2'
-                        ) . '</span>'
-                        . '<span class="privilege-preview">'
-                        . ($hasAdminPerm || $anythingGranted ? new Icon('check-circle', ['class' => 'granted']) : '')
-                        . ($anythingRefused ? new Icon('times-circle', ['class' => 'refused']) : '')
-                        . (! $isUnrestricted && $anythingRestricted
-                            ? new Icon('filter', ['class' => 'restricted'])
-                            : ''
-                        )
-                        . '</span>'
-                        . new Icon('angles-down', ['class' => 'collapse-icon'])
-                        . new Icon('angles-left', ['class' => 'expand-icon'])
-                        . '</summary>'
-                ]
+            $privilegePreview = new HtmlElement('span', new Attributes(['class' => 'privilege-preview']));
+
+            if ($hasAdminPerm || $anythingGranted) {
+                $privilegePreview->addHtml(new Icon('check-circle', ['class' => 'granted']));
+            }
+            if ($anythingRefused) {
+                $privilegePreview->addHtml(new Icon('times-circle', ['class' => 'refused']));
+            }
+            if (! $isUnrestricted && $anythingRestricted) {
+                $privilegePreview->addHtml(new Icon('filter', ['class' => 'restricted']));
+            }
+
+            $summary = new HtmlElement(
+                'summary',
+                new Attributes(['class' => 'collapsible-control']),
+                new HtmlElement('span', null, $moduleName !== 'application'
+                    ? new FormattedString('%s %s', [
+                        new Text($moduleName),
+                        new HtmlElement('em', null, new Text($this->translate('Module'))),
+                    ])
+                    : new Text('Icinga Web 2')),
+                $privilegePreview,
+                new Icon('angles-down', ['class' => 'collapse-icon']),
+                new Icon('angles-left', ['class' => 'expand-icon']),
             );
 
-            $this->addDisplayGroup($elements, $moduleName . '_elements', [
-                'decorators'    => [
-                    'FormElements',
-                    ['HtmlTag', [
-                        'tag'   => 'details',
-                        'class' => 'collapsible'
-                    ]],
-                    ['Fieldset']
-                ]
-            ]);
+            $this->addHtml(new HtmlElement('details', new Attributes(['class' => 'collapsible']), $summary, $fieldset));
         }
     }
 
-    protected function createDeleteElements(array $formData)
+    protected function assembleInsertElements(): void
     {
+        $this->assembleCommonElements();
+
+        $this->addElement('submit', 'submit_add', ['label' => $this->translate('Create Role')]);
     }
 
-    public function fetchEntry()
+    protected function assembleUpdateElements(): void
+    {
+        $this->assembleCommonElements();
+
+        $this->addElement('submit', 'submit_update', ['label' => $this->translate('Update Role')]);
+    }
+
+    protected function assembleDeleteElements(): void
+    {
+        $this->addElement('submit', 'submit_remove', ['label' => $this->translate('Confirm Removal')]);
+    }
+
+    /**
+     * Apply the requested mode on the repository and update inheriting roles
+     *
+     * After applying the mode, updates the `parent` field on all roles that
+     * reference this role by name, reflecting a rename or removal. Only applies
+     * in {@see RepositoryMode::Update} and {@see RepositoryMode::Delete} mode.
+     *
+     * @return void
+     */
+    protected function onSuccess(): void
+    {
+        parent::onSuccess();
+
+        $newName = $this->getValue('name');
+        $isUpdateOrDeleteMode = in_array($this->mode, [RepositoryMode::Update, RepositoryMode::Delete]);
+        if ($isUpdateOrDeleteMode && $this->getIdentifier() !== $newName) {
+            // Update/remove the parent reference on roles that inherit from the
+            // renamed or removed one.
+            $repo = $this->getUpdatableRepository();
+            $repo->update(
+                $repo->getBaseTable(),
+                ['parent' => $newName],
+                Filter::where('parent', $this->getIdentifier()),
+            );
+        }
+    }
+
+    /**
+     * Fetch and transform the stored role into form-ready values
+     *
+     * In addition to fetching the raw entry, maps stored `permissions` and
+     * `refusals` CSV strings to fieldset checkbox values (`'y'`), migrates
+     * legacy permissions, and copies restriction values into their respective
+     * fieldset entries.
+     *
+     * @return object|false The transformed role as a plain object, or false if
+     *   no matching entry exists
+     */
+    protected function fetchEntry(): object|false
     {
         $role = parent::fetchEntry();
         if ($role === false) {
             return false;
         }
 
+        $hasEveryPermission = $role->permissions && preg_match('~(?>^|,)\*(?>$|,)~', $role->permissions);
         $values = [
             'parent'            => $role->parent,
             'name'              => $role->name,
             'users'             => $role->users,
             'groups'            => $role->groups,
             'unrestricted'      => $role->unrestricted,
-            self::WILDCARD_NAME => $role->permissions && preg_match('~(?>^|,)\*(?>$|,)~', $role->permissions)
+            self::WILDCARD_NAME => $hasEveryPermission ? 'y' : 'n',
         ];
 
         if (! empty($role->permissions) || ! empty($role->refusals)) {
             $permissions = StringHelper::trimSplit($role->permissions);
             $refusals = StringHelper::trimSplit($role->refusals);
 
-            list($permissions, $newRefusals) = AdmissionLoader::migrateLegacyPermissions($permissions);
+            [$permissions, $newRefusals] = AdmissionLoader::migrateLegacyPermissions($permissions);
             if (! empty($newRefusals)) {
                 array_push($refusals, ...$newRefusals);
             }
 
             foreach ($this->providedPermissions as $moduleName => $permissionList) {
+                $fieldsetName = $moduleName . static::FIELDSET_SUFFIX;
                 $hasFullPerm = false;
                 foreach ($permissionList as $name => $spec) {
                     if (in_array($name, $permissions, true)) {
-                        $values[$this->filterName($name)] = 1;
+                        $values[$fieldsetName][$this->convertToElementName($name)] = 'y';
 
                         if (isset($spec['isFullPerm'])) {
                             $hasFullPerm = true;
@@ -352,20 +409,21 @@ class RoleForm extends RepositoryForm
                     }
 
                     if (in_array($name, $refusals, true)) {
-                        $values[$this->filterName(self::DENY_PREFIX . $name)] = 1;
+                        $values[$fieldsetName][$this->convertToElementName(self::DENY_PREFIX . $name)] = 'y';
                     }
                 }
 
                 if ($hasFullPerm) {
-                    unset($values[$this->filterName(Manager::MODULE_PERMISSION_NS . $moduleName)]);
+                    $modulePermission = Manager::MODULE_PERMISSION_NS . $moduleName;
+                    unset($values[$fieldsetName][$this->convertToElementName($modulePermission)]);
                 }
             }
         }
 
         foreach ($this->providedRestrictions as $moduleName => $restrictionList) {
-            foreach ($restrictionList as $name => $spec) {
+            foreach (array_keys($restrictionList) as $name) {
                 if (isset($role->$name)) {
-                    $values[$this->filterName($name)] = $role->$name;
+                    $values[$moduleName . static::FIELDSET_SUFFIX][$this->convertToElementName($name)] = $role->$name;
                 }
             }
         }
@@ -373,31 +431,46 @@ class RoleForm extends RepositoryForm
         return (object) $values;
     }
 
-    public function getValues($suppressArrayNotation = false)
+    /**
+     * Get the submitted role values in repository format
+     *
+     * Transforms the raw fieldset values returned by the parent into a flat
+     * structure suitable for persisting via the repository: collapses permission
+     * checkboxes into a comma-separated `permissions` string, deny checkboxes into
+     * `refusals`, lifts restriction values to top-level keys, and auto-includes
+     * the general module access permission (`module/<name>`) whenever the full
+     * module permission (`<name>/*`) is set. Both `permissions` and `refusals`
+     * are `null` when empty.
+     *
+     * @return array<string, string|null>
+     */
+    public function getValues(): array
     {
-        $values = parent::getValues($suppressArrayNotation);
+        $values = parent::getValues();
 
         foreach ($this->providedRestrictions as $moduleName => $restrictionList) {
-            foreach ($restrictionList as $name => $spec) {
-                $elementName = $this->filterName($name);
-                if (isset($values[$elementName])) {
-                    $values[$name] = $values[$elementName];
-                    unset($values[$elementName]);
+            $fieldsetKey = $moduleName . static::FIELDSET_SUFFIX;
+            foreach (array_keys($restrictionList) as $name) {
+                $elementName = $this->convertToElementName($name);
+                if (array_key_exists($elementName, $values[$fieldsetKey])) {
+                    $values[$name] = $values[$fieldsetKey][$elementName];
+                    unset($values[$fieldsetKey][$elementName]);
                 }
             }
         }
 
         $permissions = [];
-        if (isset($values[self::WILDCARD_NAME]) && $values[self::WILDCARD_NAME]) {
+        if (isset($values[self::WILDCARD_NAME]) && $values[self::WILDCARD_NAME] === 'y') {
             $permissions[] = '*';
         }
 
         $refusals = [];
         foreach ($this->providedPermissions as $moduleName => $permissionList) {
+            $fieldsetKey = $moduleName . static::FIELDSET_SUFFIX;
             $hasFullPerm = false;
             foreach ($permissionList as $name => $spec) {
-                $elementName = $this->filterName($name);
-                if (isset($values[$elementName]) && $values[$elementName]) {
+                $elementName = $this->convertToElementName($name);
+                if (isset($values[$fieldsetKey][$elementName]) && $values[$fieldsetKey][$elementName] === 'y') {
                     $permissions[] = $name;
 
                     if (isset($spec['isFullPerm'])) {
@@ -405,44 +478,58 @@ class RoleForm extends RepositoryForm
                     }
                 }
 
-                $denyName = $this->filterName(self::DENY_PREFIX . $name);
-                if (isset($values[$denyName]) && $values[$denyName]) {
+                $denyName = $this->convertToElementName(self::DENY_PREFIX . $name);
+                if (isset($values[$fieldsetKey][$denyName]) && $values[$fieldsetKey][$denyName] === 'y') {
                     $refusals[] = $name;
                 }
 
-                unset($values[$elementName], $values[$denyName]);
+                unset($values[$fieldsetKey][$elementName], $values[$fieldsetKey][$denyName]);
             }
 
             $modulePermission = Manager::MODULE_PERMISSION_NS . $moduleName;
             if ($hasFullPerm && ! in_array($modulePermission, $permissions, true)) {
                 $permissions[] = $modulePermission;
             }
+
+            unset($values[$fieldsetKey]);
         }
 
         unset($values[self::WILDCARD_NAME]);
-        $values['refusals'] = join(',', $refusals);
-        $values['permissions'] = join(',', $permissions);
-        return ConfigForm::transformEmptyValuesToNull($values);
+        $values['refusals']    = $refusals ? implode(',', $refusals) : null;
+        $values['permissions'] = $permissions ? implode(',', $permissions) : null;
+
+        return $values;
     }
 
-    protected function getInsertMessage($success)
+    /**
+     * Convert a name to a form element name
+     *
+     * Removes every character that is not valid in an element name, keeping only
+     * letters, digits, underscores and high bytes.
+     *
+     * @param string $value Permission or restriction name to convert
+     *
+     * @return string
+     */
+    protected function convertToElementName(string $value): string
     {
-        return $success ? $this->translate('Role created') : $this->translate('Role creation failed');
+        return preg_replace('/[^a-zA-Z0-9_\x7f-\xff]/', '', $value);
     }
 
-    protected function getUpdateMessage($success)
+    /**
+     * Sort the given permissions by name in place
+     *
+     * Full module access sorts first, general module access second, and the
+     * remaining permissions follow, natural-sorted by their first differing
+     * path segment.
+     *
+     * @param array<string, array<string, mixed>> $permissions Permission specs keyed by name, sorted in place
+     *
+     * @return void
+     */
+    protected function sortPermissions(array &$permissions): void
     {
-        return $success ? $this->translate('Role updated') : $this->translate('Role update failed');
-    }
-
-    protected function getDeleteMessage($success)
-    {
-        return $success ? $this->translate('Role removed') : $this->translate('Role removal failed');
-    }
-
-    protected function sortPermissions(&$permissions)
-    {
-        return uksort($permissions, function ($a, $b) use ($permissions) {
+        uksort($permissions, function ($a, $b) use ($permissions): int {
             if (isset($permissions[$a]['isUsagePerm'])) {
                 return isset($permissions[$b]['isFullPerm']) ? 1 : -1;
             } elseif (isset($permissions[$b]['isUsagePerm'])) {
@@ -461,10 +548,18 @@ class RoleForm extends RepositoryForm
         });
     }
 
-    protected function collectRoles()
+    /**
+     * Collect the names of roles that may be set as parent
+     *
+     * Excludes the role currently being handled and all of its descendants, so
+     * that selecting a parent cannot introduce an inheritance loop.
+     *
+     * @return array<string, string> Role names, each mapped to itself
+     */
+    protected function collectRoles(): array
     {
         // Function to get all connected children. Used to avoid reference loops
-        $getChildren = function ($name, $children = []) use (&$getChildren) {
+        $getChildren = function ($name, $children = []) use (&$getChildren): array {
             foreach ($this->repository->select()->where('parent', $name) as $child) {
                 if (isset($children[$child->name])) {
                     // Don't follow already established loops here,
@@ -491,147 +586,119 @@ class RoleForm extends RepositoryForm
         return array_combine($names, $names);
     }
 
-    public function isValid($formData)
-    {
-        $valid = parent::isValid($formData);
-
-        if ($valid && ConfigFormEventsHook::runIsValid($this) === false) {
-            foreach (ConfigFormEventsHook::getLastErrors() as $msg) {
-                $this->error($msg);
-            }
-
-            $valid = false;
-        }
-
-        return $valid;
-    }
-
-    public function onSuccess()
-    {
-        if (parent::onSuccess() === false) {
-            return false;
-        }
-
-        if ($this->getIdentifier() && ($newName = $this->getValue('name')) !== $this->getIdentifier()) {
-            $this->repository->update(
-                $this->getBaseTable(),
-                ['parent' => $newName],
-                Filter::where('parent', $this->getIdentifier())
-            );
-        }
-
-        if (ConfigFormEventsHook::runOnSuccess($this) === false) {
-            Notification::error($this->translate(
-                'Configuration successfully stored. Though, one or more module hooks failed to run.'
-                . ' See logs for details'
-            ));
-        }
-    }
-
     /**
-     * Collect permissions and restrictions provided by Icinga Web 2 and modules
+     * Collect permissions and restrictions provided by Icinga Web and modules
      *
-     * @return array[$permissions, $restrictions]
+     * Returns a two-element list: index 0 holds the permissions, index 1 the
+     * restrictions. Both are nested the same way:
+     *
+     * module name => privilege name => spec
+     *
+     * @return array{
+     *     0: array<string, array<string, array{
+     *         isFullPerm?: true,
+     *         isUsagePerm?: true,
+     *         label?: string,
+     *         description?: string
+     *     }>>,
+     *     1: array<string, array<string, array{
+     *         label?: string,
+     *         description?: string
+     *     }>>
+     * }
      */
-    public static function collectProvidedPrivileges()
+    public static function collectProvidedPrivileges(): array
     {
         $providedPermissions['application'] = [
-            'application/announcements' => [
-                'description' => t('Allow to manage announcements')
-            ],
-            'application/log' => [
-                'description' => t('Allow to view the application log')
-            ],
-            'config/*' => [
-                'description' => t('Allow full config access')
-            ],
-            'config/general' => [
-                'description' => t('Allow to adjust the general configuration')
-            ],
-            'config/security' => [
-                'description' => t('Allow to adjust the security configuration')
-            ],
-            'config/modules' => [
-                'description' => t('Allow to enable/disable and configure modules')
-            ],
-            'config/resources' => [
-                'description' => t('Allow to manage resources')
-            ],
-            'config/navigation' => [
-                'description' => t('Allow to view and adjust shared navigation items')
-            ],
-            'config/access-control/*' => [
-                'description' => t('Allow to fully manage access-control')
-            ],
-            'config/access-control/users' => [
-                'description' => t('Allow to manage user accounts')
-            ],
-            'config/access-control/groups' => [
-                'description' => t('Allow to manage user groups')
-            ],
-            'config/access-control/roles' => [
-                'description' => t('Allow to manage roles')
-            ],
-            'user/*' => [
-                'description' => t('Allow all account related functionalities')
-            ],
-            'user/password-change' => [
-                'description' => t('Allow password changes in the account preferences')
-            ],
+            'application/announcements'    => ['description' => t('Allow to manage announcements')],
+            'application/log'              => ['description' => t('Allow to view the application log')],
+            'config/*'                     => ['description' => t('Allow full config access')],
+            'config/general'               => ['description' => t('Allow to adjust the general configuration')],
+            'config/security'              => ['description' => t('Allow to adjust the security configuration')],
+            'config/modules'               => ['description' => t('Allow to enable/disable and configure modules')],
+            'config/resources'             => ['description' => t('Allow to manage resources')],
+            'config/navigation'            => ['description' => t('Allow to view and adjust shared navigation items')],
+            'config/access-control/*'      => ['description' => t('Allow to fully manage access-control')],
+            'config/access-control/users'  => ['description' => t('Allow to manage user accounts')],
+            'config/access-control/groups' => ['description' => t('Allow to manage user groups')],
+            'config/access-control/roles'  => ['description' => t('Allow to manage roles')],
+            'user/*'                       => ['description' => t('Allow all account related functionalities')],
+            'user/password-change'         => ['description' => t('Allow password changes in the account preferences')],
             'user/application/stacktraces' => [
-                'description' => t('Allow to adjust in the preferences whether to show stacktraces')
+                'description' => t('Allow to adjust in the preferences whether to show stacktraces'),
             ],
-            'user/share/navigation' => [
-                'description' => t('Allow to share navigation items')
-            ],
-            'application/sessions' => [
-                'description' => t('Allow to manage user sessions')
-            ],
-            'application/migrations' => [
-                'description' => t('Allow to apply pending application migrations')
-            ]
+            'user/share/navigation'        => ['description' => t('Allow to share navigation items')],
+            'application/sessions'         => ['description' => t('Allow to manage user sessions')],
+            'application/migrations'       => ['description' => t('Allow to apply pending application migrations')],
         ];
 
         $providedRestrictions['application'] = [
-            'application/share/users' => [
-                'description'   => t('Restrict which users this role can share items and information with')
+            'application/share/users'  => [
+                'description' => t('Restrict which users this role can share items and information with'),
             ],
             'application/share/groups' => [
-                'description'   => t('Restrict which groups this role can share items and information with')
-            ]
+                'description' => t('Restrict which groups this role can share items and information with'),
+            ],
         ];
 
         $mm = Icinga::app()->getModuleManager();
         foreach ($mm->listInstalledModules() as $moduleName) {
             $modulePermission = Manager::MODULE_PERMISSION_NS . $moduleName;
             $providedPermissions[$moduleName][$modulePermission] = [
-                'isUsagePerm'   => true,
-                'label'         => t('General Module Access'),
-                'description'   => sprintf(t('Allow access to module %s'), $moduleName)
+                'isUsagePerm' => true,
+                'label'       => t('General Module Access'),
+                'description' => sprintf(t('Allow access to module %s'), $moduleName),
             ];
 
             $module = $mm->getModule($moduleName, false);
             $permissions = $module->getProvidedPermissions();
 
             $providedPermissions[$moduleName][$moduleName . '/*'] = [
-                'isFullPerm'    => true,
-                'label'         => t('Full Module Access')
+                'isFullPerm' => true,
+                'label'      => t('Full Module Access'),
             ];
 
             foreach ($permissions as $permission) {
                 /** @var object $permission */
-                $providedPermissions[$moduleName][$permission->name] = [
-                    'description'   => $permission->description
-                ];
+                $providedPermissions[$moduleName][$permission->name] = ['description' => $permission->description];
             }
 
             foreach ($module->getProvidedRestrictions() as $restriction) {
-                $providedRestrictions[$moduleName][$restriction->name] = [
-                    'description'   => $restriction->description
-                ];
+                $providedRestrictions[$moduleName][$restriction->name] = ['description' => $restriction->description];
             }
         }
 
         return [$providedPermissions, $providedRestrictions];
+    }
+
+    /**
+     * Build label content for a permission or restriction name
+     *
+     * The name is split into path segments. The first segment is wrapped in
+     * `<em>`. Each following segment is preceded by a slash and a zero-width
+     * space so browsers can break the line at each slash, and the segment
+     * text is wrapped in `<span class="no-wrap">`.
+     *
+     * @param string $name Permission or restriction name
+     *
+     * @return HtmlDocument
+     */
+    protected function buildPrivilegeLabel(string $name): HtmlDocument
+    {
+        $segments = preg_split('~(/[^/]+)~', $name, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
+        $label = new HtmlDocument();
+        foreach ($segments as $segment) {
+            if ($segment[0] === '/') {
+                // Zero-width space after slash lets browsers break onto newlines
+                $label->addHtml(
+                    new Text('/' . "\u{200B}"),
+                    new HtmlElement('span', Attributes::create(['class' => 'no-wrap']), new Text(substr($segment, 1)))
+                );
+            } else {
+                $label->addHtml(new HtmlElement('em', null, new Text($segment)));
+            }
+        }
+
+        return $label;
     }
 }

--- a/application/forms/Security/RoleForm.php
+++ b/application/forms/Security/RoleForm.php
@@ -143,8 +143,13 @@ class RoleForm extends RepositoryForm
             'uncheckedValue' => null,
         ]);
 
-        $hasAdminPerm = $this->getPopulatedValue(self::WILDCARD_NAME) === 'y';
-        $isUnrestricted = $this->getPopulatedValue('unrestricted') === '1';
+        /** @var CheckboxElement $wildcardCheckbox */
+        $wildcardCheckbox = $this->getElement(self::WILDCARD_NAME);
+        $hasAdminPerm = $wildcardCheckbox->isChecked();
+
+        /** @var CheckboxElement $unrestrictedCheckbox */
+        $unrestrictedCheckbox = $this->getElement('unrestricted');
+        $isUnrestricted = $unrestrictedCheckbox->isChecked();
 
         foreach ($this->providedPermissions as $moduleName => $permissionList) {
             $this->sortPermissions($permissionList);
@@ -183,10 +188,6 @@ class RoleForm extends RepositoryForm
             foreach ($permissionList as $name => $spec) {
                 $elementName = $this->convertToElementName($name);
 
-                if ($fieldset->getPopulatedValue($elementName) === 'y') {
-                    $anythingGranted = true;
-                }
-
                 if ($hasFullPerm || $hasAdminPerm) {
                     $elementName .= '_fake';
                 }
@@ -200,7 +201,7 @@ class RoleForm extends RepositoryForm
                     );
                     $fieldset->registerElement($denyCheckbox);
 
-                    if ($fieldset->getPopulatedValue($denyCheckbox->getName()) === 'y') {
+                    if ($denyCheckbox->isChecked()) {
                         $anythingRefused = true;
                     }
                 }
@@ -213,6 +214,12 @@ class RoleForm extends RepositoryForm
                     'label'       => $spec['label'] ?? $this->buildPrivilegeLabel($name),
                     'checked'     => $hasFullPerm || $hasAdminPerm,
                 ]);
+
+                /** @var CheckboxElement $grantCheckbox */
+                $grantCheckbox = $fieldset->getElement($elementName);
+                if ($grantCheckbox->isChecked()) {
+                    $anythingGranted = true;
+                }
 
                 if ($denyCheckbox !== null) {
                     /** @var CheckboxElement $checkboxElement */
@@ -260,7 +267,7 @@ class RoleForm extends RepositoryForm
                 }
 
                 if (isset($spec['isFullPerm'])) {
-                    $hasFullPerm = $fieldset->getPopulatedValue($this->convertToElementName($name)) === 'y';
+                    $hasFullPerm = $grantCheckbox->isChecked();
                 }
             }
 

--- a/application/forms/Security/RoleForm.php
+++ b/application/forms/Security/RoleForm.php
@@ -347,6 +347,18 @@ class RoleForm extends RepositoryForm
     }
 
     /**
+     * Get the name of the role to handle
+     *
+     * @return ?string Narrower than the inherited contract, as this form
+     *   accepts string identifiers only. Null only in
+     *   {@see RepositoryMode::Insert} mode, where none is required
+     */
+    public function getIdentifier(): ?string
+    {
+        return $this->identifier;
+    }
+
+    /**
      * Apply the requested mode on the repository and update inheriting roles
      *
      * After applying the mode, updates the `parent` field on all roles that

--- a/application/forms/Security/RoleForm.php
+++ b/application/forms/Security/RoleForm.php
@@ -192,6 +192,8 @@ class RoleForm extends RepositoryForm
                 $elementName = $this->convertToElementName($name);
 
                 if ($hasFullPerm || $hasAdminPerm) {
+                    // Add a hidden element to preserve the configured permission value
+                    $fieldset->addElement('hidden', $elementName);
                     $elementName .= '_fake';
                 }
 
@@ -266,11 +268,6 @@ class RoleForm extends RepositoryForm
                 }
 
                 $grantCheckbox->applyDecoration();
-
-                if ($hasFullPerm || $hasAdminPerm) {
-                    // Add a hidden element to preserve the configured permission value
-                    $fieldset->addElement('hidden', $this->convertToElementName($name));
-                }
 
                 if (isset($spec['isFullPerm'])) {
                     $hasFullPerm = $grantCheckbox->isChecked();

--- a/application/forms/Security/RoleForm.php
+++ b/application/forms/Security/RoleForm.php
@@ -456,14 +456,18 @@ class RoleForm extends RepositoryForm
      * checkboxes into a comma-separated `permissions` string, deny checkboxes into
      * `refusals`, lifts restriction values to top-level keys, and auto-includes
      * the general module access permission (`module/<name>`) whenever the full
-     * module permission (`<name>/*`) is set. Both `permissions` and `refusals`
-     * are `null` when empty.
+     * module permission (`<name>/*`) is set.
      *
-     * @return array<string, string|null>
+     * @return array<string, ?string> Both `permissions` and `refusals` are
+     *   `null` when empty. In {@see RepositoryMode::Delete} mode the parent's
+     *   values are returned unchanged, since no role elements are assembled
      */
     public function getValues(): array
     {
         $values = parent::getValues();
+        if ($this->mode === RepositoryMode::Delete) {
+            return $values;
+        }
 
         foreach ($this->providedRestrictions as $moduleName => $restrictionList) {
             $fieldsetKey = $moduleName . static::FIELDSET_SUFFIX;

--- a/application/forms/Security/RoleForm.php
+++ b/application/forms/Security/RoleForm.php
@@ -23,6 +23,7 @@ use ipl\Html\Contract\FormElementDecoration;
 use ipl\Html\FormattedString;
 use ipl\Html\FormElement\CheckboxElement;
 use ipl\Html\FormElement\FieldsetElement;
+use ipl\Html\FormElement\TextElement;
 use ipl\Html\HtmlDocument;
 use ipl\Html\HtmlElement;
 use ipl\Html\Text;
@@ -166,7 +167,9 @@ class RoleForm extends RepositoryForm
 
             $this->registerElement($fieldset);
 
-            $fieldset->addHtml(new HtmlElement(
+            $details = new HtmlElement('details', new Attributes(['class' => 'collapsible']));
+
+            $details->addHtml(new HtmlElement(
                 'div',
                 null,
                 new HtmlElement('h4', null, new Text($this->translate('Permissions'))),
@@ -206,7 +209,8 @@ class RoleForm extends RepositoryForm
                     }
                 }
 
-                $fieldset->addElement('checkbox', $elementName, [
+                /** @var CheckboxElement $grantCheckbox */
+                $grantCheckbox = $fieldset->createElement('checkbox', $elementName, [
                     'class'       => isset($spec['isFullPerm']) ? 'autosubmit' : null,
                     'description' => $spec['description'] ?? $name,
                     'disabled'    => $hasFullPerm || $hasAdminPerm,
@@ -214,9 +218,9 @@ class RoleForm extends RepositoryForm
                     'label'       => $spec['label'] ?? $this->buildPrivilegeLabel($name),
                     'checked'     => $hasFullPerm || $hasAdminPerm,
                 ]);
+                $fieldset->registerElement($grantCheckbox);
+                $details->addHtml($grantCheckbox);
 
-                /** @var CheckboxElement $grantCheckbox */
-                $grantCheckbox = $fieldset->getElement($elementName);
                 if ($grantCheckbox->isChecked()) {
                     $anythingGranted = true;
                 }
@@ -261,6 +265,8 @@ class RoleForm extends RepositoryForm
                         });
                 }
 
+                $grantCheckbox->applyDecoration();
+
                 if ($hasFullPerm || $hasAdminPerm) {
                     // Add a hidden element to preserve the configured permission value
                     $fieldset->addElement('hidden', $this->convertToElementName($name));
@@ -272,21 +278,23 @@ class RoleForm extends RepositoryForm
             }
 
             if (isset($this->providedRestrictions[$moduleName])) {
-                $fieldset->addHtml(new HtmlElement('h4', null, new Text($this->translate('Restrictions'))));
+                $details->addHtml(new HtmlElement('h4', null, new Text($this->translate('Restrictions'))));
 
                 foreach ($this->providedRestrictions[$moduleName] as $name => $spec) {
-                    $elementName = $this->convertToElementName($name);
-
-                    if (! Str::isEmpty($fieldset->getPopulatedValue($elementName))) {
-                        $anythingRestricted = true;
-                    }
-
-                    $fieldset->addElement('text', $elementName, [
+                    /** @var TextElement $restrictionElement */
+                    $restrictionElement = $fieldset->createElement('text', $this->convertToElementName($name), [
                         'class'       => $isUnrestricted ? 'unrestricted-role' : '',
                         'description' => $spec['description'],
                         'label'       => $spec['label'] ?? $this->buildPrivilegeLabel($name),
                         'readonly'    => $isUnrestricted ?: null,
                     ]);
+                    $fieldset->registerElement($restrictionElement);
+                    $restrictionElement->applyDecoration();
+                    $details->addHtml($restrictionElement);
+
+                    if (! Str::isEmpty($restrictionElement->getValue())) {
+                        $anythingRestricted = true;
+                    }
                 }
             }
 
@@ -316,7 +324,9 @@ class RoleForm extends RepositoryForm
                 new Icon('angles-left', ['class' => 'expand-icon']),
             );
 
-            $this->addHtml(new HtmlElement('details', new Attributes(['class' => 'collapsible']), $summary, $fieldset));
+            $details->prependHtml($summary);
+            $fieldset->addHtml($details);
+            $this->addHtml($fieldset);
         }
     }
 

--- a/test/php/application/forms/Security/RoleFormTest.php
+++ b/test/php/application/forms/Security/RoleFormTest.php
@@ -14,6 +14,7 @@ use Icinga\Forms\Security\RoleForm;
 use Icinga\Repository\Repository;
 use Icinga\Repository\RepositoryMode;
 use Icinga\Test\BaseTestCase;
+use Icinga\Util\StringHelper;
 
 /**
  * Tests for {@see RoleForm}
@@ -404,5 +405,66 @@ class RoleFormTest extends BaseTestCase
         $this->assertSame('y', $entry->application_elements['applicationannouncements']);
         $this->assertSame('y', $entry->mymodule_elements['mymoduleread']);
         $this->assertArrayNotHasKey('applicationlog', $entry->application_elements);
+    }
+
+    public function testRoundTripKeepsAPlainRoleUnchanged(): void
+    {
+        $roles = [
+            (object) [
+                'name'                    => 'test',
+                'parent'                  => 'admins',
+                'users'                   => 'icingaadmin',
+                'groups'                  => 'support',
+                'permissions'             => 'application/announcements,mymodule/read',
+                'refusals'                => 'application/log',
+                'unrestricted'            => null,
+                'application/share/users' => 'icingaadmin',
+            ],
+            (object) ['name' => 'admins', 'parent' => null],
+        ];
+        $entry = $this->createForm(RepositoryMode::Update, [], 'test', $roles)->exposeFetchEntry();
+        // Populating with the fetched entry is what a request in update mode does
+        $values = $this->createForm(RepositoryMode::Update, (array) $entry, 'test', $roles)->getValues();
+
+        $this->assertSame('test', $values['name']);
+        $this->assertSame('admins', $values['parent']);
+        $this->assertSame('icingaadmin', $values['users']);
+        $this->assertSame('support', $values['groups']);
+        $this->assertNull($values['unrestricted']);
+        $this->assertSame('icingaadmin', $values['application/share/users']);
+        $this->assertSame('application/announcements,mymodule/read', $values['permissions']);
+        $this->assertSame('application/log', $values['refusals']);
+    }
+
+    public function testRoundTripKeepsAnAdministrativeRoleUnchanged(): void
+    {
+        $role = (object) ['name' => 'test', 'parent' => null, 'permissions' => '*,application/announcements'];
+        $entry = $this->createForm(RepositoryMode::Update, [], 'test', [$role])->exposeFetchEntry();
+        $values = $this->createForm(RepositoryMode::Update, (array) $entry, 'test', [$role])->getValues();
+
+        $this->assertSame('*,application/announcements', $values['permissions']);
+    }
+
+    public function testRoundTripKeepsFullModuleAccessUnchanged(): void
+    {
+        $role = (object) ['name' => 'test', 'parent' => null, 'permissions' => 'module/mymodule,mymodule/*'];
+        $entry = $this->createForm(RepositoryMode::Update, [], 'test', [$role])->exposeFetchEntry();
+        $values = $this->createForm(RepositoryMode::Update, (array) $entry, 'test', [$role])->getValues();
+
+        // The general module access is appended after the module's permissions, hence the different order
+        $this->assertEqualsCanonicalizing(
+            StringHelper::trimSplit($role->permissions),
+            StringHelper::trimSplit($values['permissions']),
+        );
+    }
+
+    public function testRoundTripUpgradesLegacyPermissions(): void
+    {
+        $role = (object) ['name' => 'test', 'parent' => null, 'permissions' => 'admin,no-user/password-change'];
+        $entry = $this->createForm(RepositoryMode::Update, [], 'test', [$role])->exposeFetchEntry();
+        $values = $this->createForm(RepositoryMode::Update, (array) $entry, 'test', [$role])->getValues();
+
+        $this->assertSame('application/announcements', $values['permissions']);
+        $this->assertSame('user/password-change', $values['refusals']);
     }
 }

--- a/test/php/application/forms/Security/RoleFormTest.php
+++ b/test/php/application/forms/Security/RoleFormTest.php
@@ -106,4 +106,144 @@ class RoleFormTest extends BaseTestCase
             }
         };
     }
+
+    public function testGetValuesTurnsCheckedPermissionsIntoAPermissionList(): void
+    {
+        $form = $this->createForm(RepositoryMode::Insert, [
+            'application_elements' => ['applicationannouncements' => 'y'],
+            'mymodule_elements'    => ['mymoduleread' => 'y'],
+        ]);
+
+        $this->assertSame('application/announcements,mymodule/read', $form->getValues()['permissions']);
+    }
+
+    public function testGetValuesIgnoresUncheckedPermissions(): void
+    {
+        $form = $this->createForm(RepositoryMode::Insert, [
+            'application_elements' => ['applicationannouncements' => 'y', 'applicationlog' => 'n'],
+        ]);
+
+        $this->assertSame('application/announcements', $form->getValues()['permissions']);
+    }
+
+    public function testGetValuesTurnsCheckedDenyTogglesIntoARefusalList(): void
+    {
+        $form = $this->createForm(RepositoryMode::Insert, [
+            'application_elements' => ['noapplicationlog' => 'y'],
+            'mymodule_elements'    => ['nomymoduleread' => 'y'],
+        ]);
+
+        $this->assertSame('application/log,mymodule/read', $form->getValues()['refusals']);
+    }
+
+    public function testGetValuesAddsTheWildcardPermissionForAdministrativeAccess(): void
+    {
+        $form = $this->createForm(RepositoryMode::Insert, [RoleForm::WILDCARD_NAME => 'y']);
+
+        $this->assertSame('*', $form->getValues()['permissions']);
+    }
+
+    public function testGetValuesPreservesPermissionsHiddenByAdministrativeAccess(): void
+    {
+        $form = $this->createForm(RepositoryMode::Insert, [
+            RoleForm::WILDCARD_NAME => 'y',
+            'application_elements'  => ['applicationannouncements' => 'y'],
+        ]);
+
+        $this->assertSame('*,application/announcements', $form->getValues()['permissions']);
+    }
+
+    public function testGetValuesImpliesGeneralModuleAccessForFullModuleAccess(): void
+    {
+        $form = $this->createForm(RepositoryMode::Insert, ['mymodule_elements' => ['mymodule' => 'y']]);
+
+        $this->assertSame('mymodule/*,module/mymodule', $form->getValues()['permissions']);
+    }
+
+    public function testGetValuesDoesNotAddGeneralModuleAccessTwice(): void
+    {
+        $form = $this->createForm(RepositoryMode::Insert, [
+            'mymodule_elements' => ['modulemymodule' => 'y', 'mymodule' => 'y'],
+        ]);
+
+        $this->assertSame('module/mymodule,mymodule/*', $form->getValues()['permissions']);
+    }
+
+    public function testGetValuesLiftsRestrictionsToTheTopLevel(): void
+    {
+        $form = $this->createForm(RepositoryMode::Insert, [
+            'application_elements' => ['applicationshareusers' => 'icingaadmin'],
+            'mymodule_elements'    => ['mymodulefilter' => 'host=foo'],
+        ]);
+        $values = $form->getValues();
+
+        $this->assertSame('icingaadmin', $values['application/share/users']);
+        $this->assertSame('host=foo', $values['mymodule/filter']);
+    }
+
+    public function testGetValuesDropsTheFieldsetsAndTheWildcardElement(): void
+    {
+        $form = $this->createForm(RepositoryMode::Insert, [
+            RoleForm::WILDCARD_NAME => 'y',
+            'application_elements'  => ['applicationannouncements' => 'y'],
+        ]);
+        $values = $form->getValues();
+
+        $this->assertArrayNotHasKey(RoleForm::WILDCARD_NAME, $values);
+        $this->assertArrayNotHasKey('application_elements', $values);
+        $this->assertArrayNotHasKey('mymodule_elements', $values);
+    }
+
+    public function testGetValuesKeepsTheRolesBasicProperties(): void
+    {
+        $form = $this->createForm(RepositoryMode::Insert, [
+            'name'         => 'test',
+            'parent'       => 'admins',
+            'users'        => 'icingaadmin',
+            'groups'       => 'support',
+            'unrestricted' => '1',
+        ]);
+        $values = $form->getValues();
+
+        $this->assertSame('test', $values['name']);
+        $this->assertSame('admins', $values['parent']);
+        $this->assertSame('icingaadmin', $values['users']);
+        $this->assertSame('support', $values['groups']);
+        $this->assertSame('1', $values['unrestricted']);
+    }
+
+    public function testGetValuesYieldsNullForEmptyPermissionsAndRefusals(): void
+    {
+        $form = $this->createForm(RepositoryMode::Insert);
+        $values = $form->getValues();
+
+        $this->assertNull($values['permissions']);
+        $this->assertNull($values['refusals']);
+    }
+
+    public function testGetValuesYieldsNullForEmptyProperties(): void
+    {
+        $form = $this->createForm(RepositoryMode::Insert, [
+            'name'                 => 'test',
+            'parent'               => '',
+            'users'                => '',
+            'groups'               => '',
+            'application_elements' => ['applicationshareusers' => ''],
+        ]);
+        $values = $form->getValues();
+
+        $this->assertNull($values['parent']);
+        $this->assertNull($values['users']);
+        $this->assertNull($values['groups']);
+        $this->assertNull($values['application/share/users']);
+    }
+
+    public function testGetValuesSkipsThePrivilegeTransformationInDeleteMode(): void
+    {
+        $form = $this->createForm(RepositoryMode::Delete, [], 'test');
+        $values = $form->getValues();
+
+        $this->assertArrayNotHasKey('permissions', $values);
+        $this->assertArrayNotHasKey('refusals', $values);
+    }
 }

--- a/test/php/application/forms/Security/RoleFormTest.php
+++ b/test/php/application/forms/Security/RoleFormTest.php
@@ -51,9 +51,10 @@ class RoleFormTest extends BaseTestCase
                             'user/password-change'      => ['description' => 'Allow password changes in preferences'],
                         ],
                         'mymodule'    => [
-                            'module/mymodule' => ['isUsagePerm' => true, 'label' => 'General Module Access'],
-                            'mymodule/*'      => ['isFullPerm' => true, 'label' => 'Full Module Access'],
-                            'mymodule/read'   => ['description' => 'Allow to read'],
+                            'module/mymodule'   => ['isUsagePerm' => true, 'label' => 'General Module Access'],
+                            'mymodule/*'        => ['isFullPerm' => true, 'label' => 'Full Module Access'],
+                            'mymodule/read'     => ['description' => 'Allow to read'],
+                            'no-mymodule/write' => ['description' => 'Refuse writing'],
                         ],
                     ],
                     [
@@ -466,5 +467,192 @@ class RoleFormTest extends BaseTestCase
 
         $this->assertSame('application/announcements', $values['permissions']);
         $this->assertSame('user/password-change', $values['refusals']);
+    }
+
+    public function testAssembleCreatesAFieldsetPerModule(): void
+    {
+        $form = $this->createForm(RepositoryMode::Insert);
+
+        $this->assertTrue($form->hasElement('application_elements'));
+        $this->assertTrue($form->hasElement('mymodule_elements'));
+    }
+
+    public function testAssembleAddsACheckboxForEveryPermission(): void
+    {
+        $form = $this->createForm(RepositoryMode::Insert);
+        $application = $form->getElement('application_elements');
+        $mymodule = $form->getElement('mymodule_elements');
+
+        $this->assertTrue($application->hasElement('applicationannouncements'));
+        $this->assertTrue($application->hasElement('applicationlog'));
+        $this->assertTrue($application->hasElement('userpasswordchange'));
+        $this->assertTrue($mymodule->hasElement('modulemymodule'));
+        $this->assertTrue($mymodule->hasElement('mymodule'));
+        $this->assertTrue($mymodule->hasElement('mymoduleread'));
+        $this->assertTrue($mymodule->hasElement('nomymodulewrite'));
+    }
+
+    public function testAssembleAddsATextElementForEveryRestriction(): void
+    {
+        $form = $this->createForm(RepositoryMode::Insert);
+
+        $this->assertTrue($form->getElement('application_elements')->hasElement('applicationshareusers'));
+        $this->assertTrue($form->getElement('mymodule_elements')->hasElement('mymodulefilter'));
+    }
+
+    public function testAssembleAddsADenyToggleForEveryPlainPermission(): void
+    {
+        $form = $this->createForm(RepositoryMode::Insert);
+        $application = $form->getElement('application_elements');
+        $mymodule = $form->getElement('mymodule_elements');
+
+        $this->assertTrue($application->hasElement('noapplicationannouncements'));
+        $this->assertTrue($application->hasElement('noapplicationlog'));
+        $this->assertTrue($application->hasElement('nouserpasswordchange'));
+        $this->assertTrue($mymodule->hasElement('nomodulemymodule'));
+        $this->assertTrue($mymodule->hasElement('nomymoduleread'));
+    }
+
+    public function testAssembleAddsNoDenyToggleForFullModuleAccess(): void
+    {
+        $form = $this->createForm(RepositoryMode::Insert);
+
+        $this->assertFalse($form->getElement('mymodule_elements')->hasElement('nomymodule'));
+    }
+
+    public function testAssembleAddsNoDenyToggleForPermissionsThatAlreadyDeny(): void
+    {
+        $form = $this->createForm(RepositoryMode::Insert);
+
+        $this->assertFalse($form->getElement('mymodule_elements')->hasElement('nonomymodulewrite'));
+    }
+
+    public function testAssembleDisablesPermissionsForAdministrativeAccess(): void
+    {
+        $form = $this->createForm(RepositoryMode::Insert, [RoleForm::WILDCARD_NAME => 'y']);
+        $permissions = [
+            'application_elements' => 'applicationannouncements',
+            'mymodule_elements'    => 'mymodule',
+        ];
+
+        foreach ($permissions as $fieldset => $name) {
+            $fakeName = $name . '_fake';
+
+            $this->assertTrue($form->getElement($fieldset)->hasElement($fakeName));
+
+            $checkbox = $form->getElement($fieldset)->getElement($fakeName);
+
+            $this->assertTrue($checkbox->isChecked());
+            $this->assertTrue($checkbox->isIgnored());
+            $this->assertTrue($checkbox->getAttribute('disabled')->getValue());
+        }
+    }
+
+    public function testAssemblePreservesPermissionsHiddenByAdministrativeAccess(): void
+    {
+        $form = $this->createForm(RepositoryMode::Insert, [
+            RoleForm::WILDCARD_NAME => 'y',
+            'application_elements'  => ['applicationannouncements' => 'y'],
+        ]);
+        $hidden = $form->getElement('application_elements')->getElement('applicationannouncements');
+
+        $this->assertFalse($hidden->isIgnored());
+        $this->assertSame('y', $hidden->getValue());
+    }
+
+    public function testAssembleDisablesOnlyThePermissionsSortedAfterFullModuleAccess(): void
+    {
+        $form = $this->createForm(RepositoryMode::Insert, ['mymodule_elements' => ['mymodule' => 'y']]);
+        $mymodule = $form->getElement('mymodule_elements');
+
+        $this->assertFalse($mymodule->hasElement('mymodule_fake'));
+        $this->assertFalse($mymodule->getElement('mymodule')->getAttribute('disabled')->getValue());
+
+        foreach (['modulemymodule', 'mymoduleread', 'nomymodulewrite'] as $name) {
+            $fakeName = $name . '_fake';
+
+            $this->assertTrue($mymodule->hasElement($fakeName));
+
+            $checkbox = $mymodule->getElement($fakeName);
+
+            $this->assertTrue($checkbox->isIgnored());
+            $this->assertTrue($checkbox->getAttribute('disabled')->getValue());
+        }
+    }
+
+    public function testAssembleMarksRestrictionsReadonlyForUnrestrictedAccess(): void
+    {
+        $form = $this->createForm(RepositoryMode::Insert, ['unrestricted' => '1']);
+        $restriction = $form->getElement('application_elements')->getElement('applicationshareusers');
+
+        $this->assertTrue($restriction->getAttribute('readonly')->getValue());
+        $this->assertSame('unrestricted-role', $restriction->getAttribute('class')->getValue());
+    }
+
+    public function testAssembleKeepsRestrictionsEditableWithoutUnrestrictedAccess(): void
+    {
+        $form = $this->createForm(RepositoryMode::Insert);
+        $restriction = $form->getElement('application_elements')->getElement('applicationshareusers');
+
+        $this->assertNull($restriction->getAttribute('readonly')->getValue());
+        $this->assertSame('', $restriction->getAttribute('class')->getValue());
+    }
+
+    public function testAssembleShowsTheGrantedIconForACheckedPermission(): void
+    {
+        $form = $this->createForm(RepositoryMode::Insert, [
+            'application_elements' => ['applicationannouncements' => 'y'],
+        ]);
+
+        $this->assertStringContainsString('fa-check-circle', $form->getElement('application_elements')->render());
+        $this->assertStringNotContainsString('fa-check-circle', $form->getElement('mymodule_elements')->render());
+    }
+
+    public function testAssembleShowsTheGrantedIconForAdministrativeAccess(): void
+    {
+        $form = $this->createForm(RepositoryMode::Insert, [RoleForm::WILDCARD_NAME => 'y']);
+
+        $this->assertStringContainsString('fa-check-circle', $form->getElement('application_elements')->render());
+        $this->assertStringContainsString('fa-check-circle', $form->getElement('mymodule_elements')->render());
+    }
+
+    public function testAssembleShowsTheRefusedIconForACheckedDenyToggle(): void
+    {
+        $form = $this->createForm(RepositoryMode::Insert, [
+            'application_elements' => ['noapplicationlog' => 'y'],
+        ]);
+
+        $this->assertStringContainsString('fa-times-circle', $form->getElement('application_elements')->render());
+        $this->assertStringNotContainsString('fa-times-circle', $form->getElement('mymodule_elements')->render());
+    }
+
+    public function testAssembleShowsTheRestrictedIconForAFilledRestriction(): void
+    {
+        $form = $this->createForm(RepositoryMode::Insert, [
+            'application_elements' => ['applicationshareusers' => 'icingaadmin'],
+        ]);
+
+        $this->assertStringContainsString('fa-filter', $form->getElement('application_elements')->render());
+        $this->assertStringNotContainsString('fa-filter', $form->getElement('mymodule_elements')->render());
+    }
+
+    public function testAssembleHidesTheRestrictedIconForUnrestrictedAccess(): void
+    {
+        $form = $this->createForm(RepositoryMode::Insert, [
+            'unrestricted'         => '1',
+            'application_elements' => ['applicationshareusers' => 'icingaadmin'],
+        ]);
+
+        $this->assertStringNotContainsString('fa-filter', $form->getElement('application_elements')->render());
+    }
+
+    public function testAssembleShowsNoPreviewIconsForARoleWithoutPrivileges(): void
+    {
+        $application = $this->createForm(RepositoryMode::Insert)->getElement('application_elements')->render();
+
+        $this->assertStringContainsString('privilege-preview', $application);
+        $this->assertStringNotContainsString('fa-check-circle', $application);
+        $this->assertStringNotContainsString('fa-times-circle', $application);
+        $this->assertStringNotContainsString('fa-filter', $application);
     }
 }

--- a/test/php/application/forms/Security/RoleFormTest.php
+++ b/test/php/application/forms/Security/RoleFormTest.php
@@ -15,6 +15,8 @@ use Icinga\Repository\Repository;
 use Icinga\Repository\RepositoryMode;
 use Icinga\Test\BaseTestCase;
 use Icinga\Util\StringHelper;
+use InvalidArgumentException;
+use ipl\Html\HtmlDocument;
 
 /**
  * Tests for {@see RoleForm}
@@ -72,6 +74,38 @@ class RoleFormTest extends BaseTestCase
             {
                 return $this->fetchEntry();
             }
+
+            public function exposeOnSuccess(): void
+            {
+                $this->onSuccess();
+            }
+
+            public function exposeRepository(): Repository
+            {
+                return $this->repository;
+            }
+
+            public function exposeConvertToElementName(string $value): string
+            {
+                return $this->convertToElementName($value);
+            }
+
+            /**
+             * @param array<string, array<string, mixed>> $permissions
+             *
+             * @return array<string, array<string, mixed>>
+             */
+            public function exposeSortPermissions(array $permissions): array
+            {
+                $this->sortPermissions($permissions);
+
+                return $permissions;
+            }
+
+            public function exposeBuildPrivilegeLabel(string $name): HtmlDocument
+            {
+                return $this->buildPrivilegeLabel($name);
+            }
         };
 
         $form->disableCsrfCounterMeasure();
@@ -106,16 +140,28 @@ class RoleFormTest extends BaseTestCase
                 ],
             ];
 
+            /** @var list<array{target: string, data: array<string, mixed>}> */
+            public array $insertCalls = [];
+
+            /** @var list<array{target: string, data: array<string, mixed>, filter: ?Filter}> */
+            public array $updateCalls = [];
+
+            /** @var list<array{target: string, filter: ?Filter}> */
+            public array $deleteCalls = [];
+
             public function insert($target, array $data): void
             {
+                $this->insertCalls[] = ['target' => $target, 'data' => $data];
             }
 
             public function update($target, array $data, ?Filter $filter = null): void
             {
+                $this->updateCalls[] = ['target' => $target, 'data' => $data, 'filter' => $filter];
             }
 
             public function delete($target, ?Filter $filter = null): void
             {
+                $this->deleteCalls[] = ['target' => $target, 'filter' => $filter];
             }
         };
     }
@@ -654,5 +700,210 @@ class RoleFormTest extends BaseTestCase
         $this->assertStringNotContainsString('fa-check-circle', $application);
         $this->assertStringNotContainsString('fa-times-circle', $application);
         $this->assertStringNotContainsString('fa-filter', $application);
+    }
+
+    public function testDeleteModeRequiresAnUpdatableRepository(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $repository = new class (new ArrayDatasource([])) extends Repository implements Reducible {
+            public function delete($target, ?Filter $filter = null): void
+            {
+            }
+        };
+
+        new RoleForm($repository, RepositoryMode::Delete, 'test');
+    }
+
+    public function testOnSuccessUpdatesTheParentOfInheritingRolesOnRename(): void
+    {
+        $roles = [
+            (object) ['name' => 'test', 'parent' => null],
+            (object) ['name' => 'child', 'parent' => 'test'],
+        ];
+        $form = $this->createForm(RepositoryMode::Update, ['name' => 'renamed'], 'test', $roles);
+        $form->exposeOnSuccess();
+        $updateCalls = $form->exposeRepository()->updateCalls;
+
+        // The first call is the role itself, the second one re-parents what inherits from it
+        $this->assertCount(2, $updateCalls);
+        $this->assertSame(['parent' => 'renamed'], $updateCalls[1]['data']);
+        $this->assertEquals(Filter::where('parent', 'test'), $updateCalls[1]['filter']);
+    }
+
+    public function testOnSuccessKeepsInheritingRolesUntouchedWithoutRename(): void
+    {
+        $roles = [
+            (object) ['name' => 'test', 'parent' => null],
+            (object) ['name' => 'child', 'parent' => 'test'],
+        ];
+        $form = $this->createForm(RepositoryMode::Update, ['name' => 'test'], 'test', $roles);
+        $form->exposeOnSuccess();
+
+        $this->assertCount(1, $form->exposeRepository()->updateCalls);
+    }
+
+    public function testOnSuccessClearsTheParentOfInheritingRolesOnRemoval(): void
+    {
+        $roles = [
+            (object) ['name' => 'test', 'parent' => null],
+            (object) ['name' => 'child', 'parent' => 'test'],
+        ];
+        $form = $this->createForm(RepositoryMode::Delete, [], 'test', $roles);
+        $form->exposeOnSuccess();
+        $repository = $form->exposeRepository();
+
+        $this->assertCount(1, $repository->deleteCalls);
+        $this->assertCount(1, $repository->updateCalls);
+        $this->assertSame(['parent' => null], $repository->updateCalls[0]['data']);
+    }
+
+    public function testOnSuccessKeepsInheritingRolesUntouchedInInsertMode(): void
+    {
+        $form = $this->createForm(RepositoryMode::Insert, ['name' => 'test']);
+        $form->exposeOnSuccess();
+        $repository = $form->exposeRepository();
+
+        $this->assertCount(1, $repository->insertCalls);
+        $this->assertEmpty($repository->updateCalls);
+    }
+
+    public function testCollectRolesOffersEveryOtherRoleAsParent(): void
+    {
+        $roles = [
+            (object) ['name' => 'test', 'parent' => null],
+            (object) ['name' => 'admins', 'parent' => null],
+            (object) ['name' => 'support', 'parent' => null],
+        ];
+        $parent = $this->createForm(RepositoryMode::Update, [], 'test', $roles)->getElement('parent');
+
+        $this->assertNotNull($parent->getOption('admins'));
+        $this->assertNotNull($parent->getOption('support'));
+        $this->assertNull($parent->getOption('test'));
+    }
+
+    public function testCollectRolesExcludesInheritingRoles(): void
+    {
+        $roles = [
+            (object) ['name' => 'test', 'parent' => null],
+            (object) ['name' => 'child', 'parent' => 'test'],
+            (object) ['name' => 'grandchild', 'parent' => 'child'],
+            (object) ['name' => 'other', 'parent' => null],
+        ];
+        $parent = $this->createForm(RepositoryMode::Update, [], 'test', $roles)->getElement('parent');
+
+        $this->assertNull($parent->getOption('child'));
+        $this->assertNull($parent->getOption('grandchild'));
+        $this->assertNotNull($parent->getOption('other'));
+    }
+
+    public function testCollectRolesTerminatesOnCyclicInheritance(): void
+    {
+        $roles = [
+            (object) ['name' => 'test', 'parent' => 'child'],
+            (object) ['name' => 'child', 'parent' => 'test'],
+        ];
+        $parent = $this->createForm(RepositoryMode::Update, [], 'test', $roles)->getElement('parent');
+
+        $this->assertNull($parent->getOption('child'));
+    }
+
+    public function testCollectRolesOffersEveryRoleInInsertMode(): void
+    {
+        $roles = [
+            (object) ['name' => 'test', 'parent' => null],
+            (object) ['name' => 'child', 'parent' => 'test'],
+        ];
+        $parent = $this->createForm(RepositoryMode::Insert, [], null, $roles)->getElement('parent');
+
+        $this->assertNotNull($parent->getOption('test'));
+        $this->assertNotNull($parent->getOption('child'));
+    }
+
+    public function testConvertToElementNameStripsEverythingButWordCharacters(): void
+    {
+        $form = $this->createForm(RepositoryMode::Insert);
+
+        $this->assertSame('configaccesscontrolusers', $form->exposeConvertToElementName('config/access-control/users'));
+        $this->assertSame('mymodule', $form->exposeConvertToElementName('mymodule/*'));
+        $this->assertSame('mymoduleread_write', $form->exposeConvertToElementName('mymodule/read_write'));
+        $this->assertSame('mübung', $form->exposeConvertToElementName('m/übung'));
+    }
+
+    public function testSortPermissionsPutsFullModuleAccessFirstAndGeneralModuleAccessSecond(): void
+    {
+        $form = $this->createForm(RepositoryMode::Insert);
+        $permissions = $form->exposeSortPermissions([
+            'mymodule/read'     => [],
+            'no-mymodule/write' => [],
+            'mymodule/write'    => [],
+            'module/mymodule'   => ['isUsagePerm' => true],
+            'mymodule/*'        => ['isFullPerm' => true],
+        ]);
+
+        $this->assertSame(
+            ['mymodule/*', 'module/mymodule', 'mymodule/read', 'mymodule/write', 'no-mymodule/write'],
+            array_keys($permissions),
+        );
+    }
+
+    public function testSortPermissionsOrdersNamesByTheirFirstDifferingSegment(): void
+    {
+        $form = $this->createForm(RepositoryMode::Insert);
+        $permissions = $form->exposeSortPermissions([
+            'user/password-change'        => [],
+            'config/general'              => [],
+            'application/log'             => [],
+            'config/access-control/users' => [],
+            'config/*'                    => [],
+            'application/announcements'   => [],
+            'config/access-control/*'     => [],
+            'user/*'                      => [],
+        ]);
+
+        $this->assertSame(
+            [
+                'application/announcements',
+                'application/log',
+                'config/*',
+                'config/access-control/*',
+                'config/access-control/users',
+                'config/general',
+                'user/*',
+                'user/password-change',
+            ],
+            array_keys($permissions),
+        );
+    }
+
+    public function testSortPermissionsPutsAShorterNameBeforeItsExtensions(): void
+    {
+        $form = $this->createForm(RepositoryMode::Insert);
+        $permissions = $form->exposeSortPermissions([
+            'config/general' => [],
+            'config'         => [],
+            'config/*'       => [],
+        ]);
+
+        $this->assertSame(['config', 'config/*', 'config/general'], array_keys($permissions));
+    }
+
+    public function testBuildPrivilegeLabelAllowsLineBreaksAfterEverySlash(): void
+    {
+        $form = $this->createForm(RepositoryMode::Insert);
+        $label = $form->exposeBuildPrivilegeLabel('config/access-control/users');
+
+        $this->assertSame(
+            "<em>config</em>/\u{200B}<span class=\"no-wrap\">access-control</span>/\u{200B}"
+            . "<span class=\"no-wrap\">users</span>",
+            $label->render()
+        );
+    }
+
+    public function testBuildPrivilegeLabelEmphasizesASingleSegment(): void
+    {
+        $form = $this->createForm(RepositoryMode::Insert);
+
+        $this->assertSame('<em>admin</em>', $form->exposeBuildPrivilegeLabel('admin')->render());
     }
 }

--- a/test/php/application/forms/Security/RoleFormTest.php
+++ b/test/php/application/forms/Security/RoleFormTest.php
@@ -29,12 +29,17 @@ class RoleFormTest extends BaseTestCase
      * @param RepositoryMode $mode
      * @param array<string, mixed> $values
      * @param ?string $identifier
+     * @param array<int, object> $roles The roles the repository provides
      *
      * @return RoleForm
      */
-    private function createForm(RepositoryMode $mode, array $values = [], ?string $identifier = null): RoleForm
-    {
-        $form = new class ($this->createRepository(), $mode, $identifier) extends RoleForm {
+    private function createForm(
+        RepositoryMode $mode,
+        array $values = [],
+        ?string $identifier = null,
+        array $roles = []
+    ): RoleForm {
+        $form = new class ($this->createRepository($roles), $mode, $identifier) extends RoleForm {
             public static function collectProvidedPrivileges(): array
             {
                 return [
@@ -42,6 +47,7 @@ class RoleFormTest extends BaseTestCase
                         'application' => [
                             'application/announcements' => ['description' => 'Allow to manage announcements'],
                             'application/log'           => ['description' => 'Allow to view the application log'],
+                            'user/password-change'      => ['description' => 'Allow password changes in preferences'],
                         ],
                         'mymodule'    => [
                             'module/mymodule' => ['isUsagePerm' => true, 'label' => 'General Module Access'],
@@ -59,6 +65,11 @@ class RoleFormTest extends BaseTestCase
                     ],
                 ];
             }
+
+            public function exposeFetchEntry(): object|false
+            {
+                return $this->fetchEntry();
+            }
         };
 
         $form->disableCsrfCounterMeasure();
@@ -71,7 +82,7 @@ class RoleFormTest extends BaseTestCase
     /**
      * Create a repository suitable for every mode the role form supports
      *
-     * @param array<int, array<string, mixed>> $roles The roles the repository provides
+     * @param array<int, object> $roles The roles the repository provides
      *
      * @return Repository
      */
@@ -245,5 +256,153 @@ class RoleFormTest extends BaseTestCase
 
         $this->assertArrayNotHasKey('permissions', $values);
         $this->assertArrayNotHasKey('refusals', $values);
+    }
+
+    public function testFetchEntryReturnsFalseIfTheRoleDoesNotExist(): void
+    {
+        $form = $this->createForm(RepositoryMode::Update, [], 'missing');
+
+        $this->assertFalse($form->exposeFetchEntry());
+    }
+
+    public function testFetchEntryMapsTheRolesBasicProperties(): void
+    {
+        $role = (object) [
+            'name'         => 'test',
+            'parent'       => 'admins',
+            'users'        => 'icingaadmin',
+            'groups'       => 'support',
+            'unrestricted' => '1',
+        ];
+        $form = $this->createForm(RepositoryMode::Update, [], 'test', [$role]);
+        $entry = $form->exposeFetchEntry();
+
+        $this->assertSame('test', $entry->name);
+        $this->assertSame('admins', $entry->parent);
+        $this->assertSame('icingaadmin', $entry->users);
+        $this->assertSame('support', $entry->groups);
+        $this->assertSame('1', $entry->unrestricted);
+    }
+
+    public function testFetchEntryChecksTheElementsOfGrantedPermissions(): void
+    {
+        $role = (object) [
+            'name'        => 'test',
+            'parent'      => null,
+            'permissions' => 'application/announcements,mymodule/read',
+        ];
+        $form = $this->createForm(RepositoryMode::Update, [], 'test', [$role]);
+        $entry = $form->exposeFetchEntry();
+
+        $this->assertSame('y', $entry->application_elements['applicationannouncements']);
+        $this->assertSame('y', $entry->mymodule_elements['mymoduleread']);
+        $this->assertArrayNotHasKey('applicationlog', $entry->application_elements);
+    }
+
+    public function testFetchEntryChecksTheDenyTogglesOfRefusedPermissions(): void
+    {
+        $role = (object) ['name' => 'test', 'parent' => null, 'refusals' => 'application/log'];
+        $form = $this->createForm(RepositoryMode::Update, [], 'test', [$role]);
+        $entry = $form->exposeFetchEntry();
+
+        $this->assertSame('y', $entry->application_elements['noapplicationlog']);
+        $this->assertArrayNotHasKey('applicationlog', $entry->application_elements);
+    }
+
+    public function testFetchEntryDetectsAdministrativeAccessAsFirstPermission(): void
+    {
+        $role = (object) ['name' => 'test', 'parent' => null, 'permissions' => '*,application/log'];
+        $form = $this->createForm(RepositoryMode::Update, [], 'test', [$role]);
+        $entry = $form->exposeFetchEntry();
+
+        $this->assertSame('y', $entry->{RoleForm::WILDCARD_NAME});
+    }
+
+    public function testFetchEntryDetectsAdministrativeAccessAsLastPermission(): void
+    {
+        $role = (object) ['name' => 'test', 'parent' => null, 'permissions' => 'application/log,*'];
+        $form = $this->createForm(RepositoryMode::Update, [], 'test', [$role]);
+        $entry = $form->exposeFetchEntry();
+
+        $this->assertSame('y', $entry->{RoleForm::WILDCARD_NAME});
+    }
+
+    public function testFetchEntryDetectsAdministrativeAccessAsMiddlePermission(): void
+    {
+        $role = (object) ['name' => 'test', 'parent' => null, 'permissions' => 'application/log,*,mymodule/read'];
+        $form = $this->createForm(RepositoryMode::Update, [], 'test', [$role]);
+        $entry = $form->exposeFetchEntry();
+
+        $this->assertSame('y', $entry->{RoleForm::WILDCARD_NAME});
+    }
+
+    public function testFetchEntryDoesNotMistakeAModuleWildcardForAdministrativeAccess(): void
+    {
+        $role = (object) ['name' => 'test', 'parent' => null, 'permissions' => 'mymodule/*'];
+        $form = $this->createForm(RepositoryMode::Update, [], 'test', [$role]);
+        $entry = $form->exposeFetchEntry();
+
+        $this->assertSame('n', $entry->{RoleForm::WILDCARD_NAME});
+    }
+
+    public function testFetchEntryMigratesLegacyPermissions(): void
+    {
+        $role = (object) ['name' => 'test', 'parent' => null, 'permissions' => 'admin,no-user/password-change'];
+        $form = $this->createForm(RepositoryMode::Update, [], 'test', [$role]);
+        $entry = $form->exposeFetchEntry();
+
+        $this->assertSame('y', $entry->application_elements['applicationannouncements']);
+        $this->assertSame('y', $entry->application_elements['nouserpasswordchange']);
+    }
+
+    public function testFetchEntryOmitsGeneralModuleAccessForFullModuleAccess(): void
+    {
+        $role = (object) ['name' => 'test', 'parent' => null, 'permissions' => 'module/mymodule,mymodule/*'];
+        $form = $this->createForm(RepositoryMode::Update, [], 'test', [$role]);
+        $entry = $form->exposeFetchEntry();
+
+        $this->assertSame('y', $entry->mymodule_elements['mymodule']);
+        $this->assertArrayNotHasKey('modulemymodule', $entry->mymodule_elements);
+    }
+
+    public function testFetchEntryCopiesRestrictionsIntoTheirFieldsets(): void
+    {
+        $role = (object) [
+            'name'                    => 'test',
+            'parent'                  => null,
+            'application/share/users' => 'icingaadmin',
+            'mymodule/filter'         => 'host=foo',
+        ];
+        $form = $this->createForm(RepositoryMode::Update, [], 'test', [$role]);
+        $entry = $form->exposeFetchEntry();
+
+        $this->assertSame('icingaadmin', $entry->application_elements['applicationshareusers']);
+        $this->assertSame('host=foo', $entry->mymodule_elements['mymodulefilter']);
+    }
+
+    public function testFetchEntryYieldsNoFieldsetsForARoleWithoutPrivileges(): void
+    {
+        $role = (object) ['name' => 'test', 'parent' => null];
+        $form = $this->createForm(RepositoryMode::Update, [], 'test', [$role]);
+        $entry = $form->exposeFetchEntry();
+
+        $this->assertSame('n', $entry->{RoleForm::WILDCARD_NAME});
+        $this->assertObjectNotHasProperty('application_elements', $entry);
+        $this->assertObjectNotHasProperty('mymodule_elements', $entry);
+    }
+
+    public function testFetchEntryTrimsSpacesBetweenPermissions(): void
+    {
+        $role = (object) [
+            'name'        => 'test',
+            'parent'      => null,
+            'permissions' => 'application/announcements , mymodule/read',
+        ];
+        $form = $this->createForm(RepositoryMode::Update, [], 'test', [$role]);
+        $entry = $form->exposeFetchEntry();
+
+        $this->assertSame('y', $entry->application_elements['applicationannouncements']);
+        $this->assertSame('y', $entry->mymodule_elements['mymoduleread']);
+        $this->assertArrayNotHasKey('applicationlog', $entry->application_elements);
     }
 }

--- a/test/php/application/forms/Security/RoleFormTest.php
+++ b/test/php/application/forms/Security/RoleFormTest.php
@@ -1,0 +1,109 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Tests\Icinga\Forms\Security;
+
+use Icinga\Data\DataArray\ArrayDatasource;
+use Icinga\Data\Extensible;
+use Icinga\Data\Filter\Filter;
+use Icinga\Data\Reducible;
+use Icinga\Data\Updatable;
+use Icinga\Forms\Security\RoleForm;
+use Icinga\Repository\Repository;
+use Icinga\Repository\RepositoryMode;
+use Icinga\Test\BaseTestCase;
+
+/**
+ * Tests for {@see RoleForm}
+ */
+class RoleFormTest extends BaseTestCase
+{
+    /**
+     * Create a role form providing a fixed set of privileges
+     *
+     * The form is populated first and assembled afterwards, just like when
+     * handling a request. $values is what a browser would have submitted.
+     *
+     * @param RepositoryMode $mode
+     * @param array<string, mixed> $values
+     * @param ?string $identifier
+     *
+     * @return RoleForm
+     */
+    private function createForm(RepositoryMode $mode, array $values = [], ?string $identifier = null): RoleForm
+    {
+        $form = new class ($this->createRepository(), $mode, $identifier) extends RoleForm {
+            public static function collectProvidedPrivileges(): array
+            {
+                return [
+                    [
+                        'application' => [
+                            'application/announcements' => ['description' => 'Allow to manage announcements'],
+                            'application/log'           => ['description' => 'Allow to view the application log'],
+                        ],
+                        'mymodule'    => [
+                            'module/mymodule' => ['isUsagePerm' => true, 'label' => 'General Module Access'],
+                            'mymodule/*'      => ['isFullPerm' => true, 'label' => 'Full Module Access'],
+                            'mymodule/read'   => ['description' => 'Allow to read'],
+                        ],
+                    ],
+                    [
+                        'application' => [
+                            'application/share/users' => ['description' => 'Restrict which users to share with'],
+                        ],
+                        'mymodule'    => [
+                            'mymodule/filter' => ['description' => 'Restrict what to see'],
+                        ],
+                    ],
+                ];
+            }
+        };
+
+        $form->disableCsrfCounterMeasure();
+        $form->populate($values);
+        $form->ensureAssembled();
+
+        return $form;
+    }
+
+    /**
+     * Create a repository suitable for every mode the role form supports
+     *
+     * @param array<int, array<string, mixed>> $roles The roles the repository provides
+     *
+     * @return Repository
+     */
+    private function createRepository(array $roles = []): Repository
+    {
+        return new class (new ArrayDatasource($roles)) extends Repository implements Extensible, Reducible, Updatable {
+            /** @var array<string, array<int, string>> */
+            protected $queryColumns = [
+                'roles' => [
+                    'name',
+                    'parent',
+                    'users',
+                    'groups',
+                    'permissions',
+                    'refusals',
+                    'unrestricted',
+                    'application/share/users',
+                    'mymodule/filter',
+                ],
+            ];
+
+            public function insert($target, array $data): void
+            {
+            }
+
+            public function update($target, array $data, ?Filter $filter = null): void
+            {
+            }
+
+            public function delete($target, ?Filter $filter = null): void
+            {
+            }
+        };
+    }
+}


### PR DESCRIPTION
Migrate `RoleForm` and `RoleController` from the legacy Zend `RepositoryForm` to a `CompatForm`-based repository form.

## Changes

- **`FieldsetElement` value mapping**: privileges are grouped into `FieldsetElement`s per module. Because ipl stores fieldset values as nested arrays, `fetchEntry()` and `getValues()` map between the flat ini-key names stored in `roles.ini` and the nested element structure.
- **`assembleCommonElements()`**: the privilege fieldsets are assembled for insert and update mode.
- **`isChecked()` for checkboxes**: replaces manual value comparisons.
- **Privilege transformation skipped on delete**: `getValues()` no longer maps privileges when the form is used to remove a role.
- **Narrowed `getIdentifier()` return type**: to `?string`, ruling out `Stringable` and `int` values the constructor never accepts.
- **`Updatable` guard**: the constructor throws when the repository does not implement `Updatable` in delete mode, which is required to clear parent references on child roles.

require Icinga/ipl-html#202