### PR TITLE
Render urls without an authority as `scheme:path`

### DIFF
--- a/library/Icinga/Web/Url.php
+++ b/library/Icinga/Web/Url.php
@@ -529,6 +529,14 @@ class Url
         }
 
         if ($this->getUsername() || $this->isExternal()) {
+            if ($this->getScheme() && ! $this->getHost() && ! $this->getUsername()) {
+                // Without a host there is no authority component, so `scheme:path`
+                // is the only correct rendering. Injecting `//` and the base path
+                // would corrupt the url, as it does for schemes such as `data:`,
+                // `mailto:` or `tel:`.
+                return $this->getScheme() . ':' . $path;
+            }
+
             $urlString = '';
             if ($this->getScheme()) {
                 $urlString .= $this->getScheme() . '://';

--- a/test/php/library/Icinga/Web/UrlTest.php
+++ b/test/php/library/Icinga/Web/UrlTest.php
@@ -163,6 +163,30 @@ class UrlTest extends BaseTestCase
         );
     }
 
+    public function testWhetherGetAbsoluteUrlDoesNotInjectAnAuthorityForSchemesWithoutOne()
+    {
+        $this->getRequestMock()->shouldReceive('getServer')->with('SERVER_NAME')->andReturn('localhost')
+            ->shouldReceive('getServer')->with('SERVER_PORT')->andReturn('80');
+
+        $urls = [
+            'data:image/png',
+            'data:image/png;base64,iVBORw0KGgo=',
+            'data:text/csv;charset=utf-8,a,b,c',
+            'mailto:user@example.com',
+            'mailto:user@example.com?subject=Hi%20there',
+            'tel:+49123456789',
+            'geo:50.11,8.68',
+        ];
+
+        foreach ($urls as $url) {
+            $this->assertEquals(
+                $url,
+                Url::fromPath($url)->getAbsoluteUrl(),
+                'Url::getAbsoluteUrl injects `//` and the base path into ' . $url
+            );
+        }
+    }
+
     public function testWhetherFromRequestWorksWithoutARequest()
     {
         $this->getRequestMock()->shouldReceive('getBaseUrl')->andReturn('/path/to')


### PR DESCRIPTION
`getAbsoluteUrl()` assumed that every scheme is followed by an authority component and appended `://` plus the base path to it. Urls whose scheme carries no authority came out corrupted: `data:image/png` became `data:///image/png` and `mailto:user@example.com` became `mailto:///user@example.com`.

RFC 3986 section 3 only permits the double slash when an authority is present, so the absence of a host now selects `scheme:path` instead. This covers every authority-less scheme rather than a fixed set, e.g. `data:`, `mailto:`, `tel:`, and `geo:`.

Safari refuses to start a download for a data url containing the stray slashes, which made every `ipl\Web\Widget\Link` pointing at generated file contents unusable there. Chrome and Firefox tolerated the corrupted form.

fix #5459 