### PR TITLE
Add `CsrfCounterMeasure` to `ConfigForm`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Please make sure to always read our [Upgrading](doc/80-Upgrading.md) documentati
 
 ### What's New in Version 2.14.1
 
+#### CSRF Protection for Config Forms
+
+`Icinga\Web\Form\ConfigForm` callers must now set a session-stable ID with
+`setCsrfCounterMeasureId()` before assembly or explicitly disable protection
+with `disableCsrfCounterMeasure()`.
+
 #### CompatForm-based Repository Form
 
 `Icinga\Web\Form\RepositoryForm` is a new `CompatForm`-based base class for

--- a/application/controllers/ConfigController.php
+++ b/application/controllers/ConfigController.php
@@ -8,6 +8,7 @@ namespace Icinga\Controllers;
 use Exception;
 use GuzzleHttp\Psr7\ServerRequest;
 use Icinga\Application\Version;
+use Icinga\Web\Session;
 use InvalidArgumentException;
 use Icinga\Application\Config;
 use Icinga\Application\Icinga;
@@ -134,6 +135,7 @@ class ConfigController extends Controller
 
         $config = Config::app();
         $cspForm = new CspConfigForm($config);
+        $cspForm->setCsrfCounterMeasureId(Session::getSession()->getId());
         // Keep the auto-generation options off by default for installations that already
         // had CSP enabled, so their existing behavior isn't changed. For installations
         // enabling CSP for the first time, default them on as the recommended setting.

--- a/application/forms/Config/Security/CspConfigForm.php
+++ b/application/forms/Config/Security/CspConfigForm.php
@@ -17,7 +17,6 @@ use Icinga\Security\Csp\Reason\NavigationCspReason;
 use Icinga\Security\Csp\Reason\StaticCspReason;
 use Icinga\Util\Csp;
 use Icinga\Web\Form\ConfigForm;
-use Icinga\Web\Session;
 use ipl\Html\Attributes;
 use ipl\Html\BaseHtmlElement;
 use ipl\Html\HtmlElement;
@@ -26,7 +25,6 @@ use ipl\Html\Text;
 use ipl\Validator\CallbackValidator;
 use ipl\Web\Common\CalloutType;
 use ipl\Web\Common\Csp as CspInstance;
-use ipl\Web\Common\CsrfCounterMeasure;
 use ipl\Web\Common\FormUid;
 use ipl\Web\Compat\DisplayFormElement;
 use ipl\Web\Widget\Callout;
@@ -43,7 +41,6 @@ use ipl\Web\Widget\Link;
 class CspConfigForm extends ConfigForm
 {
     use FormUid;
-    use CsrfCounterMeasure;
 
     /**
      * @var string[] List of all keywords that are considered secure. {@link https://centralcsp.com/docs/csp-keywords}
@@ -129,8 +126,6 @@ class CspConfigForm extends ConfigForm
         Csp::createNonce();
 
         $this->addElement($this->createUidElement());
-
-        $this->addCsrfCounterMeasure(Session::getSession()->getId());
 
         $this->addElement('checkbox', 'security__use_strict_csp', [
             'label'          => $this->translate('Send CSP header'),

--- a/application/views/scripts/error/error.phtml
+++ b/application/views/scripts/error/error.phtml
@@ -34,7 +34,7 @@ $modReason = [];
 
 if (isset($requiredVendor, $requiredProject) && $requiredVendor && $requiredProject) {
     // TODO: I don't like this, can we define requirements somewhere else?
-    $coreDeps = ['icinga-php-library' => '>= 1.0.0', 'icinga-php-thirdparty' => '>= 1.0.0'];
+    $coreDeps = ['icinga-php-library' => '>= 1.1.0', 'icinga-php-thirdparty' => '>= 1.0.0'];
 
     foreach ($coreDeps as $libraryName => $requiredVersion) {
         if (! $libraries->has($libraryName)) {

--- a/doc/02-Installation.md.d/From-Source.md
+++ b/doc/02-Installation.md.d/From-Source.md
@@ -11,7 +11,7 @@ You will need to install certain dependencies depending on your setup:
   monitor your infrastructure
 * A web server, e.g. Apache or Nginx
 * PHP version ≥ 8.2
-* [Icinga PHP Library (ipl)](https://github.com/Icinga/icinga-php-library) ≥ 1.0.0
+* [Icinga PHP Library (ipl)](https://github.com/Icinga/icinga-php-library) ≥ 1.1.0
 * [Icinga PHP Thirdparty](https://github.com/Icinga/icinga-php-thirdparty) ≥ 1.0.0
 * The following PHP modules must be installed: cURL, json, gettext, fileinfo, intl, dom, OpenSSL and xml
 * The [pdfexport](https://github.com/Icinga/icingaweb2-module-pdfexport) module (≥0.13.0) for PDF export

--- a/library/Icinga/Web/Form/ConfigForm.php
+++ b/library/Icinga/Web/Form/ConfigForm.php
@@ -12,6 +12,7 @@ use ipl\Html\Contract\ValueCandidates;
 use ipl\Html\HtmlElement;
 use ipl\Html\ValidHtml;
 use ipl\Stdlib\Str;
+use ipl\Web\Common\CsrfCounterMeasure;
 use ipl\Web\Compat\CompatForm;
 use ipl\Web\Compat\DisplayFormElement;
 use ipl\Web\Widget\CopyToClipboard;
@@ -20,14 +21,20 @@ use LogicException;
 /**
  * Form base-class providing standard functionality for configuration forms
  *
- *  Element names follow a `section__key` convention: the part before the
- *  {@see $sectionKeyDelimiter} (default: `__`) is the INI section name and the
- *  part after is the configuration key within that section. Subclasses add
- *  elements whose names match this pattern; `populateFromConfig` and `save`
- *  use it to map form values to and from the INI file automatically.
+ * Element names follow a `section__key` convention: the part before the
+ * {@see $sectionKeyDelimiter} (default: `__`) is the INI section name and the
+ * part after is the configuration key within that section. Subclasses add
+ * elements whose names match this pattern; `populateFromConfig` and `save`
+ * use it to map form values to and from the INI file automatically.
+ *
+ * Before assembly, callers must either set a session-stable ID with
+ * {@see setCsrfCounterMeasureId()} or explicitly disable the countermeasure
+ * with {@see disableCsrfCounterMeasure()}.
  */
 class ConfigForm extends CompatForm
 {
+    use CsrfCounterMeasure;
+
     /** @var string Name of the submit button element */
     protected const SUBMIT_BUTTON_NAME = 'store';
 
@@ -78,21 +85,10 @@ class ConfigForm extends CompatForm
                 $element->setValueCandidates(array_merge($candidates, [$configValue]));
             }
         });
