### PR TITLE
Docs: Mention that RenderHooks should not be used anymore

### DIFF
--- a/public/js/icinga.js
+++ b/public/js/icinga.js
@@ -66,7 +66,8 @@
         this.behaviors = {};
 
         /**
-         * Site behaviors which hook into the rendering process
+         * Site behaviors which hook into the rendering process.
+         * RenderHooks should not be used anymore.
          */
         this.renderHooks = [];
 


### PR DESCRIPTION
This is to disencourage the use of the renderHooks feature.

Let me know if I should change the wording in any way.