### PR TITLE
Set `baseTarget` for user and group access-control list tabs

### DIFF
--- a/application/controllers/GroupController.php
+++ b/application/controllers/GroupController.php
@@ -375,22 +375,22 @@ class GroupController extends AuthBackendController
             $tabs->add(
                 'role/list',
                 [
-                    'baseTarget'    => '_main',
-                    'label'         => $this->translate('Roles'),
-                    'title'         => $this->translate(
+                    'title'      => $this->translate(
                         'Configure roles to permit or restrict users and groups accessing Icinga Web 2'
                     ),
-                    'url'           => 'role/list'
+                    'label'      => $this->translate('Roles'),
+                    'url'        => 'role/list',
+                    'baseTarget' => '_main',
                 ]
             );
 
             $tabs->add(
                 'role/audit',
                 [
-                    'title'         => $this->translate('Audit a user\'s or group\'s privileges'),
-                    'label'         => $this->translate('Audit'),
-                    'url'           => 'role/audit',
-                    'baseTarget'    => '_main',
+                    'title'      => $this->translate('Audit a user\'s or group\'s privileges'),
+                    'label'      => $this->translate('Audit'),
+                    'url'        => 'role/audit',
+                    'baseTarget' => '_main',
                 ]
             );
         }
@@ -399,9 +399,10 @@ class GroupController extends AuthBackendController
             $tabs->add(
                 'user/list',
                 [
-                    'title'     => $this->translate('List users of authentication backends'),
-                    'label'     => $this->translate('Users'),
-                    'url'       => 'user/list'
+                    'title'      => $this->translate('List users of authentication backends'),
+                    'label'      => $this->translate('Users'),
+                    'url'        => 'user/list',
+                    'baseTarget' => '_main',
                 ]
             );
         }
@@ -409,9 +410,10 @@ class GroupController extends AuthBackendController
         $tabs->add(
             'group/list',
             [
-                'title'     => $this->translate('List groups of user group backends'),
-                'label'     => $this->translate('User Groups'),
-                'url'       => 'group/list'
+                'title'      => $this->translate('List groups of user group backends'),
+                'label'      => $this->translate('User Groups'),
+                'url'        => 'group/list',
+                'baseTarget' => '_main',
             ]
         );
 

--- a/application/controllers/RoleController.php
+++ b/application/controllers/RoleController.php
@@ -346,22 +346,22 @@ class RoleController extends AuthBackendController
         $tabs->add(
             'role/list',
             [
-                'baseTarget'    => '_main',
-                'label'         => $this->translate('Roles'),
-                'title'         => $this->translate(
+                'title'      => $this->translate(
                     'Configure roles to permit or restrict users and groups accessing Icinga Web 2'
                 ),
-                'url'           => 'role/list'
+                'label'      => $this->translate('Roles'),
+                'url'        => 'role/list',
+                'baseTarget' => '_main',
             ]
         );
 
         $tabs->add(
             'role/audit',
             [
-                'title'         => $this->translate('Audit a user\'s or group\'s privileges'),
-                'label'         => $this->translate('Audit'),
-                'url'           => 'role/audit',
-                'baseTarget'    => '_main'
+                'title'      => $this->translate('Audit a user\'s or group\'s privileges'),
+                'label'      => $this->translate('Audit'),
+                'url'        => 'role/audit',
+                'baseTarget' => '_main',
             ]
         );
 
@@ -369,9 +369,10 @@ class RoleController extends AuthBackendController
             $tabs->add(
                 'user/list',
                 [
-                    'title'     => $this->translate('List users of authentication backends'),
-                    'label'     => $this->translate('Users'),
-                    'url'       => 'user/list'
+                    'title'      => $this->translate('List users of authentication backends'),
+                    'label'      => $this->translate('Users'),
+                    'url'        => 'user/list',
+                    'baseTarget' => '_main',
                 ]
             );
         }
@@ -380,9 +381,10 @@ class RoleController extends AuthBackendController
             $tabs->add(
                 'group/list',
                 [
-                    'title'     => $this->translate('List groups of user group backends'),
-                    'label'     => $this->translate('User Groups'),
-                    'url'       => 'group/list'
+                    'title'      => $this->translate('List groups of user group backends'),
+                    'label'      => $this->translate('User Groups'),
+                    'url'        => 'group/list',
+                    'baseTarget' => '_main',
                 ]
             );
         }

--- a/application/controllers/UserController.php
+++ b/application/controllers/UserController.php
@@ -331,22 +331,22 @@ class UserController extends AuthBackendController
             $tabs->add(
                 'role/list',
                 [
-                    'baseTarget'    => '_main',
-                    'label'         => $this->translate('Roles'),
-                    'title'         => $this->translate(
+                    'title'      => $this->translate(
                         'Configure roles to permit or restrict users and groups accessing Icinga Web 2'
                     ),
-                    'url'           => 'role/list'
+                    'label'      => $this->translate('Roles'),
+                    'url'        => 'role/list',
+                    'baseTarget' => '_main',
                 ]
             );
 
             $tabs->add(
                 'role/audit',
                 [
-                    'title'         => $this->translate('Audit a user\'s or group\'s privileges'),
-                    'label'         => $this->translate('Audit'),
-                    'url'           => 'role/audit',
-                    'baseTarget'    => '_main'
+                    'title'      => $this->translate('Audit a user\'s or group\'s privileges'),
+                    'label'      => $this->translate('Audit'),
+                    'url'        => 'role/audit',
+                    'baseTarget' => '_main',
                 ]
             );
         }
@@ -354,9 +354,10 @@ class UserController extends AuthBackendController
         $tabs->add(
             'user/list',
             [
-                'title'     => $this->translate('List users of authentication backends'),
-                'label'     => $this->translate('Users'),
-                'url'       => 'user/list'
+                'title'      => $this->translate('List users of authentication backends'),
+                'label'      => $this->translate('Users'),
+                'url'        => 'user/list',
+                'baseTarget' => '_main',
             ]
         );
 
@@ -364,9 +365,10 @@ class UserController extends AuthBackendController
             $tabs->add(
                 'group/list',
                 [
-                    'title'     => $this->translate('List groups of user group backends'),
-                    'label'     => $this->translate('User Groups'),
-                    'url'       => 'group/list'
+                    'title'      => $this->translate('List groups of user group backends'),
+                    'label'      => $this->translate('User Groups'),
+                    'url'        => 'group/list',
+                    'baseTarget' => '_main',
                 ]
             );
         }


### PR DESCRIPTION
### Problem

The access-control navigation (shared by the Roles, Users, and Groups configuration pages) lets you open a detail form, e.g. clicking a user opens the user form in the second column, and then switch sections via the tab bar. Switching sections should behave the same regardless of which tab you started from, but it did not:

- **Open a *user*, then click the *Roles* tab** → the user form is correctly closed and roles list is shown in single column layout.
- **Open a *role*, then click the *Users* tab** → the role form **stays open in the second column** while the user list loads in the first. You're now looking at a role form next to an unrelated user list.

### Change

Adds the missing `'baseTarget' => '_main'` to the `user/list` and `group/list` tab definitions so switching to *any* access-control tab reliably closes a detail form left open from another section. The same navigation is duplicated across `GroupController`, `RoleController`, and `UserController`, so the fix is applied to all three to keep them in sync.

While touching these blocks, the tab arrays were normalized to a consistent key order (`title`, `label`, `url`, `baseTarget`) and alignment.