-    }
 
-    /**
-     * Ensure that all required form elements are present
-     *
-     * @return $this
-     */
-    public function ensureAssembled(): static
-    {
-        if (! $this->hasBeenAssembled) {
-            parent::ensureAssembled();
-            $this->addRequiredElements();
-        }
-
-        return $this;
+        $this->on(static::ON_ASSEMBLED, function (ConfigForm $form) {
+            $form->addRequiredElements();
+        });
     }
 
     /**
@@ -200,7 +196,7 @@ class ConfigForm extends CompatForm
     }
 
     /**
-     * Add the submit button to the form
+     * Add the submit button and CSRF counter-measure element to the form
      *
      * Called automatically during assembly. Subclasses may override this to add
      * additional required elements but must call the parent implementation.
@@ -213,5 +209,7 @@ class ConfigForm extends CompatForm
             'label' => $this->translate('Store'),
             'ignore' => true,
         ]);
+
+        $this->addCsrfCounterMeasure();
     }
 }

--- a/modules/setup/library/Setup/WebWizard.php
+++ b/modules/setup/library/Setup/WebWizard.php
@@ -604,7 +604,7 @@ class WebWizard extends Wizard implements SetupWizard
         ]));
 
         $set->add(new WebLibraryRequirement([
-            'condition'     => ['icinga-php-library', '>=', '1.0.0'],
+            'condition'     => ['icinga-php-library', '>=', '1.1.0'],
             'alias'         => 'Icinga PHP library',
             'description'   => mt(
                 'setup',

--- a/test/php/library/Icinga/Web/Form/ConfigFormTest.php
+++ b/test/php/library/Icinga/Web/Form/ConfigFormTest.php
@@ -5,6 +5,7 @@
 
 namespace Tests\Icinga\Web\Form;
 
+use Error;
 use Icinga\Application\Config;
 use Icinga\Data\ConfigObject;
 use Icinga\Test\BaseTestCase;
@@ -14,33 +15,78 @@ use LogicException;
 
 class ConfigFormTest extends BaseTestCase
 {
-    private function makeForm(array $configData = [])
+    /** @var mixed Original value restored to avoid leaking global test state */
+    private mixed $secFetchSiteHeader;
+
+    public function setUp(): void
     {
-        $form = new class(Config::fromArray($configData)) extends ConfigForm {
-            public function exposeSetSectionKeyDelimiter(string $delimiter): void
-            {
-                $this->sectionKeyDelimiter = $delimiter;
-            }
-        };
+        parent::setUp();
 
-        $form->disableCsrfCounterMeasure();
+        $this->secFetchSiteHeader = $_SERVER['HTTP_SEC_FETCH_SITE'] ?? null;
+        // Force token protection because safe Sec-Fetch-Site values use a dummy element.
+        unset($_SERVER['HTTP_SEC_FETCH_SITE']);
+    }
 
