### PR TITLE
Fix logging level description in configuration

### DIFF
--- a/doc/03-Configuration.md
+++ b/doc/03-Configuration.md
@@ -46,7 +46,7 @@ module_path = "/usr/share/icingaweb2/modules"
 Option                   | Description
 -------------------------|-----------------------------------------------
 log                      | **Optional.** Specifies the logging type. Can be set to `syslog`, `file`, `php` (web server's error log) or `none`.
-level                    | **Optional.** Specifies the logging level. Can be set to `ERROR`, `WARNING`, `INFORMATION` or `DEBUG`.
+level                    | **Optional.** Specifies the logging level. Can be set to `ERROR`, `WARNING`, `INFO` or `DEBUG`.
 file                     | **Optional.** Specifies the log file path if `log` is set to `file`.
 application              | **Optional.** Specifies the application name if `log` is set to `syslog`.
 facility                 | **Optional.** Specifies the syslog facility if `log` is set to `syslog`. Can be set to `user`, `local0` to `local7`. Defaults to `user`.


### PR DESCRIPTION
Updated logging level option description to use 'INFO' instead of 'INFORMATION'. 

https://github.com/Icinga/icingaweb2/blob/622c30e7b7bb104afed560675fb9141111ca555d/library/Icinga/Application/Logger.php#L46-L51

If you use the UI to set the log level, it works correctly and the level is set to ‘INFO’.