### PR TITLE
Mark `TwoFactor::verify()` token parameter as sensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@ It supersedes `Icinga\Forms\RepositoryForm`, which will be deprecated in version
 signature, assembly method names, notification ownership, and submit controls
 all differ and have to be adjusted when migrating.
 
+#### Sensitive Two-Factor Token
+
+The `$token` parameter of `Icinga\Authentication\TwoFactor::verify()` is now
+marked `#[SensitiveParameter]` so the entered token is redacted from stack
+traces and error reports. Implementations of the contract should mark their own
+`verify()` parameter the same way.
+
+* Mark TwoFactor::verify() token parameter as sensitive [#5559](https://github.com/Icinga/icingaweb2/pull/5559)
+
 ### What's New in Version 2.14.0
 
 You can find all issues related to this release on our

--- a/library/Icinga/Authentication/TwoFactor.php
+++ b/library/Icinga/Authentication/TwoFactor.php
@@ -9,6 +9,7 @@ use Icinga\Application\Hook\TwoFactorHook;
 use Icinga\Forms\Account\TwoFactorEnrollmentForm;
 use Icinga\User;
 use ipl\Html\FormElement\FieldsetElement;
+use SensitiveParameter;
 
 /**
  * Contract for a two-factor authentication method
@@ -57,7 +58,7 @@ interface TwoFactor
      *
      * @return bool True if the token is valid, false otherwise
      */
-    public function verify(User $user, string $token): bool;
+    public function verify(User $user, #[SensitiveParameter] string $token): bool;
 
     /**
      * Verify the submitted credential and persist it for the given user


### PR DESCRIPTION
Add `#[SensitiveParameter]` to the `$token` parameter so an entered two-factor token is redacted from stack traces and error reports instead of appearing in plaintext. Implementations of the contract should mark their own `verify()` parameter the same way.