-        return $form;
+    public function tearDown(): void
+    {
+        if ($this->secFetchSiteHeader === null) {
+            unset($_SERVER['HTTP_SEC_FETCH_SITE']);
+        } else {
+            $_SERVER['HTTP_SEC_FETCH_SITE'] = $this->secFetchSiteHeader;
+        }
+
+        parent::tearDown();
     }
 
     public function testSubmitButtonIsAddedAfterAssembly(): void
     {
         $form = $this->makeForm();
+        $form->disableCsrfCounterMeasure();
         $form->ensureAssembled();
         $this->assertTrue($form->hasElement('store'));
     }
 
     public function testCsrfElementIsAddedAfterAssembly(): void
     {
-        $form = new class(Config::fromArray([])) extends ConfigForm {};
+        $form = $this->makeForm();
         $form->setCsrfCounterMeasureId('bogus');
         $form->ensureAssembled();
         $this->assertTrue($form->hasElement('CSRFToken'));
+        $this->assertTrue($form->getElement('CSRFToken')->isRequired());
+        $this->assertMatchesRegularExpression(
+            '/ value="[^"]+\|[^"]+"/',
+            $form->getElement('CSRFToken')->render()
+        );
+    }
+
+    public function testDisabledCsrfCounterMeasureDoesNotAddElement(): void
+    {
+        $form = $this->makeForm();
+        $form->disableCsrfCounterMeasure();
+        $form->ensureAssembled();
+        $this->assertFalse($form->hasElement('CSRFToken'));
+        $this->assertTrue($form->hasElement('store'));
+    }
+
+    public function testAssemblyWithoutCsrfCounterMeasureIdFails(): void
+    {
+        $form = $this->makeForm();
+        $this->expectException(Error::class);
+        $this->expectExceptionMessage('No CSRF counter measure ID set');
+        $form->ensureAssembled();
+    }
+
+    public function testRepeatedAssemblyDoesNotDuplicateRequiredElements(): void
+    {
+        $form = $this->makeForm();
+        $form->setCsrfCounterMeasureId('bogus');
+        $form->ensureAssembled();
+        $submitElement = $form->getElement('store');
+        $csrfElement = $form->getElement('CSRFToken');
+        $form->ensureAssembled();
+        $this->assertCount(2, $form->getElements());
+        $this->assertSame($submitElement, $form->getElement('store'));
+        $this->assertSame($csrfElement, $form->getElement('CSRFToken'));
     }
 
     public function testSaveThrowsForArrayElementValue(): void
@@ -119,5 +165,11 @@ class ConfigFormTest extends BaseTestCase
         $form->exposeSave();
 
         $this->assertFalse($config->hasSection('mysection'));
+    }
+
+    private function makeForm(): ConfigForm
+    {
+        return new class (Config::fromArray([])) extends ConfigForm {
+        };
     }
 }

--- a/test/php/library/Icinga/Web/Form/ConfigFormTest.php
+++ b/test/php/library/Icinga/Web/Form/ConfigFormTest.php
@@ -16,12 +16,16 @@ class ConfigFormTest extends BaseTestCase
 {
     private function makeForm(array $configData = [])
     {
-        return new class(Config::fromArray($configData)) extends ConfigForm {
+        $form = new class(Config::fromArray($configData)) extends ConfigForm {
             public function exposeSetSectionKeyDelimiter(string $delimiter): void
             {
                 $this->sectionKeyDelimiter = $delimiter;
             }
         };
+
+        $form->disableCsrfCounterMeasure();
+
+        return $form;
     }
 
     public function testSubmitButtonIsAddedAfterAssembly(): void
@@ -29,6 +33,14 @@ class ConfigFormTest extends BaseTestCase
         $form = $this->makeForm();
         $form->ensureAssembled();
         $this->assertTrue($form->hasElement('store'));
+    }
+
+    public function testCsrfElementIsAddedAfterAssembly(): void
+    {
+        $form = new class(Config::fromArray([])) extends ConfigForm {};
+        $form->setCsrfCounterMeasureId('bogus');
+        $form->ensureAssembled();
+        $this->assertTrue($form->hasElement('CSRFToken'));
     }
 
     public function testSaveThrowsForArrayElementValue(): void
@@ -53,6 +65,7 @@ class ConfigFormTest extends BaseTestCase
                 $this->save();
             }
         };
+        $form->disableCsrfCounterMeasure();
         $form->ensureAssembled();
         $form->populate(['mysection__key' => ['a', 'b']]);
         $form->exposeSave();
@@ -75,6 +88,7 @@ class ConfigFormTest extends BaseTestCase
                 $this->save();
             }
         };
+        $form->disableCsrfCounterMeasure();
         $form->populate(['mysection__password' => PasswordElement::DUMMYPASSWORD]);
         $form->ensureAssembled();
         $form->exposeSave();
@@ -99,6 +113,7 @@ class ConfigFormTest extends BaseTestCase
                 $this->save();
             }
         };
+        $form->disableCsrfCounterMeasure();
         $form->ensureAssembled();
         $form->populate(['mysection__key' => '']);
         $form->exposeSave();


### PR DESCRIPTION
Move CSRF protection from `CspConfigForm` into the base class so all `ConfigForm` subclasses inherit it. Replace the `ensureAssembled()` override with an `ON_ASSEMBLED` event listener, which is the idiomatic IPL Web lifecycle hook for post-assembly work.

require Icinga/ipl-html#207