### PR TITLE
Deprecate old `Icinga\Forms\RepositoryForm`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ Please make sure to always read our [Upgrading](doc/80-Upgrading.md) documentati
 
 ## What's New
 
+### What's New in Version 2.15.0
+
+#### Old Repository Form Deprecation
+
+`Icinga\Forms\RepositoryForm` is deprecated in favor of
+`Icinga\Web\Form\RepositoryForm`, which builds on `CompatForm` instead of the
+legacy Zend form layer. Existing subclasses keep working until version 2.17,
+which removes the deprecated class. Please migrate them to the new base class
+before then.
+
+* Deprecate old RepositoryForm [#5553](https://github.com/Icinga/icingaweb2/pull/5553)
+
 ### What's New in Version 2.14.1
 
 #### CSRF Protection for Config Forms

--- a/application/forms/RepositoryForm.php
+++ b/application/forms/RepositoryForm.php
@@ -14,6 +14,9 @@ use Icinga\Web\Notification;
 
 /**
  * Form base-class providing standard functionality for extensible, updatable and reducible repositories
+ *
+ * @deprecated Use {@see \Icinga\Web\Form\RepositoryForm} instead for a
+ * {@see \ipl\Web\Compat\CompatForm} based implementation.
  */
 abstract class RepositoryForm extends Form
 {

--- a/doc/80-Upgrading.md
+++ b/doc/80-Upgrading.md
@@ -3,6 +3,17 @@
 Specific version upgrades are described below. Please note that upgrades are incremental. An upgrade from
 v2.6 to v2.8 requires to follow the instructions for v2.7 too.
 
+## Upgrading to Icinga Web 2.15
+
+**Deprecations**
+
+* `Icinga\Forms\RepositoryForm` is deprecated in favor of `Icinga\Web\Form\RepositoryForm`,
+  which builds on `CompatForm` instead of the legacy Zend form layer.
+  * Existing subclasses continue to work until v2.17, which removes the deprecated class.
+  * The new class is no drop-in replacement. The constructor signature, assembly
+    method names, notification ownership, and submit controls all differ and have
+    to be adjusted when migrating.
+
 ## Upgrading to Icinga Web 2.14.1
 
 **Breaking changes**


### PR DESCRIPTION
Deprecate the old `Icinga\Forms\RepositoryForm`, since it's superseded by #5536.