### PR TITLE
Tell DbTool about the resource's TLS settings

### DIFF
--- a/library/Icinga/Application/MigrationManager.php
+++ b/library/Icinga/Application/MigrationManager.php
@@ -22,6 +22,16 @@ final class MigrationManager implements Countable
 {
     use Translation;
 
+    private const TLS_OPTIONS = [
+        'use_ssl'                       => 'useSsl',
+        'ssl_key'                       => 'sslKey',
+        'ssl_cert'                      => 'sslCert',
+        'ssl_ca'                        => 'sslCa',
+        'ssl_capath'                    => 'sslCapath',
+        'ssl_cipher'                    => 'sslCipher',
+        'ssl_do_not_verify_server_cert' => 'sslDoNotVerifyServerCert'
+    ];
+
     /** @var array<string, DbMigrationHook> All pending migration hooks */
     protected $pendingMigrations;
 
@@ -287,7 +297,7 @@ final class MigrationManager implements Countable
     {
         $config = $db->getConfig();
 
-        return new DbTool(array_merge([
+        $dbToolConfig = [
             'db' => $config->db,
             'host' => $config->host,
             'port' => $config->port,
@@ -295,7 +305,14 @@ final class MigrationManager implements Countable
             'username' => $config->username,
             'password' => $config->password,
             'charset'  => $config->charset
-        ], $db->getAdapter()->getOptions($config)));
+        ];
+
+        // DbTool applies these itself, but knows them only by their resources.ini names
+        foreach (self::TLS_OPTIONS as $name => $property) {
+            $dbToolConfig[$name] = $config->$property ?? null;
+        }
+
+        return new DbTool($dbToolConfig);
     }
 
     protected function load(): void

--- a/test/php/library/Icinga/Application/MigrationManagerTest.php
+++ b/test/php/library/Icinga/Application/MigrationManagerTest.php
@@ -1,0 +1,122 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Tests\Icinga\Application;
+
+use Icinga\Application\MigrationManager;
+use Icinga\Module\Setup\Utils\DbTool;
+use Icinga\Test\BaseTestCase;
+use ipl\Sql\Connection;
+use ReflectionMethod;
+use ReflectionProperty;
+
+class MigrationManagerTest extends BaseTestCase
+{
+    /** @var array<string, string> A database resource which requires a TLS client certificate */
+    private static $tlsResource = [
+        'db'        => 'mysql',
+        'host'      => 'localhost',
+        'port'      => '3306',
+        'dbname'    => 'icingaweb2',
+        'username'  => 'icingaweb2',
+        'password'  => 'secret',
+        'use_ssl'   => '1',
+        'ssl_ca'    => '/etc/icingaweb2/ssl/ca.crt',
+        'ssl_cert'  => '/etc/icingaweb2/ssl/client.crt',
+        'ssl_key'   => '/etc/icingaweb2/ssl/client.key'
+    ];
+
+    public function testDbToolIsGivenTheTlsSettingsOfTheResource()
+    {
+        $config = $this->createDbToolConfig(self::$tlsResource);
+
+        $this->assertSame('1', $config['use_ssl'], 'DbTool has not been told to use TLS');
+        $this->assertSame('/etc/icingaweb2/ssl/ca.crt', $config['ssl_ca']);
+        $this->assertSame('/etc/icingaweb2/ssl/client.crt', $config['ssl_cert']);
+        $this->assertSame('/etc/icingaweb2/ssl/client.key', $config['ssl_key']);
+    }
+
+    public function testDbToolIsGivenTheRemainingTlsSettingsOfTheResource()
+    {
+        $config = $this->createDbToolConfig(array_merge(self::$tlsResource, [
+            'ssl_capath'                    => '/etc/icingaweb2/ssl',
+            'ssl_cipher'                    => 'ECDHE-RSA-AES256-GCM-SHA384',
+            'ssl_do_not_verify_server_cert' => '1'
+        ]));
+
+        $this->assertSame('/etc/icingaweb2/ssl', $config['ssl_capath']);
+        $this->assertSame('ECDHE-RSA-AES256-GCM-SHA384', $config['ssl_cipher']);
+        $this->assertSame('1', $config['ssl_do_not_verify_server_cert']);
+    }
+
+    public function testDbToolIsGivenAClientCertificateWithoutACertificateAuthority()
+    {
+        $resource = self::$tlsResource;
+        unset($resource['ssl_ca']);
+        $resource['ssl_do_not_verify_server_cert'] = '1';
+
+        $config = $this->createDbToolConfig($resource);
+
+        $this->assertSame('1', $config['use_ssl']);
+        $this->assertSame('/etc/icingaweb2/ssl/client.crt', $config['ssl_cert']);
+        $this->assertSame('/etc/icingaweb2/ssl/client.key', $config['ssl_key']);
+        $this->assertSame('1', $config['ssl_do_not_verify_server_cert']);
+        $this->assertNull($config['ssl_ca'], 'A missing ssl_ca must not be missing from the config');
+    }
+
+    public function testDbToolIsGivenAllTlsSettingsEvenIfTheResourceDefinesNone()
+    {
+        $config = $this->createDbToolConfig([
+            'db'        => 'mysql',
+            'host'      => 'localhost',
+            'port'      => '3306',
+            'dbname'    => 'icingaweb2',
+            'username'  => 'icingaweb2',
+            'password'  => 'secret'
+        ]);
+
+        // DbTool accesses these unconditionally once use_ssl is set, so they must never be missing
+        foreach (['use_ssl', 'ssl_key', 'ssl_cert', 'ssl_ca', 'ssl_capath', 'ssl_cipher'] as $name) {
+            $this->assertArrayHasKey($name, $config);
+            $this->assertNull($config[$name]);
+        }
+
+        $this->assertArrayHasKey('ssl_do_not_verify_server_cert', $config);
+        $this->assertNull($config['ssl_do_not_verify_server_cert']);
+    }
+
+    public function testDbToolIsGivenTheConnectionParametersOfTheResource()
+    {
+        $config = $this->createDbToolConfig(self::$tlsResource);
+
+        $this->assertSame('mysql', $config['db']);
+        $this->assertSame('localhost', $config['host']);
+        $this->assertSame('3306', $config['port']);
+        $this->assertSame('icingaweb2', $config['dbname']);
+        $this->assertSame('icingaweb2', $config['username']);
+        $this->assertSame('secret', $config['password']);
+    }
+
+    /**
+     * Get the configuration the migration manager passes to DbTool for the given resource
+     *
+     * @param array<string, string> $resource
+     *
+     * @return array<string, mixed>
+     */
+    private function createDbToolConfig(array $resource): array
+    {
+        $createDbTool = new ReflectionMethod(MigrationManager::class, 'createDbTool');
+        $createDbTool->setAccessible(true);
+
+        /** @var DbTool $tool */
+        $tool = $createDbTool->invoke(MigrationManager::instance(), new Connection($resource));
+
+        $config = new ReflectionProperty(DbTool::class, 'config');
+        $config->setAccessible(true);
+
+        return $config->getValue($tool);
+    }
+}


### PR DESCRIPTION
fixes #5570

`MigrationManager::createDbTool()` built the `DbTool` configuration from seven
string keys and merged the adapter's PDO options on top. Those options are keyed
by PDO driver constants - `ipl\Sql\Adapter\Mysql::getOptions()` returns
`PdoMysql::ATTR_SSL_CA => '/path/to/ca.crt'`, an integer key - so `array_merge()`
renumbered them to `0`, `1`, `2`, and `DbTool`, which looks for the
`resources.ini` names `use_ssl`, `ssl_ca`, `ssl_cert` and `ssl_key`, never saw
any of them.

`DbTool` therefore opened its second connection without a client certificate,
which a user created with `REQUIRE X509` rejects, and Configuration > Database
Migrations showed only `SQLSTATE[HY000] [1045] Access denied` as soon as a
module had a pending migration.

The seven TLS settings are now passed through under the names `DbTool` knows
them by, `use_ssl` among them, so the switch that gates the whole block reaches
`DbTool` as well and turns the certificates on and off there the same way it
does for the ipl connection. They are always present, if only as `null`, because
`DbTool` reads `ssl_key`, `ssl_cert`, `ssl_ca`, `ssl_capath`, `ssl_cipher` and
`ssl_do_not_verify_server_cert` unconditionally once `use_ssl` is set. The
adapter's PDO options are dropped rather than passed alongside: `DbTool` reads
only string keys and builds its own driver options, so the merge never
contributed anything it could use.

Verified against MariaDB 10.11 with a `REQUIRE X509` user: `connectToDb()` and
the privilege check both fail with 1045 before the change and succeed after. A
client certificate without a certificate authority works too, as long as
`ssl_do_not_verify_server_cert` is set - and is refused with 2002 when it is
not, exactly as the ipl connection is. A resource with `use_ssl` off connects in
the clear, as it did before.

The added unit test covers the configuration `DbTool` is handed: for a TLS
resource, for one with a client certificate but no CA, and for one without any
TLS settings at all.
